### PR TITLE
chore: use platform structure for gko changelog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .env
 .env.*
 .idea
+.vscode

--- a/docs/gko/4.x/SUMMARY.md
+++ b/docs/gko/4.x/SUMMARY.md
@@ -47,7 +47,7 @@
   * [GKO 4.3](releases-and-changelog/release-notes/gko-4.3.md)
 * [Changelog](releases-and-changelog/changelog/README.md)
   * [GKO 4.4.x](releases-and-changelog/changelog/gko-4.4.x.md)
-  * [GKO 4.3.7](releases-and-changelog/changelog/gko-4.3.7.md)
+  * [GKO 4.3.x](releases-and-changelog/changelog/gko-4.3.x.md)
 
 ## COMMUNITY & SUPPORT
 

--- a/docs/gko/4.x/releases-and-changelog/changelog/gko-4.3.x.md
+++ b/docs/gko/4.x/releases-and-changelog/changelog/gko-4.3.x.md
@@ -1,4 +1,6 @@
-# GKO 4.3.7
+# GKO 4.3.x
+
+## Gravitee Kubernetes Operator 4.3.7 - June 24, 2024
 
 GKO 4.3.7 is a tag based on GKO 0.13.1. For details of changes that came in releases from GKO 4.3.7 and earlier, please take a look at the change logs in Github.
 

--- a/docs/gko/4.x/releases-and-changelog/changelog/gko-4.4.x.md
+++ b/docs/gko/4.x/releases-and-changelog/changelog/gko-4.4.x.md
@@ -4,7 +4,7 @@
 
 <details>
 
-<summary>Fixes</summary>
+<summary>Bug fixes</summary>
 
 * default image tag for Kube RBAC proxy should be upgraded [9825](https://github.com/gravitee-io/issues/issues/9825)
 * v2 API exported as CRD can't be re-imported due to unknown field status [9824](https://github.com/gravitee-io/issues/issues/9824)
@@ -15,7 +15,7 @@
 
 <details>
 
-<summary>Enhancements</summary>
+<summary>Improvements</summary>
 
 * Core support for v4 API definition
 * Documentation page support for v2 and v4 API definitions


### PR DESCRIPTION
This is to allow automated changelog generation and match file structure of APIM and AM.
