### PR TITLE
feat: add a note about new USER_TOKEN permission in upgrade guides

### DIFF
--- a/docs/apim/4.1/getting-started/install-guides/installation-guide-migration.md
+++ b/docs/apim/4.1/getting-started/install-guides/installation-guide-migration.md
@@ -160,3 +160,11 @@ eventsCollection.find({"type": "PUBLISH_API"}).forEach((event) => {
        eventsCollection.replaceOne({ _id: event._id }, event);
 });
 ```
+
+## Introduction of USER_TOKEN Permission for Token Management
+
+Starting with version 4.1.26, there is a new permission called USER_TOKEN. This permission controls which users have the ability to read, create, update, and delete user tokens.
+
+Previously, these actions were governed by the broader 'USER' permission. As part of the migration from version 4.1.25 to 4.1.26, no breaking changes have been introduced. Users who previously had the permission to manage user tokens under the 'USER' permission will retain their access automatically.
+
+However, this new 'USER_TOKEN' permission gives administrators more granular control. They can now selectively determine which users truly need access to manage user tokens, allowing for better security and role-based management within the system.

--- a/docs/apim/4.2/getting-started/install-and-upgrade-guides/4.2-upgrade-guide.md
+++ b/docs/apim/4.2/getting-started/install-and-upgrade-guides/4.2-upgrade-guide.md
@@ -231,3 +231,12 @@ installation:
         - envId: environment#2
           url: http:/localhost:4101
 ```
+
+
+## Introduction of USER_TOKEN Permission for Token Management
+
+Starting with version 4.2.20, there is a new permission called USER_TOKEN. This permission controls which users have the ability to read, create, update, and delete user tokens.
+
+Previously, these actions were governed by the broader 'USER' permission. As part of the migration from version 4.1.25 to 4.1.26, no breaking changes have been introduced. Users who previously had the permission to manage user tokens under the 'USER' permission will retain their access automatically.
+
+However, this new 'USER_TOKEN' permission gives administrators more granular control. They can now selectively determine which users truly need access to manage user tokens, allowing for better security and role-based management within the system.

--- a/docs/apim/4.3/getting-started/upgrading-gravitee-api-management/4.2-upgrade-guide.md
+++ b/docs/apim/4.3/getting-started/upgrading-gravitee-api-management/4.2-upgrade-guide.md
@@ -194,3 +194,11 @@ installation:
         - envId: environment#2
           url: http:/localhost:4101
 ```
+
+## Introduction of USER_TOKEN Permission for Token Management
+
+Starting with version 4.3.15, there is a new permission called USER_TOKEN. This permission controls which users have the ability to read, create, update, and delete user tokens.
+
+Previously, these actions were governed by the broader 'USER' permission. As part of the migration from version 4.1.25 to 4.1.26, no breaking changes have been introduced. Users who previously had the permission to manage user tokens under the 'USER' permission will retain their access automatically.
+
+However, this new 'USER_TOKEN' permission gives administrators more granular control. They can now selectively determine which users truly need access to manage user tokens, allowing for better security and role-based management within the system.

--- a/docs/apim/4.4/getting-started/upgrading-gravitee-api-management/upgrade-guide.md
+++ b/docs/apim/4.4/getting-started/upgrading-gravitee-api-management/upgrade-guide.md
@@ -245,3 +245,11 @@ GRAVITEE_MANAGEMENT_HTTP_SSL_TRUSTALL="true"
 You may have noticed the "trust all" configuration parameter was formerly named `trustall`, it is now named `trustAll` for consistency. To avoid a breaking change here both names work, but the former has been deprecated.
 
 ***
+
+## Introduction of USER_TOKEN Permission for Token Management
+
+Starting with version 4.4.11, there is a new permission called USER_TOKEN. This permission controls which users have the ability to read, create, update, and delete user tokens.
+
+Previously, these actions were governed by the broader 'USER' permission. As part of the migration from version 4.1.25 to 4.1.26, no breaking changes have been introduced. Users who previously had the permission to manage user tokens under the 'USER' permission will retain their access automatically.
+
+However, this new 'USER_TOKEN' permission gives administrators more granular control. They can now selectively determine which users truly need access to manage user tokens, allowing for better security and role-based management within the system.


### PR DESCRIPTION
## Description

Following this issue https://gravitee.atlassian.net/browse/APIM-6960 I'm adding a note in the upgrade guides for the incoming versions of APIM.
This PR explain to the user the creation of a new ROLE named USER_TOKEN. 

☢️ We need to merge this PR only when the issue is **done** and **the associated releases are done** ☢️ 