### PR TITLE
doc: update versions in compatibility matrix for hybrid deployment

### DIFF
--- a/docs/apim/4.3/getting-started/hybrid-deployment/advanced-hybrid-deployment.md
+++ b/docs/apim/4.3/getting-started/hybrid-deployment/advanced-hybrid-deployment.md
@@ -27,20 +27,20 @@ This page focuses on the installation of the Self-Hosted Data-Plane, which is pa
 The following table lists the Data-Plane (Gateway) versions supported by each Control-Plane (Bridge) version.
 
 | Control-Plane version | Supported Data-Plane versions |
-| --------------------- | ----------------------------- |
-| 3.20.x                | 3.20.x                        |
-| 4.0.x                 | 3.20.x to 4.0.x               |
-| 4.1.x                 | 3.20.x to 4.1.x               |
-| 4.2.x                 | 3.20.x to 4.2.x               |
+|-----------------------|-------------------------------|
+| 4.0.x                 | 4.0.x                         |
+| 4.1.x                 | 4.0.x to 4.1.x                |
+| 4.2.x                 | 4.0.x to 4.2.x                |
+| 4.3.x                 | 4.0.x to 4.3.x                |
 
 The following table lists the Control-Plane (Bridge) versions supported by each Data-Plane (Gateway) version.
 
 | Data-Plane version | Supported Control-Plane versions |
-| ------------------ | -------------------------------- |
-| 3.20.x             | 3.20.x to 4.2.x                  |
-| 4.0.x              | 4.0.x to 4.2.x                   |
-| 4.1.x              | 4.1.x to 4.2.x                   |
-| 4.2.x              | 4.2.x                            |
+|--------------------|----------------------------------|
+| 4.0.x              | 4.0.x to 4.3.x                   |
+| 4.1.x              | 4.1.x to 4.3.x                   |
+| 4.2.x              | 4.2.x to 4.3.x                   |
+| 4.3.x              | 4.3.x                            |
 
 ## Self-Hosted Hybrid Gateway installation <a href="#installation" id="installation"></a>
 


### PR DESCRIPTION
Add 4.3.x versions in the bridge compatibility matrix.

After changes:
![image](https://github.com/gravitee-io/gravitee-platform-docs/assets/13161768/b8d2e2bb-56de-457b-a62b-49098564e8e2)
