### PR TITLE
fixed broken link

### DIFF
--- a/docs/apim/4.1/guides/policy-design/README.md
+++ b/docs/apim/4.1/guides/policy-design/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The Gravitee Policy Studio allows you to design "flows," or policy enforcement sequences that protect, transform, or otherwise alter how APIs are consumed. Gravitee offers a number of preconfigured policies, some of which are available in the Community Edition while others are only available in Gravitee's Enterprise Edition. For more information on specific policies, please refer to the [Policy Reference](broken-reference) documentation.
+The Gravitee Policy Studio allows you to design "flows," or policy enforcement sequences that protect, transform, or otherwise alter how APIs are consumed. Gravitee offers a number of preconfigured policies, some of which are available in the Community Edition while others are only available in Gravitee's Enterprise Edition. For more information on specific policies, please refer to the [Policy Reference](https://documentation.gravitee.io/apim/reference/policy-reference) documentation.
 
 ### v2 Policy Studio and v4 Policy Studio
 


### PR DESCRIPTION
The link to policy reference here goes nowhere:

![image](https://github.com/gravitee-io/gravitee-platform-docs/assets/5730842/92500814-a546-4883-9b9a-0813b1325582)
