### PR TITLE
Correct "Resource filtering" policy example for v2 API definition

### DIFF
--- a/docs/apim/4.6/policies/resource-filtering.md
+++ b/docs/apim/4.6/policies/resource-filtering.md
@@ -65,7 +65,7 @@ This policy can be applied to v2 APIs and v4 HTTP proxy APIs. It cannot be appli
           "name" : "Resource filtering",
           "description" : "Allow access to all paths",
           "enabled" : true,
-          "policy" : "policy-assign-attributes",
+          "policy" : "resource-filtering",
           "configuration" : {
              "whitelist": [
               {

--- a/docs/apim/4.7/policies/resource-filtering.md
+++ b/docs/apim/4.7/policies/resource-filtering.md
@@ -64,7 +64,7 @@ This policy can be applied to v2 APIs and v4 HTTP proxy APIs. It cannot be appli
           "name" : "Resource filtering",
           "description" : "Allow access to all paths",
           "enabled" : true,
-          "policy" : "policy-assign-attributes",
+          "policy" : "resource-filtering",
           "configuration" : {
              "whitelist": [
               {

--- a/docs/apim/4.7x/create-and-configure-apis/apply-policies/policy-reference/resource-filtering.md
+++ b/docs/apim/4.7x/create-and-configure-apis/apply-policies/policy-reference/resource-filtering.md
@@ -60,7 +60,7 @@ This policy can be applied to v2 APIs and v4 HTTP proxy APIs. It cannot be appli
           "name" : "Resource filtering",
           "description" : "Allow access to all paths",
           "enabled" : true,
-          "policy" : "policy-assign-attributes",
+          "policy" : "resource-filtering",
           "configuration" : {
              "whitelist": [
               {

--- a/docs/apim/4.8/policies/resource-filtering.md
+++ b/docs/apim/4.8/policies/resource-filtering.md
@@ -64,7 +64,7 @@ This policy can be applied to v2 APIs and v4 HTTP proxy APIs. It cannot be appli
           "name" : "Resource filtering",
           "description" : "Allow access to all paths",
           "enabled" : true,
-          "policy" : "policy-assign-attributes",
+          "policy" : "resource-filtering",
           "configuration" : {
              "whitelist": [
               {


### PR DESCRIPTION
- Correctly set the `"policy"` property to `"resource-filtering"` in the example for the "v2 API definition" section of the "Resource Filtering" policy documentation.