### PR TITLE
[sync] add GKO to version sync + backfill 4.10 → 4.11

### DIFF
--- a/.github/workflows/version-sync.yml
+++ b/.github/workflows/version-sync.yml
@@ -17,8 +17,7 @@ on:
       # Add one entry per product/version you want to sync FROM.
       - 'docs/apim/4.10/**'
       - 'docs/am/4.10/**'
-      # Add more as needed:
-      # - 'docs/gko/4.10/**'
+      - 'docs/gko/4.10/**'
 
 # Grant write access so the bot can create branches and PRs
 permissions:
@@ -38,9 +37,9 @@ jobs:
           - product: am
             current: "4.10"
             next: "4.11"
-          # - product: gko
-          #   current: "4.10"
-          #   next: "4.11"
+          - product: gko
+            current: "4.10"
+            next: "4.11"
 
     steps:
       - uses: actions/checkout@v4

--- a/docs/gko/4.11/releases-and-changelog/changelog/gko-4.10.x.md
+++ b/docs/gko/4.11/releases-and-changelog/changelog/gko-4.10.x.md
@@ -1,0 +1,61 @@
+# GKO 4.10.x
+
+## Gravitee Kubernetes Operator 4.10.6 - February 16, 2026
+
+There is nothing new in version 4.10.6.
+
+> This version was generated to keep the kubernetes operator in sync with other gravitee products.
+
+
+
+## Gravitee Kubernetes Operator 4.10.5 - February 16, 2026
+
+<details>
+<summary>Improvements</summary>
+
+  **GKO**
+
+  * Add archived state to v4 API [#11124](https://github.com/gravitee-io/issues/issues/11124)
+  * Allow to configure autoscaling when deploying gateway-api gateways [#11120](https://github.com/gravitee-io/issues/issues/11120)
+
+  **APIM**
+
+  * Add break glass mode for automation APIs [#11099](https://github.com/gravitee-io/issues/issues/11099)
+
+</details>
+
+## Gravitee Kubernetes Operator 4.10.4 - February 10, 2026
+
+<details>
+<summary>Improvements</summary>
+
+  **GKO**
+
+  * Support deprecated state for v4 APIS [#11068](https://github.com/gravitee-io/issues/issues/11068)
+  * Gateway class parameters annotations are not applied to gateway service [#11114](https://github.com/gravitee-io/issues/issues/11114)
+  * CRD export contains null fields and extra properties after GKO deployment [#11031](https://github.com/gravitee-io/issues/issues/11031)
+
+</details>
+
+## Gravitee Kubernetes Operator 4.10.3 - January 30, 2026
+
+<details>
+<summary>Bug fixes</summary>
+
+  **GKO**
+
+  * Importing a v4 can throw a NoSuchElementException when no default role is associated to a scope [#11098](https://github.com/gravitee-io/issues/issues/11098)
+
+</details>
+
+## Gravitee Kubernetes Operator 4.10.2 - January 22, 2026
+
+This version does not introduce any new features or bug fixes.
+
+> This version was generated to keep the Kubernetes Operator in sync with other Gravitee products.
+
+## Gravitee Kubernetes Operator 4.10.1 - January 22, 2026
+
+This version does not introduce any new features or bug fixes.
+
+> This version was generated to keep the Kubernetes Operator in sync with other Gravitee products.

--- a/docs/gko/4.11/releases-and-changelog/release-notes/gko-4.10.md
+++ b/docs/gko/4.11/releases-and-changelog/release-notes/gko-4.10.md
@@ -1,0 +1,34 @@
+---
+Gravitee Kubernetes Operator 4.10 Release Notes.
+---
+
+# GKO 4.10
+
+## Highlights
+
+This release brings bug fixes and new features focused on HTTP Client configuration, and **official Gateway API v1.3 partial conformance** recognition.
+
+## New Features
+
+**GKO HTTP Client configuration enhancements**
+
+* Management APIs connection through proxy. 
+* Support for custom CA certificates outside of `/etc/ssl/certs`.
+* Connection timeout
+
+Refer to the Helm Chart section to know how to configure proxy URL & auth, timeouts and CAs.
+All of the above were back-ported to 4.8.x and 4.9.x versions of GKO.
+
+**Windowed Count Sample Strategy**
+
+This release adds support for the Windowed Count sampling strategy for message APIs.
+
+## Gateway API Conformance
+
+We're excited to announce that **Gravitee Kubernetes Operator 4.10 is now officially recognized** as a **Partially Conformant** implementation of the Kubernetes Gateway API specification version 1.3! The Gravitee Kubernetes Operator is now officially listed on the [Gateway API implementations page](https://gateway-api.sigs.k8s.io/implementations/#gravitee-kubernetes-operator), joining a select group of gateway providers recognized by the Kubernetes community.
+
+This milestone, first achieved in version 4.8.5, recognizes our commitment to providing a standards-compliant API gateway solution for Kubernetes environments.
+
+### What This Means for You
+
+**Gravitee Kubernetes Operator 4.10** delivers partial conformance for Gateway and HTTPRoute resources, enabling you to leverage the Gateway API standard for managing your API infrastructure. While the current implementation focuses on core Gateway and HTTPRoute functionality with Kubernetes Core v1 services, we're working on expanding support for additional matching rules across routes and alternative service types in upcoming releases.


### PR DESCRIPTION
Enables GKO 4.10→4.11 sync in the version-sync workflow. Backfills 2 new files: gko-4.10.x changelog and gko-4.10 release notes.