### PR TITLE
Fix root hint blocks

### DIFF
--- a/docs/am/4.1/guides/identity-providers/user-and-role-mapping.md
+++ b/docs/am/4.1/guides/identity-providers/user-and-role-mapping.md
@@ -89,7 +89,7 @@ In addition, when it comes to fine-grained authorization management, it is consi
 
 The goal is to dynamically add scopes to the `access_token`, depending on the role associated with the user when authenticating.
 
-\{% hint style="info" %\} When the roles are updated via SCIM, the roles already applied via Role Mappers won’t be persisted as an assigned role. This ensures that it can be safely removed when the mapper rule does not match anymore. For more about SCIM, click [here](../auth-protocols/scim-2.0.md). \{% endhint %\}
+{% hint style="info" %} When the roles are updated via SCIM, the roles already applied via Role Mappers won’t be persisted as an assigned role. This ensures that it can be safely removed when the mapper rule does not match anymore. For more about SCIM, click [here](../auth-protocols/scim-2.0.md). {% endhint %}
 
 ### Example
 

--- a/docs/am/4.2/guides/identity-providers/user-and-role-mapping.md
+++ b/docs/am/4.2/guides/identity-providers/user-and-role-mapping.md
@@ -89,7 +89,7 @@ In addition, when it comes to fine-grained authorization management, it is consi
 
 The goal is to dynamically add scopes to the `access_token`, depending on the role associated with the user when authenticating.
 
-\{% hint style="info" %\} When the roles are updated via SCIM, the roles already applied via Role Mappers won’t be persisted as an assigned role. This ensures that it can be safely removed when the mapper rule does not match anymore. For more about SCIM, click [here](../auth-protocols/scim-2.0.md). \{% endhint %\}
+{% hint style="info" %} When the roles are updated via SCIM, the roles already applied via Role Mappers won’t be persisted as an assigned role. This ensures that it can be safely removed when the mapper rule does not match anymore. For more about SCIM, click [here](../auth-protocols/scim-2.0.md). {% endhint %}
 
 ### Example
 

--- a/docs/am/4.3/guides/identity-providers/user-and-role-mapping.md
+++ b/docs/am/4.3/guides/identity-providers/user-and-role-mapping.md
@@ -89,7 +89,7 @@ In addition, when it comes to fine-grained authorization management, it is consi
 
 The goal is to dynamically add scopes to the `access_token`, depending on the role associated with the user when authenticating.
 
-\{% hint style="info" %\} When the roles are updated via SCIM, the roles already applied via Role Mappers won’t be persisted as an assigned role. This ensures that it can be safely removed when the mapper rule does not match anymore. For more about SCIM, click [here](../auth-protocols/scim-2.0.md). \{% endhint %\}
+{% hint style="info" %} When the roles are updated via SCIM, the roles already applied via Role Mappers won’t be persisted as an assigned role. This ensures that it can be safely removed when the mapper rule does not match anymore. For more about SCIM, click [here](../auth-protocols/scim-2.0.md). {% endhint %}
 
 ### Example
 

--- a/docs/am/4.4/guides/identity-providers/user-and-role-mapping.md
+++ b/docs/am/4.4/guides/identity-providers/user-and-role-mapping.md
@@ -89,7 +89,7 @@ In addition, when it comes to fine-grained authorization management, it is consi
 
 The goal is to dynamically add scopes to the `access_token`, depending on the role associated with the user when authenticating.
 
-\{% hint style="info" %\} When the roles are updated via SCIM, the roles already applied via Role Mappers won’t be persisted as an assigned role. This ensures that it can be safely removed when the mapper rule does not match anymore. For more about SCIM, click [here](../auth-protocols/scim-2.0.md). \{% endhint %\}
+{% hint style="info" %} When the roles are updated via SCIM, the roles already applied via Role Mappers won’t be persisted as an assigned role. This ensures that it can be safely removed when the mapper rule does not match anymore. For more about SCIM, click [here](../auth-protocols/scim-2.0.md). {% endhint %}
 
 ### Example
 

