### PR TITLE
fix: remove unreleased fix from gko 4.5 changelog

### DIFF
--- a/docs/gko/4.5/releases-and-changelog/changelog/gko-4.5.x.md
+++ b/docs/gko/4.5/releases-and-changelog/changelog/gko-4.5.x.md
@@ -8,7 +8,6 @@
   * Having two plans with same name lead to duplicate key error on API v4 export [#10128](https://github.com/gravitee-io/issues/issues/10128)
   * APIs sourced from kubernetes config map get out of sync after some time [#10095](https://github.com/gravitee-io/issues/issues/10095)
   * Adding a member with an existing role id to a V2 API issues a warning [#10096](https://github.com/gravitee-io/issues/issues/10096)
-  * API Pages are not deleted when combining http-fetcher (or markdown) and github-fetchers together [#10087](https://github.com/gravitee-io/issues/issues/10087)
   * GKO removes attributes with empty value from API Definition [#10034](https://github.com/gravitee-io/issues/issues/10034)
 </details>
 


### PR DESCRIPTION
This bug fix is coming with the upcoming maintenance release of APIM and have been mistakenly flagged for 4.5.2 in Jira.