### PR TITLE
Fix example shell commands on the GKO quick start

### DIFF
--- a/docs/apim/4.0/guides/gravitee-kubernetes-operator/quick-start.md
+++ b/docs/apim/4.0/guides/gravitee-kubernetes-operator/quick-start.md
@@ -24,8 +24,8 @@ To deploy the GKO on the cluster of your current Kubernetes context, run the fol
 
 {% code overflow="wrap" %}
 ```sh
-$ helm repo add graviteeio https://helm.gravitee.io
-$ helm install graviteeio-gko graviteeio/gko
+helm repo add graviteeio https://helm.gravitee.io
+helm install graviteeio-gko graviteeio/gko
 ```
 {% endcode %}
 

--- a/docs/apim/4.1/guides/gravitee-kubernetes-operator/quick-start.md
+++ b/docs/apim/4.1/guides/gravitee-kubernetes-operator/quick-start.md
@@ -24,8 +24,8 @@ To deploy the GKO on the cluster of your current Kubernetes context, run the fol
 
 {% code overflow="wrap" %}
 ```sh
-$ helm repo add graviteeio https://helm.gravitee.io
-$ helm install graviteeio-gko graviteeio/gko
+helm repo add graviteeio https://helm.gravitee.io
+helm install graviteeio-gko graviteeio/gko
 ```
 {% endcode %}
 

--- a/docs/apim/4.2/guides/gravitee-kubernetes-operator/quick-start.md
+++ b/docs/apim/4.2/guides/gravitee-kubernetes-operator/quick-start.md
@@ -24,8 +24,8 @@ To deploy the GKO on the cluster of your current Kubernetes context, run the fol
 
 {% code overflow="wrap" %}
 ```sh
-$ helm repo add graviteeio https://helm.gravitee.io
-$ helm install graviteeio-gko graviteeio/gko
+helm repo add graviteeio https://helm.gravitee.io
+helm install graviteeio-gko graviteeio/gko
 ```
 {% endcode %}
 

--- a/docs/apim/4.3/guides/gravitee-kubernetes-operator/quick-start.md
+++ b/docs/apim/4.3/guides/gravitee-kubernetes-operator/quick-start.md
@@ -25,8 +25,8 @@ The GKO deployment process is the same for both remote and local Kubernetes clus
 
 {% code overflow="wrap" %}
 ```sh
-$ helm repo add graviteeio https://helm.gravitee.io
-$ helm install graviteeio-gko graviteeio/gko
+helm repo add graviteeio https://helm.gravitee.io
+helm install graviteeio-gko graviteeio/gko
 ```
 {% endcode %}
 

--- a/docs/gko/4.4/getting-started/quickstart-guide.md
+++ b/docs/gko/4.4/getting-started/quickstart-guide.md
@@ -25,8 +25,8 @@ Use Helm to install GKO on your Kubernetes cluster:
 
 {% code overflow="wrap" %}
 ```sh
-$ helm repo add graviteeio https://helm.gravitee.io
-$ helm install graviteeio-gko graviteeio/gko
+helm repo add graviteeio https://helm.gravitee.io
+helm install graviteeio-gko graviteeio/gko
 ```
 {% endcode %}
 

--- a/docs/gko/4.5/getting-started/quickstart-guide.md
+++ b/docs/gko/4.5/getting-started/quickstart-guide.md
@@ -25,8 +25,8 @@ Use Helm to install GKO on your Kubernetes cluster:
 
 {% code overflow="wrap" %}
 ```sh
-$ helm repo add graviteeio https://helm.gravitee.io
-$ helm install graviteeio-gko graviteeio/gko
+helm repo add graviteeio https://helm.gravitee.io
+helm install graviteeio-gko graviteeio/gko
 ```
 {% endcode %}
 

--- a/docs/gko/4.6/getting-started/quickstart-guide.md
+++ b/docs/gko/4.6/getting-started/quickstart-guide.md
@@ -29,8 +29,8 @@ Use Helm to install GKO on your Kubernetes cluster:
 
 {% code overflow="wrap" %}
 ```sh
-$ helm repo add graviteeio https://helm.gravitee.io
-$ helm install graviteeio-gko graviteeio/gko
+helm repo add graviteeio https://helm.gravitee.io
+helm install graviteeio-gko graviteeio/gko
 ```
 {% endcode %}
 

--- a/docs/gko/4.7/getting-started/quickstart-guide.md
+++ b/docs/gko/4.7/getting-started/quickstart-guide.md
@@ -29,8 +29,8 @@ Use Helm to install GKO on your Kubernetes cluster:
 
 {% code overflow="wrap" %}
 ```sh
-$ helm repo add graviteeio https://helm.gravitee.io
-$ helm install graviteeio-gko graviteeio/gko
+helm repo add graviteeio https://helm.gravitee.io
+helm install graviteeio-gko graviteeio/gko
 ```
 {% endcode %}
 

--- a/docs/gko/4.8/getting-started/quickstart-guide.md
+++ b/docs/gko/4.8/getting-started/quickstart-guide.md
@@ -29,8 +29,8 @@ Use Helm to install GKO on your Kubernetes cluster:
 
 {% code overflow="wrap" %}
 ```sh
-$ helm repo add graviteeio https://helm.gravitee.io
-$ helm install graviteeio-gko graviteeio/gko
+helm repo add graviteeio https://helm.gravitee.io
+helm install graviteeio-gko graviteeio/gko
 ```
 {% endcode %}
 


### PR DESCRIPTION
The Quick starts for the Kubernetes operator in the `APIM` and `GKO` sections contains a few shell commands with a `$` at the begining.

This is a problem because you can't just copy/paste these commands in the Linux CLI (and probably othr CLIs as well) or you'll get an error.