--- a/docs/am/4.5/guides/identity-providers/user-and-role-mapping.md
+++ b/docs/am/4.5/guides/identity-providers/user-and-role-mapping.md
@@ -89,7 +89,7 @@ In addition, when it comes to fine-grained authorization management, it is consi
 
 The goal is to dynamically add scopes to the `access_token`, depending on the role associated with the user when authenticating.
 
-\{% hint style="info" %\} When the roles are updated via SCIM, the roles already applied via Role Mappers won’t be persisted as an assigned role. This ensures that it can be safely removed when the mapper rule does not match anymore. For more about SCIM, click [here](../auth-protocols/scim-2.0.md). \{% endhint %\}
+{% hint style="info" %} When the roles are updated via SCIM, the roles already applied via Role Mappers won’t be persisted as an assigned role. This ensures that it can be safely removed when the mapper rule does not match anymore. For more about SCIM, click [here](../auth-protocols/scim-2.0.md). {% endhint %}
 
 ### Example
 

--- a/docs/am/4.6/guides/identity-providers/user-and-role-mapping.md
+++ b/docs/am/4.6/guides/identity-providers/user-and-role-mapping.md
@@ -89,7 +89,7 @@ In addition, when it comes to fine-grained authorization management, it is consi
 
 The goal is to dynamically add scopes to the `access_token`, depending on the role associated with the user when authenticating.
 
-\{% hint style="info" %\} When the roles are updated via SCIM, the roles already applied via Role Mappers won’t be persisted as an assigned role. This ensures that it can be safely removed when the mapper rule does not match anymore. For more about SCIM, click [here](../auth-protocols/scim-2.0.md). \{% endhint %\}
+{% hint style="info" %} When the roles are updated via SCIM, the roles already applied via Role Mappers won’t be persisted as an assigned role. This ensures that it can be safely removed when the mapper rule does not match anymore. For more about SCIM, click [here](../auth-protocols/scim-2.0.md). {% endhint %}
 
 ### Example
 

--- a/docs/am/4.7/guides/identity-providers/user-and-role-mapping.md
+++ b/docs/am/4.7/guides/identity-providers/user-and-role-mapping.md
@@ -89,7 +89,7 @@ In addition, when it comes to fine-grained authorization management, it is consi
 
 The goal is to dynamically add scopes to the `access_token`, depending on the role associated with the user when authenticating.
 
-\{% hint style="info" %\} When the roles are updated via SCIM, the roles already applied via Role Mappers won’t be persisted as an assigned role. This ensures that it can be safely removed when the mapper rule does not match anymore. For more about SCIM, click [here](../auth-protocols/scim-2.0.md). \{% endhint %\}
+{% hint style="info" %} When the roles are updated via SCIM, the roles already applied via Role Mappers won’t be persisted as an assigned role. This ensures that it can be safely removed when the mapper rule does not match anymore. For more about SCIM, click [here](../auth-protocols/scim-2.0.md). {% endhint %}
 
 ### Example
 

--- a/docs/am/4.8/getting-started/install-and-upgrade-guides/deploy-in-kubernetes.md
+++ b/docs/am/4.8/getting-started/install-and-upgrade-guides/deploy-in-kubernetes.md
@@ -549,7 +549,7 @@ oauth2:
 
 If you want to deploy a MongoDB ReplicaSet using the Helm Chart dependency, you simply have to enable it. The **dbhost** has to be defined using the name of the helm installation (in this example **am**) followed by **-mongodb-replicaset**.
 
-\{% hint style="danger" %\} This is not recommended for production environments. \{% endhint %\}
+{% hint style="danger" %} This is not recommended for production environments. {% endhint %}
 
 \{% code title="MongoDB ReplicaSet" %\}
 

--- a/docs/am/4.8/guides/identity-providers/user-and-role-mapping.md
+++ b/docs/am/4.8/guides/identity-providers/user-and-role-mapping.md
@@ -89,7 +89,7 @@ In addition, when it comes to fine-grained authorization management, it is consi
 
 The goal is to dynamically add scopes to the `access_token`, depending on the role associated with the user when authenticating.
 
