### PR TITLE
Debug Vale workflow: remove stderr suppression and add test file

### DIFF
--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -54,6 +54,6 @@ jobs:
           echo "${{ steps.changed-files.outputs.files }}" | while IFS= read -r file; do
             if [ -n "$file" ] && [ -f "$file" ]; then
               echo "Linting: $file" >&2
-              /tmp/vale-bin/vale --output=vale/output.tmpl "$file" 2>/dev/null || true
+              /tmp/vale-bin/vale --output=vale/output.tmpl "$file" || true
             fi
           done | reviewdog -efm="%f:%l:%c:%m" -name=vale -reporter=github-pr-review -filter-mode=added -fail-on-error=false -level=warning

--- a/docs/vale-test.md
+++ b/docs/vale-test.md
@@ -1,0 +1,5 @@
+# Vale test
+
+Before managing client certificates via REST API, ensure the following:
+
+This request returns resources starting with "prod".

--- a/docs/vale-test.md
+++ b/docs/vale-test.md
@@ -1,5 +1,0 @@
-# Vale test
-
-Before managing client certificates via REST API, ensure the following:
-
-This request returns resources starting with "prod".


### PR DESCRIPTION
Remove 2>/dev/null so Vale errors are visible in Actions logs. Add test file to trigger Vale rules.