### PR TITLE
docs: add a note about api-key usage in expression language for APIs using v4 emulation engine

### DIFF
--- a/docs/apim/4.0/guides/gravitee-expression-language.md
+++ b/docs/apim/4.0/guides/gravitee-expression-language.md
@@ -193,6 +193,17 @@ Request context attributes and examples are listed below.
 {% endtab %}
 {% endtabs %}
 
+#### Important Note for v4 Emulation Engine Users
+When you use the v4 emulation engine, you retrieve the API Key from the request parameters or headers. You cannot reference the API directly with expressions like `{#context.attributes['api-key'] == 'api-key-value'}` because the api-key attribute is not accessible in the context as a logging filter expression.
+
+To retrieve API key from the request parameters or headers, use the following expression:
+
+```
+{(#request.params['api-key'] != null && #request.params['api-key'][0] == 'my-api-key') || #request.headers['X-Gravitee-Api-Key'][0] == 'my-api-key'}
+```
+
+This approach checks for the API key either in the query parameters (api-key) or in the headers (X-Gravitee-Api-Key), which ensures compatibility with v4 emulation.
+
 ### SSL object properties <a href="#ssl_object" id="ssl_object"></a>
 
 The object properties you can access in the `ssl` session object from the `{#request.ssl}` root-level object property are listed below.

--- a/docs/apim/4.1/guides/gravitee-expression-language.md
+++ b/docs/apim/4.1/guides/gravitee-expression-language.md
@@ -210,6 +210,15 @@ Request context attributes and examples are listed below.
 {% endtab %}
 {% endtabs %}
 
+#### Important Note for v4 Emulation Engine Users
+When you use the v4 emulation engine, you retrieve the API Key from the request parameters or headers. You cannot reference the API directly with expressions like `{#context.attributes['api-key'] == 'api-key-value'}` because the api-key attribute is not accessible in the context as a logging filter expression.
+
+```
+{(#request.params['api-key'] != null && #request.params['api-key'][0] == 'my-api-key') || #request.headers['X-Gravitee-Api-Key'][0] == 'my-api-key'}
+```
+
+This approach checks for the API key either in the query parameters (api-key) or in the headers (X-Gravitee-Api-Key), which ensures compatibility with v4 emulation.
+
 ### SSL object properties <a href="#ssl_object" id="ssl_object"></a>
 
 The object properties you can access in the `ssl` session object from the `{#request.ssl}` root-level object property are listed below.

--- a/docs/apim/4.2/guides/gravitee-expression-language.md
+++ b/docs/apim/4.2/guides/gravitee-expression-language.md
@@ -211,6 +211,17 @@ Request context attributes and examples are listed below.
 {% endtab %}
 {% endtabs %}
 
+#### Important Note for v4 Emulation Engine Users
+When you use the v4 emulation engine, you retrieve the API Key from the request parameters or headers. You cannot reference the API directly with expressions like `{#context.attributes['api-key'] == 'api-key-value'}` because the api-key attribute is not accessible in the context as a logging filter expression.
+
+To retrieve API key from the request parameters or headers, use the following expression:
+
+```
+{(#request.params['api-key'] != null && #request.params['api-key'][0] == 'my-api-key') || #request.headers['X-Gravitee-Api-Key'][0] == 'my-api-key'}
+```
+
+This approach checks for the API key either in the query parameters (api-key) or in the headers (X-Gravitee-Api-Key), which ensures compatibility with v4 emulation.
+
 ### SSL object properties <a href="#ssl_object" id="ssl_object"></a>
 
 The object properties you can access in the `ssl` session object from the `{#request.ssl}` root-level object property are listed below.

--- a/docs/apim/4.3/guides/gravitee-expression-language.md
+++ b/docs/apim/4.3/guides/gravitee-expression-language.md
@@ -213,6 +213,17 @@ Request context attributes and examples are listed below.
 {% endtab %}
 {% endtabs %}
 
+#### Important Note for v4 Emulation Engine Users
+When you use the v4 emulation engine, you retrieve the API Key from the request parameters or headers. You cannot reference the API directly with expressions like `{#context.attributes['api-key'] == 'api-key-value'}` because the api-key attribute is not accessible in the context as a logging filter expression.
+
+To retrieve API key from the request parameters or headers, use the following expression:
+
+```
+{(#request.params['api-key'] != null && #request.params['api-key'][0] == 'my-api-key') || #request.headers['X-Gravitee-Api-Key'][0] == 'my-api-key'}
+```
+
+This approach checks for the API key either in the query parameters (api-key) or in the headers (X-Gravitee-Api-Key), which ensures compatibility with v4 emulation.
+
 ### SSL object properties <a href="#ssl_object" id="ssl_object"></a>
 
 The object properties you can access in the `ssl` session object from the `{#request.ssl}` root-level object property are listed below.

--- a/docs/apim/4.4/guides/gravitee-expression-language.md
+++ b/docs/apim/4.4/guides/gravitee-expression-language.md
@@ -210,6 +210,17 @@ Request context attributes and examples are listed below.
 {% endtab %}
 {% endtabs %}
 
+#### Important Note for v4 Emulation Engine Users
+When you use the v4 emulation engine, you retrieve the API Key from the request parameters or headers. You cannot reference the API directly with expressions like `{#context.attributes['api-key'] == 'api-key-value'}` because the api-key attribute is not accessible in the context as a logging filter expression.
+
+To retrieve API key from the request parameters or headers, use the following expression:
+
+```
+{(#request.params['api-key'] != null && #request.params['api-key'][0] == 'my-api-key') || #request.headers['X-Gravitee-Api-Key'][0] == 'my-api-key'}
+```
+
+This approach checks for the API key either in the query parameters (api-key) or in the headers (X-Gravitee-Api-Key), which ensures compatibility with v4 emulation.
+
 ### SSL object properties <a href="#ssl_object" id="ssl_object"></a>
 
 The object properties you can access in the `ssl` session object from the `{#request.ssl}` root-level object property are listed below.


### PR DESCRIPTION
## Description

In this PR we add a small note about the usage of the `api-key` attribute for APIs using v4 emulation engine.
Basically to resume it, something was working before v4 and does not work now with V4. 