-\{% hint style="info" %\} When the roles are updated via SCIM, the roles already applied via Role Mappers won’t be persisted as an assigned role. This ensures that it can be safely removed when the mapper rule does not match anymore. For more about SCIM, click [here](../auth-protocols/scim-2.0.md). \{% endhint %\}
+{% hint style="info" %} When the roles are updated via SCIM, the roles already applied via Role Mappers won’t be persisted as an assigned role. This ensures that it can be safely removed when the mapper rule does not match anymore. For more about SCIM, click [here](../auth-protocols/scim-2.0.md). {% endhint %}
 
 ### Example
 

--- a/docs/am/4.9/guides/identity-providers/user-and-role-mapping.md
+++ b/docs/am/4.9/guides/identity-providers/user-and-role-mapping.md
@@ -89,7 +89,7 @@ In addition, when it comes to fine-grained authorization management, it is consi
 
 The goal is to dynamically add scopes to the `access_token`, depending on the role associated with the user when authenticating.
 
-\{% hint style="info" %\} When the roles are updated via SCIM, the roles already applied via Role Mappers won’t be persisted as an assigned role. This ensures that it can be safely removed when the mapper rule does not match anymore. For more about SCIM, click [here](../auth-protocols/scim-2.0.md). \{% endhint %\}
+{% hint style="info" %} When the roles are updated via SCIM, the roles already applied via Role Mappers won’t be persisted as an assigned role. This ensures that it can be safely removed when the mapper rule does not match anymore. For more about SCIM, click [here](../auth-protocols/scim-2.0.md). {% endhint %}
 
 ### Example
 

--- a/docs/apim/4.4/installation-and-upgrades/install-gravitee-api-management/installing-gravitee-api-management-on-premise/install-on-red-hat-and-centos.md
+++ b/docs/apim/4.4/installation-and-upgrades/install-gravitee-api-management/installing-gravitee-api-management-on-premise/install-on-red-hat-and-centos.md
@@ -58,28 +58,28 @@ An SELinux configuration issue can prevent Nginx from opening on ports 8084/8085
 
 1. Validate that the port is not listed here:
 
-{% code overflow="wrap" syntax="sh" %}
-
+{% code overflow="wrap" %}
+```sh
 # semanage port -l | grep http_port_t
 http_port_t                    tcp      80, 81, 443, 488, 8008, 8009, 8443, 9000
-
+```
 {% endcode %}
 
 2.  Add the port to bind to, e.g., 8084:
 
-{% code overflow="wrap" syntax="sh" %}
-
+{% code overflow="wrap" %}
+```sh
 # semanage port -a -t http_port_t -p tcp 8084
-
+```
 {% endcode %}
 
 3. Validate that the port is listed:
 
-{% code overflow="wrap" syntax="sh" %}
-
+{% code overflow="wrap" %}
+```sh
 # semanage port -l | grep http_port_t
 http_port_t                    tcp      8084, 80, 81, 443, 488, 8008, 8009, 8443, 9000
-
+```
 {% endcode %}
 
 4. Restart Nginx

--- a/docs/apim/4.4/installation-and-upgrades/install-gravitee-api-management/installing-gravitee-api-management-on-premise/install-on-red-hat-and-centos.md
+++ b/docs/apim/4.4/installation-and-upgrades/install-gravitee-api-management/installing-gravitee-api-management-on-premise/install-on-red-hat-and-centos.md
@@ -19,19 +19,19 @@ To establish access to Gravitee’s repository using `yum`, complete the followi
 
 1.  Create a file called `/etc/yum.repos.d/graviteeio.repo` using the following command:
 
