### PR TITLE
fix: broken types-of-plans link

### DIFF
--- a/docs/apim/4.5/using-the-product/managing-your-apis/preparing-apis-for-subscribers/README.md
+++ b/docs/apim/4.5/using-the-product/managing-your-apis/preparing-apis-for-subscribers/README.md
@@ -6,4 +6,4 @@ For more information about preparing your APIs for subscribers, see the followin
 
 
 
-<table data-view="cards"><thead><tr><th data-type="content-ref"></th><th></th><th></th></tr></thead><tbody><tr><td><a href="plans/">plans</a></td><td></td><td></td></tr><tr><td><a href="broken-reference">Broken link</a></td><td></td><td></td></tr><tr><td><a href="applications.md">applications.md</a></td><td></td><td></td></tr><tr><td><a href="subscriptions.md">subscriptions.md</a></td><td></td><td></td></tr></tbody></table>
+<table data-view="cards"><thead><tr><th data-type="content-ref"></th><th></th><th></th></tr></thead><tbody><tr><td><a href="plans/">plans</a></td><td></td><td></td></tr><tr><td><a href="types-of-plans.md">types-of-plans.md</a></td><td></td><td></td></tr><tr><td><a href="applications.md">applications.md</a></td><td></td><td></td></tr><tr><td><a href="subscriptions.md">subscriptions.md</a></td><td></td><td></td></tr></tbody></table>


### PR DESCRIPTION
Hello Gravitee team,

I made a modification to correct a broken link in the documentation. 
The link to the document **types-of-plans.md** was broken.

In the documentation, it looked like this:

<img src="https://github.com/user-attachments/assets/2c377665-35df-47df-94b4-7f5b44f828a8" alt="empty_section" width="500" />

Looking forward to helping out.

See you soon,
Loïc