### PR TITLE
chore: add a changelog for the Sept 12 release

### DIFF
--- a/docs/apim/4.5/overview/changelog/apim-4.5.x.md
+++ b/docs/apim/4.5/overview/changelog/apim-4.5.x.md
@@ -5,6 +5,27 @@ description: >-
 ---
 
 # APIM 4.5.x
+
+## Gravitee API Management 4.5.26 - September 12, 2025
+<details>
+
+<summary>Bug Fixes</summary>
+
+**Management API**
+
+* Memory issues when loading audit events [#10582](https://github.com/gravitee-io/issues/issues/10582)
+* Heavy latencies using Audit section with a larger number of apps.[#10783](https://github.com/gravitee-io/issues/issues/10783)
+* Audit History groups fetch timeout[#10682](https://github.com/gravitee-io/issues/issues/10682)
+* Bad behavior on weighted round robin[#10405](https://github.com/gravitee-io/issues/issues/10405)
+
+**Console**
+
+* Unable to import path mapping from swagger document [#10810](https://github.com/gravitee-io/issues/issues/10810)
+* Alert creation form missing fields on smaller screens[#10823](https://github.com/gravitee-io/issues/issues/10823)
+* Slow loading when viewing 'Tasks' on Console[#10650](https://github.com/gravitee-io/issues/issues/10650)
+* Bad behavior on weighted round robin[#10405](https://github.com/gravitee-io/issues/issues/10405)
+
+</details>
  
 ## Gravitee API Management 4.5.25 - August 29, 2025
 <details>

--- a/docs/apim/4.6/overview/changelog/apim-4.6.x.md
+++ b/docs/apim/4.6/overview/changelog/apim-4.6.x.md
@@ -5,7 +5,29 @@ description: >-
 ---
 
 # APIM 4.6.x
- 
+
+## Gravitee API Management 4.6.20 - September 12, 2025
+<details>
+
+<summary>Bug Fixes</summary>
+
+**Management API**
+
+* Memory issues when loading audit events [#10582](https://github.com/gravitee-io/issues/issues/10582)
+* Heavy latencies using Audit section with a larger number of apps.[#10783](https://github.com/gravitee-io/issues/issues/10783)
+* Audit History groups fetch timeout[#10682](https://github.com/gravitee-io/issues/issues/10682)
+* Bad behavior on weighted round robin[#10405](https://github.com/gravitee-io/issues/issues/10405)
+
+**Console**
+
+* Unable to import path mapping from swagger document [#10810](https://github.com/gravitee-io/issues/issues/10810)
+* Alert creation form missing fields on smaller screens[#10823](https://github.com/gravitee-io/issues/issues/10823)
+* Slow loading when viewing 'Tasks' on Console[#10650](https://github.com/gravitee-io/issues/issues/10650)
+* Bad behavior on weighted round robin[#10405](https://github.com/gravitee-io/issues/issues/10405)
+
+</details>
+
+
 ## Gravitee API Management 4.6.19 - August 29, 2025
 <details>
 

--- a/docs/apim/4.7/overview/changelog/apim-4.7.x.md
+++ b/docs/apim/4.7/overview/changelog/apim-4.7.x.md
@@ -1,5 +1,28 @@
 # APIM 4.7.x
- 
+
+## Gravitee API Management 4.7.14 - September 12, 2025
+<details>
+
+<summary>Bug Fixes</summary>
+
+**Management API**
+
+* Memory issues when loading audit events [#10582](https://github.com/gravitee-io/issues/issues/10582)
+* Heavy latencies using Audit section with a larger number of apps.[#10783](https://github.com/gravitee-io/issues/issues/10783)
+* Audit History groups fetch timeout[#10682](https://github.com/gravitee-io/issues/issues/10682)
+* Bad behavior on weighted round robin[#10405](https://github.com/gravitee-io/issues/issues/10405)
+* Dynamic Properties configuration is not exported when exporting a V4 API[#10726](https://github.com/gravitee-io/issues/issues/10726)
+
+**Console**
+
+* Unable to import path mapping from swagger document [#10810](https://github.com/gravitee-io/issues/issues/10810)
+* Alert creation form missing fields on smaller screens[#10823](https://github.com/gravitee-io/issues/issues/10823)
+* Slow loading when viewing 'Tasks' on Console[#10650](https://github.com/gravitee-io/issues/issues/10650)
+* Bad behavior on weighted round robin[#10405](https://github.com/gravitee-io/issues/issues/10405)
+
+</details>
+
+
 ## Gravitee API Management 4.7.13 - August 29, 2025
 <details>
 

--- a/docs/apim/4.8/release-information/changelog/apim-4.8.x.md
+++ b/docs/apim/4.8/release-information/changelog/apim-4.8.x.md
@@ -1,4 +1,37 @@
 # APIM 4.8.x
+
+## Gravitee API Management 4.8.7 - September 12, 2025
+<details>
+
+<summary>Bug Fixes</summary>
+
+
+**Gateway**
+
+* Unable to retrieve secrets from HashiCorp[#10760](https://github.com/gravitee-io/issues/issues/10760)
+
+**Management API**
+
+* Memory issues when loading audit events [#10582](https://github.com/gravitee-io/issues/issues/10582)
+* Heavy latencies using Audit section with a larger number of apps.[#10783](https://github.com/gravitee-io/issues/issues/10783)
+* Audit History groups fetch timeout[#10682](https://github.com/gravitee-io/issues/issues/10682)
+* Bad behavior on weighted round robin[#10405](https://github.com/gravitee-io/issues/issues/10405)
+* Dynamic Properties configuration is not exported when exporting a V4 API[#10726](https://github.com/gravitee-io/issues/issues/10726)
+
+**Console**
+
+* Unable to import path mapping from swagger document [#10810](https://github.com/gravitee-io/issues/issues/10810)
+* Alert creation form missing fields on smaller screens[#10823](https://github.com/gravitee-io/issues/issues/10823)
+* Slow loading when viewing 'Tasks' on Console[#10650](https://github.com/gravitee-io/issues/issues/10650)
+* Bad behavior on weighted round robin[#10405](https://github.com/gravitee-io/issues/issues/10405)
+
+**Other**
+
+* Elastic reporter fails with ES7 and V4 Proxy API[#10772](https://github.com/gravitee-io/issues/issues/10772)
+* APIs with MCP enabled require the Accept header to be present in debug requests [#10652](https://github.com/gravitee-io/issues/issues/10652)
+
+</details>
+
  
 ## Gravitee API Management 4.8.6 - September 1, 2025
 <details>


### PR DESCRIPTION
Sept 12 changelog for APIM were missing from docs because jira deprecated some endpoints/urls which are being used to automate the changelog process during release.