-    ```sh
-    sudo tee -a /etc/yum.repos.d/graviteeio.repo <<EOF
-    [graviteeio]
-    name=graviteeio
-    gpgcheck=1
-    repo_gpgcheck=1
-    enabled=1
-    gpgkey=https://packagecloud.io/graviteeio/rpms/gpgkey,https://packagecloud.io/graviteeio/rpms/gpgkey/graviteeio-rpms-319791EF7A93C060.pub.gpg
-    sslverify=1
-    sslcacert=/etc/pki/tls/certs/ca-bundle.crt
-    metadata_expire=300
-    EOF
-    ```
+```sh
+sudo tee -a /etc/yum.repos.d/graviteeio.repo <<EOF
+[graviteeio]
+name=graviteeio
+gpgcheck=1
+repo_gpgcheck=1
+enabled=1
+gpgkey=https://packagecloud.io/graviteeio/rpms/gpgkey,https://packagecloud.io/graviteeio/rpms/gpgkey/graviteeio-rpms-319791EF7A93C060.pub.gpg
+sslverify=1
+sslcacert=/etc/pki/tls/certs/ca-bundle.crt
+metadata_expire=300
+EOF
+```
 
 {% hint style="info" %}
 Since APIM 4.4.27, RPM packages are signed with GPG. To verify the packages, use the `gpgcheck=1` configuration.
@@ -40,11 +40,10 @@ Since APIM 4.4.27, RPM packages are signed with GPG. To verify the packages, use
 2. Refresh the local cache using the following command:
 
 {% code overflow="wrap" %}
-```
+```sh
+sudo yum -q makecache -y --disablerepo='\*' --enablerepo='graviteeio'
 ```
 {% endcode %}
-
-\`\`\`\` \`\`\`sh sudo yum -q makecache -y --disablerepo='\*' --enablerepo='graviteeio' \`\`\` \`\`\`\` \{% endcode %\}
 
 ## Installing Gravitee’s API Management
 

--- a/docs/apim/4.4/installation-and-upgrades/install-gravitee-api-management/installing-gravitee-api-management-on-premise/install-on-red-hat-and-centos.md
+++ b/docs/apim/4.4/installation-and-upgrades/install-gravitee-api-management/installing-gravitee-api-management-on-premise/install-on-red-hat-and-centos.md
@@ -61,7 +61,7 @@ An SELinux configuration issue can prevent Nginx from opening on ports 8084/8085
 {% code overflow="wrap" %}
 ```sh
 # semanage port -l | grep http_port_t
-http_port_t                    tcp      80, 81, 443, 488, 8008, 8009, 8443, 9000
+http_port_t        tcp      80, 81, 443, 488, 8008, 8009, 8443, 9000
 ```
 {% endcode %}
 
@@ -78,7 +78,7 @@ http_port_t                    tcp      80, 81, 443, 488, 8008, 8009, 8443, 9000
 {% code overflow="wrap" %}
 ```sh
 # semanage port -l | grep http_port_t
-http_port_t                    tcp      8084, 80, 81, 443, 488, 8008, 8009, 8443, 9000
+http_port_t        tcp      8084, 80, 81, 443, 488, 8008, 8009, 8443, 9000
 ```
 {% endcode %}
 
@@ -97,10 +97,8 @@ Before you install the full APIM stack, you must complete the following configur
 
 1. Install Nginx using the following commands:
 
-\`
-
-\`\`bash sudo yum install epel-release sudo yum install nginx
-
+```bash
+sudo yum install epel-release sudo yum install nginx
 ```
 
 2. You can install Gravitee’s APIM stack with dependencies or without dependencies. To install Gravitee’s APIM with dependencies or without dependencies complete the following steps:
@@ -135,6 +133,8 @@ $ curl -X GET http://localhost:8083/management/organizations/DEFAULT/console
 $ curl -X GET http://localhost:8083/portal/environments/DEFAULT/apis
 $ curl -X GET http://localhost:8085/
 ```
+
+</details>
 
 ### Installing Gravitee's API Management components on Linux using Manual install
 

