### PR TITLE
Update the compatibility matrix for QoS

### DIFF
--- a/docs/apim/guides/api-configuration/v4-api-configuration/quality-of-service.md
+++ b/docs/apim/guides/api-configuration/v4-api-configuration/quality-of-service.md
@@ -21,15 +21,13 @@ A higher quality of service could lead to lower system performance depending on 
 
 The quality of service is set on the entrypoints. A given quality of service may or may not be supported by a given endpoint. Support also depends on the protocol used for the entrypoint. Please see the following table that outlines QoS compatibility:
 
-| Entrypoint       | MQTT endpoint               | MQTT Advanced endpoint      | Kafka endpoint | Kafka Advanced endpoint                 |
-| ---------------- | --------------------------- | --------------------------- | -------------- | --------------------------------------- |
-| HTTP POST        | None, Auto                  | None, Auto                  | None, Auto     | None, Auto                              |
-| HTTP GET         | Auto                        | Auto                        | Auto           | Auto, At-Least-Once, At-Most-Once       |
-| SSE              | None, Auto                  | None, Auto                  | None, Auto     | None, Auto                              |
-| SSE Advanced     | None, Auto                  | None, Auto                  | None, Auto     | None, Auto, At-Least-Once, At-Most-Once |
-| WebSocket        | None, Auto                  | None, Auto                  | None, Auto     | None, Auto                              |
-| Webhook          | At-Least-Once, At-Most-Once | At-Least-Once, At-Most-Once | None, Auto     | None, Auto, At-Least-Once, At-Most-Once |
-| Webhook Advanced | At-Least-Once, At-Most-Once | At-Least-Once, At-Most-Once | None, Auto     | None, Auto, At-Least-Once, At-Most-Once |
+| Entrypoint       | Kafka endpoint                          | Mock endpoint                                                    | MQTT 5.x endpoint                          | RabbitMQ endpoint | Solace Endpoint                          |
+|------------------|-----------------------------------------|------------------------------------------------------------------|--------------------------------------------|-------------------|------------------------------------------|
+| **HTTP GET**     | Auto, At-Least-Once, At-Most-Once       | Auto, At-Least-Once, At-Most-Once                                | Auto, At-Least-Once, At-Most-Once          | Auto              | Auto, At-Least-Once, At-Most-Once        |
+| **HTTP POST**    | None, Auto                              | None, Auto                                                       | None, Auto                                 | None, Auto        | None, Auto                               |
+| **SSE**          | None, Auto, At-Least-Once, At-Most-Once | None, Auto, At-Least-Once, At-Most-Once                          | None, Auto, At-Least-Once, At-Most-Once    | None, Auto        | None, Auto, At-Least-Once, At-Most-Once  |
+| **Webhook**      | None, Auto, At-Least-Once, At-Most-Once | None, Auto, At-Least-Once, At-Most-Once                          | None, Auto, At-Least-Once, At-Most-Once    | None, Auto        | None, Auto, At-Least-Once, At-Most-Once  |
+| **WebSocket**    | None, Auto                              | None, Auto                                                       | None, Auto                                 | None, Auto        | None, Auto                               |
 
 ## Setting quality of service for Gravitee v4 APIs
 


### PR DESCRIPTION
Based on the supported QOS of each endpoint and entrypoint, I've updated the compatibility matrix of QoS.

Entrypoints:
- https://github.com/gravitee-io/gravitee-entrypoint-http-get/blob/main/src/main/java/com/graviteesource/entrypoint/http/get/HttpGetEntrypointConnector.java#L53
- https://github.com/gravitee-io/gravitee-entrypoint-http-post/blob/main/src/main/java/com/graviteesource/entrypoint/http/post/HttpPostEntrypointConnector.java#L38
- https://github.com/gravitee-io/gravitee-entrypoint-sse/blob/master/src/main/java/com/graviteesource/entrypoint/sse/SseEntrypointConnector.java#L59
- https://github.com/gravitee-io/gravitee-entrypoint-sse/blob/master/src/main/java/com/graviteesource/entrypoint/sse/SseEntrypointConnector.java#L59
- https://github.com/gravitee-io/gravitee-entrypoint-websocket/blob/main/src/main/java/com/graviteesource/entrypoint/websocket/WebSocketEntrypointConnector.java#L50

Endpoints:
- https://github.com/gravitee-io/gravitee-endpoint-kafka/blob/master/src/main/java/com/graviteesource/endpoint/kafka/KafkaEndpointConnector.java#L77
- https://github.com/gravitee-io/gravitee-api-management/blob/master/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-mock/src/main/java/io/gravitee/plugin/endpoint/mock/MockEndpointConnector.java#L50
- https://github.com/gravitee-io/gravitee-endpoint-mqtt5/blob/master/src/main/java/com/graviteesource/endpoint/mqtt5/Mqtt5EndpointConnector.java#L81
- https://github.com/gravitee-io/gravitee-endpoint-rabbitmq/blob/main/src/main/java/com/graviteesource/endpoint/rabbitmq/RabbitMQEndpointConnector.java#L41
- https://github.com/gravitee-io/gravitee-endpoint-solace/blob/main/src/main/java/com/graviteesource/endpoint/solace/SolaceEndpointConnector.java#L67



Related to
https://gravitee.atlassian.net/browse/APIM-1820