### PR TITLE
fix: put back APIM 4.7.1 changelog

### DIFF
--- a/docs/apim/4.7/overview/changelog/apim-4.7.x.md
+++ b/docs/apim/4.7/overview/changelog/apim-4.7.x.md
@@ -37,3 +37,36 @@
 
 
 
+## Gravitee API Management 4.7.1 - April 4, 2025
+<details>
+
+<summary>Bug Fixes</summary>
+
+**Gateway**
+
+* Gateway stops synching apis after failling to connect to jdbc datasource [#10441](https://github.com/gravitee-io/issues/issues/10441)
+
+**Management API**
+
+* API key is not working for API subscriptions when we use Shared API key [#10122](https://github.com/gravitee-io/issues/issues/10122)
+* Adding an unknown group id to excluded groups on a plan removes all excluded groups and prevents exports of the API [#10389](https://github.com/gravitee-io/issues/issues/10389)
+
+**Console**
+
+* API key is not working for API subscriptions when we use Shared API key [#10122](https://github.com/gravitee-io/issues/issues/10122)
+* Account page broken in multi-environment installation [#10451](https://github.com/gravitee-io/issues/issues/10451)
+* API Export does not "respect" selected export options [#10455](https://github.com/gravitee-io/issues/issues/10455)
+* Display only http methods in debug mode tool [#10467](https://github.com/gravitee-io/issues/issues/10467)
+
+**Portal**
+
+* NewDevPortal - Swagger expands outside of allowed frame [#10461](https://github.com/gravitee-io/issues/issues/10461)
+* Unable to show Swagger docs for Native api on Portal-Next [#10462](https://github.com/gravitee-io/issues/issues/10462)
+
+**Other**
+
+* Groups not automatically added to new applications when they should be [#10470](https://github.com/gravitee-io/issues/issues/10470)
+
+</details>
+
+


### PR DESCRIPTION
Put back 4.7.1 APIM changelog, accidentally removed in 4c92e7526489899b663a69ff0b2d0bb26c842b90