--- a/docs/apim/4.4/installation-and-upgrades/install-gravitee-api-management/installing-gravitee-api-management-on-premise/install-on-red-hat-and-centos.md
+++ b/docs/apim/4.4/installation-and-upgrades/install-gravitee-api-management/installing-gravitee-api-management-on-premise/install-on-red-hat-and-centos.md
@@ -53,38 +53,37 @@ There are two methods that you can use to install Gravitee’s API Management (A
 * Quick install. You install all the prerequisites that you need to run Gravitee’s APIM and the full APIM stack.
 * Manual install. You control the installation of the prerequisites that you need to run APIM. Also, you control the installation of the individual components of the APIM stack
 
-\{% hint style="warning" %\} An SELinux configuration issue can prevent Nginx from opening on ports 8084/8085. To correct this:
+{% hint style="warning" %}
+An SELinux configuration issue can prevent Nginx from opening on ports 8084/8085. To correct this:
 
 1. Validate that the port is not listed here:
 
-\{% code overflow="wrap" %\}
+{% code overflow="wrap" syntax="sh" %}
 
-````
-```sh
 # semanage port -l | grep http_port_t
 http_port_t                    tcp      80, 81, 443, 488, 8008, 8009, 8443, 9000
-```
-````
 
-\{% endcode %\}
+{% endcode %}
 
 2.  Add the port to bind to, e.g., 8084:
 
-    \`
+{% code overflow="wrap" syntax="sh" %}
 
-\`\`sh # semanage port -a -t http\_port\_t -p tcp 8084 \`\`\` 3. Validate that the port is listed:
+# semanage port -a -t http_port_t -p tcp 8084
 
-\{% code overflow="wrap" %\} \`
+{% endcode %}
 
-\`\`
+3. Validate that the port is listed:
 
-```
+{% code overflow="wrap" syntax="sh" %}
 
-</div>
+# semanage port -l | grep http_port_t
+http_port_t                    tcp      8084, 80, 81, 443, 488, 8008, 8009, 8443, 9000
 
-\`\`\`\` \`\`\`sh # semanage port -l | grep http\_port\_t http\_port\_t tcp 8084, 80, 81, 443, 488, 8008, 8009, 8443, 9000 \`\`\` \`\`\`\` {% endcode %}
+{% endcode %}
 
-4. Restart Nginx {% endhint %}
+4. Restart Nginx
+{% endhint %}
 
 ### Install the full APIM stack
 
@@ -139,9 +138,11 @@ $ curl -X GET http://localhost:8085/
 
 ### Installing Gravitee's API Management components on Linux using Manual install
 
-\{% hint style="info" %\} **Gravitee dependencies**
+{% hint style="info" %}
+**Gravitee dependencies**
 
-Gravitee's [Installation & Upgrade Guides](../) provide information about how you install Gravitee components. For prerequisite documentation on third-party products like [MongoDB](https://www.mongodb.com/docs/v7.0/tutorial/install-mongodb-on-red-hat/) or [Elasticsearch](https://www.elastic.co/guide/en/elasticsearch/reference/8.11/rpm.html), please visit their respective websites. \{% endhint %\}
+Gravitee's [Installation & Upgrade Guides](../) provide information about how you install Gravitee components. For prerequisite documentation on third-party products like [MongoDB](https://www.mongodb.com/docs/v7.0/tutorial/install-mongodb-on-red-hat/) or [Elasticsearch](https://www.elastic.co/guide/en/elasticsearch/reference/8.11/rpm.html), please visit their respective websites.
+{% endhint %}
 
 Depending on your environment's configuration, you can install only the APIM components that you want for your environment. Here are the components that you can install individually:
 


### PR DESCRIPTION
This PR fixes all currently broken hint blocks that are at the root of the documents.

The remaining hint blocks are currently nested in lists, which isn't supported in GitBook. So before fixing them, more care should be given to the way these remaining blocks should be rendered.

This PR also takes the opportunity to fix the `docs/apim/4.4/installation-and-upgrades/install-gravitee-api-management/installing-gravitee-api-management-on-premise/install-on-red-hat-and-centos.md` page more globally, since it also had a missing HTML `</details>` tag, causing part of the page to be lost during imports, and broken code blocks.