### PR TITLE
feat(federation): Revert - update federation ingress definition in APIM

### DIFF
--- a/docs/apim/4.4/installation-and-upgrades/install-gravitee-api-management/installing-gravitee-api-management-on-premise/install-on-kubernetes.md
+++ b/docs/apim/4.4/installation-and-upgrades/install-gravitee-api-management/installing-gravitee-api-management-on-premise/install-on-kubernetes.md
@@ -633,6 +633,7 @@ federation:
 When this flag is set to enabled, it has the following impacts:
 
 * APIM cluster mode is activated. Federation can work correctly in a highly available APIM deployment.  Also, Hazelcast is configured and runs in memory as a library inside APIM.
+* The default ingress used is the host used for the management API. Here is the default path: `/integration-controller`. The default ingress can be overridden n the federation ingress section with a dedicated host for the integration controller.
 
 If you run a single replica of APIM, you can deactivate cluster mode by specifying the following environment variables and values:
 

--- a/docs/apim/4.5/installation-and-upgrades/install-on-kubernetes.md
+++ b/docs/apim/4.5/installation-and-upgrades/install-on-kubernetes.md
@@ -639,6 +639,7 @@ federation:
 When this flag is set to enabled, it has the following impacts:
 
 * APIM cluster mode is activated. Federation can work correctly in a highly available APIM deployment.  Also, Hazelcast is configured and runs in memory as a library inside APIM.
+* The default ingress used is the host used for the management API. Here is the default path: `/integration-controller`. The default ingress can be overridden n the federation ingress section with a dedicated host for the integration controller.
 
 If you run a single replica of APIM, you can deactivate cluster mode by specifying the following environment variables and values:
 

--- a/docs/apim/4.6/install-and-upgrade/kubernetes.md
+++ b/docs/apim/4.6/install-and-upgrade/kubernetes.md
@@ -629,6 +629,7 @@ federation:
 When this flag is set to enabled, it has the following impacts:
 
 * APIM cluster mode is activated. Federation can work correctly in a highly available APIM deployment. Also, Hazelcast is configured and runs in memory as a library inside APIM.
+* The default ingress used is the host used for the management API. Here is the default path: `/integration-controller`. The default ingress can be overridden in the federation ingress section with a dedicated host for the integration controller.
 
 If you run a single replica of APIM, you can deactivate cluster mode by specifying the following environment variables and values:
 

--- a/docs/apim/4.7/install-and-upgrade/kubernetes.md
+++ b/docs/apim/4.7/install-and-upgrade/kubernetes.md
@@ -629,6 +629,7 @@ federation:
 When this flag is set to enabled, it has the following impacts:
 
 * APIM cluster mode is activated. Federation can work correctly in a highly available APIM deployment. Also, Hazelcast is configured and runs in memory as a library inside APIM.
+* The default ingress used is the host used for the management API. Here is the default path: `/integration-controller`. The default ingress can be overridden in the federation ingress section with a dedicated host for the integration controller.
 
 If you run a single replica of APIM, you can deactivate cluster mode by specifying the following environment variables and values:
 

--- a/docs/apim/4.8/self-hosted-installation-guides/kubernetes/vanilla-kubernetes.md
+++ b/docs/apim/4.8/self-hosted-installation-guides/kubernetes/vanilla-kubernetes.md
@@ -629,6 +629,7 @@ federation:
 When this flag is set to enabled, it has the following impacts:
 
 * APIM cluster mode is activated. Federation can work correctly in a highly available APIM deployment. Also, Hazelcast is configured and runs in memory as a library inside APIM.
+* The default ingress used is the host used for the management API. Here is the default path: `/integration-controller`. The default ingress can be overridden in the federation ingress section with a dedicated host for the integration controller.
 
 If you run a single replica of APIM, you can deactivate cluster mode by specifying the following environment variables and values:
 


### PR DESCRIPTION
This reverts commit 2228da1448b0f22101272701fea6ff6adc026e3c.
Finally, as the change is a breaking change, it will impact only APIM
4.9.

So I reverted the documentation update accordingly.

DOC-612
TT-8076
APIM-9766
