### PR TITLE
update naming convention

### DIFF
--- a/docs/apim/4.11/release-information/release-notes/apim-4.11.md
+++ b/docs/apim/4.11/release-information/release-notes/apim-4.11.md
@@ -50,9 +50,9 @@
 <!-- PIPELINE:APIM-12371 -->
 #### **API Products**
 
-* Bundle multiple V4 HTTP Proxy APIs into a single subscribable package with unified access control and product-level plans (API Key, JWT, or mTLS).
-* Manage subscriptions at the product level instead of individual APIs, enabling API product managers to package and monetize APIs at scale.
-* APIs must have the `allowedInApiProducts` flag enabled to be included in products; APIs can belong to multiple products while maintaining their own direct subscription plans.
+* Bundle multiple V4 HTTP Proxy APIs into a single subscribable package with unified access control and API Product-level plans (API Key, JWT, or mTLS).
+* Manage subscriptions at the API Product level instead of individual APIs, enabling API Product managers to package and monetize APIs at scale.
+* APIs must have the `allowedInApiProducts` flag enabled to be included in API Products; APIs can belong to multiple API Products while maintaining their own direct subscription plans.
 * Requires Enterprise Universe tier license and environment-level permissions for API Product management.
 * Plans and subscriptions now support a reference model with `referenceType` (API or API_PRODUCT) and `referenceId` fields; the legacy `api` field is deprecated as of 4.11.0.
 <!-- /PIPELINE:APIM-12371 -->

--- a/docs/apim/4.11/secure-and-expose-apis/api-products-configuration-reference.md
+++ b/docs/apim/4.11/secure-and-expose-apis/api-products-configuration-reference.md
@@ -4,16 +4,16 @@
 
 | Property | Type | Required | Description |
 |:---------|:-----|:---------|:------------|
-| `name` | string | Yes | Product name. Unique within the environment (case-sensitive comparison). Leading and trailing whitespace is trimmed. |
-| `version` | string | Yes | Product version |
-| `description` | string | No | Product description |
-| `apiIds` | string[] | No | List of API IDs included in the product. All referenced APIs must exist and have `allowedInApiProducts=true`. |
+| `name` | string | Yes | API Product name. Unique within the environment (case-sensitive comparison). Leading and trailing whitespace is trimmed. |
+| `version` | string | Yes | API Product version |
+| `description` | string | No | API Product description |
+| `apiIds` | string[] | No | List of API IDs included in the API Product. All referenced APIs must exist and have `allowedInApiProducts=true`. |
 
 ## API eligibility configuration
 
 | Property | Type | Default | Description |
 |:---------|:-----|:--------|:------------|
-| `allowedInApiProducts` | Boolean | `true` for new V4 HTTP Proxy APIs; `false` for existing APIs created before 4.11.0; `null` for non-HTTP Proxy types | Enables API inclusion in API Products. Only applicable to V4 HTTP Proxy APIs. Cannot be disabled once the API is included in a product. |
+| `allowedInApiProducts` | Boolean | `true` for new V4 HTTP Proxy APIs; `false` for existing APIs created before 4.11.0; `null` for non-HTTP Proxy types | Enables API inclusion in API Products. Only applicable to V4 HTTP Proxy APIs. Can't be disabled once the API is included in an API Product. |
 
 ## Plan reference model
 

--- a/docs/apim/4.11/secure-and-expose-apis/api-products/README.md
+++ b/docs/apim/4.11/secure-and-expose-apis/api-products/README.md
@@ -15,7 +15,7 @@ An API Product is an environment-level resource that groups V4 HTTP Proxy APIs u
 - A unique name within its environment (name comparison is case-sensitive, so "Product A" and "product a" are treated as different names)
 - A version
 - An optional description
-- API Product-level plans (API Key, JWT, or mTLS only — Keyless and OAuth plans are not supported)
+- API Product-level plans (API Key, JWT, or mTLS only — Keyless and OAuth plans aren't supported)
 - API Product-level subscriptions
 
 ## How APIs, API Products, plans, and subscriptions relate

--- a/docs/apim/4.11/secure-and-expose-apis/api-products/README.md
+++ b/docs/apim/4.11/secure-and-expose-apis/api-products/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-API Products enable administrators to bundle multiple V4 HTTP Proxy APIs into a single subscribable package with unified access control. Instead of managing subscriptions to individual APIs, organizations define product-level plans that grant access to all APIs within the product.
+API Products enable administrators to bundle multiple V4 HTTP Proxy APIs into a single subscribable package with unified access control. Instead of managing subscriptions to individual APIs, organizations define API Product-level plans that grant access to all APIs within the API Product.
 
 This feature requires an Enterprise Universe tier license.
 
@@ -10,21 +10,21 @@ This feature requires an Enterprise Universe tier license.
 
 ## What is an API Product?
 
-An API Product is an environment-level resource that groups V4 HTTP Proxy APIs under a single subscription model. Each product has:
+An API Product is an environment-level resource that groups V4 HTTP Proxy APIs under a single subscription model. Each API Product has:
 
 - A unique name within its environment (name comparison is case-sensitive, so "Product A" and "product a" are treated as different names)
 - A version
 - An optional description
-- Product-level plans (API Key, JWT, or mTLS only — Keyless and OAuth plans are not supported)
-- Product-level subscriptions
+- API Product-level plans (API Key, JWT, or mTLS only — Keyless and OAuth plans are not supported)
+- API Product-level subscriptions
 
-## How APIs, products, plans, and subscriptions relate
+## How APIs, API Products, plans, and subscriptions relate
 
 An API Product groups one or more V4 HTTP Proxy APIs. Each API Product has its own plans and subscriptions, separate from the plans and subscriptions of the individual APIs it contains.
 
-APIs within a product retain their own plans and subscriptions. Consumers can subscribe to an individual API's plans independently of the product, and existing API-level subscriptions remain active when an API is added to a product.
+APIs within an API Product retain their own plans and subscriptions. Consumers can subscribe to an individual API's plans independently of the API Product, and existing API-level subscriptions remain active when an API is added to an API Product.
 
-An API can belong to multiple products simultaneously. The API's General Info page displays an **Included in** field listing the API Products the API belongs to. If the API is included in more than 5 products, the first 5 are shown with a **+n more** link that opens a searchable dialog.
+An API can belong to multiple API Products simultaneously. The API's General Info page displays an **Included in** field listing the API Products the API belongs to. If the API is included in more than 5 API Products, the first 5 are shown with a **+n more** link that opens a searchable dialog.
 
 When viewing subscriptions from the Application level, each subscription displays an **API** or **API Product** label to indicate whether the subscription is for an individual API or an API Product. When creating a subscription from an Application, the search returns results for both APIs and API Products.
 
@@ -35,7 +35,7 @@ When a request reaches the gateway, the gateway validates subscriptions in the f
 1. The gateway checks the request against the API Product plan subscription first.
 2. If no valid API Product subscription exists, the gateway falls back to validating against the individual API plan.
 
-API Product plans take priority, but access through API-level plans is still possible when no product-level subscription applies.
+API Product plans take priority, but access through API-level plans is still possible when no API Product-level subscription applies.
 
 ## API eligibility
 
@@ -45,7 +45,7 @@ Only V4 HTTP Proxy APIs with the **Allow in API Products** toggle enabled can be
 - Defaults to `true` for new V4 HTTP Proxy APIs created in version 4.11.0 or later
 - Defaults to `false` for existing V4 HTTP Proxy APIs created before version 4.11.0
 - Is unavailable for read-only APIs (for example, Kubernetes-managed APIs)
-- Can't be disabled once an API is included in a product (the toggle is greyed out with the tooltip "API is currently used in API Products")
+- Can't be disabled once an API is included in an API Product (the toggle is greyed out with the tooltip "API is currently used in API Products")
 
 ### Enable an API for use in API Products
 
@@ -67,7 +67,7 @@ Only V4 HTTP Proxy APIs with the **Allow in API Products** toggle enabled can be
 
 1. In the APIM Console, select **API Products** in the left sidebar.
 2. Click **Create API Product**.
-3. Enter a unique **Name** for the product. Names are case-sensitive — "Product A" and "product a" are treated as different names.
+3. Enter a unique **Name** for the API Product. Names are case-sensitive — "Product A" and "product a" are treated as different names.
 4. Enter a **Version** number.
 5. Optionally, enter a **Description**.
 6. Click **Create API Product**.
@@ -80,7 +80,7 @@ Only V4 HTTP Proxy APIs with the **Allow in API Products** toggle enabled can be
 2. Update the **Name**, **Version**, or **Description** fields as needed.
 3. A save bar appears at the bottom of the page when changes are detected. Click **Save** to apply the changes, or click **Reset** to discard them.
 
-## Add APIs to a product
+## Add APIs to an API Product
 
 1. Open the API Product and select **APIs** in the left sidebar.
 2. Click **Add API**.
@@ -93,13 +93,13 @@ If an expected API doesn't appear in the search results, verify that the **Allow
 
 <figure><img src="../../.gitbook/assets/add-api-to-product.png" alt=""><figcaption><p>Add API dialog for an API Product</p></figcaption></figure>
 
-## Remove an API from a product
+## Remove an API from an API Product
 
 1. Open the API Product and select **APIs** in the left sidebar.
 2. In the APIs list, click the trash icon next to the API to remove.
 3. In the confirmation dialog, click **Yes, remove it**.
 
-## Remove all APIs from a product
+## Remove all APIs from an API Product
 
 1. Open the API Product and select **Configuration** in the left sidebar.
 2. Scroll to the **Danger Zone** section at the bottom of the page.
@@ -150,7 +150,7 @@ To change the order in which plans are evaluated, drag and drop plans in the lis
 
 ## Deploy an API Product
 
-After creating plans and adding APIs, deploy the API Product to make it available at the gateway. When the product is out of sync, a warning banner displays "This API Product is out of sync." with a **Deploy API Product** button.
+After creating plans and adding APIs, deploy the API Product to make it available at the gateway. When the API Product is out of sync, a warning banner displays "This API Product is out of sync." with a **Deploy API Product** button.
 
 1. Click **Deploy API Product** in the banner.
 2. In the **Deploy your API Product** dialog, click **Deploy**.

--- a/docs/apim/4.11/secure-and-expose-apis/api-products/console-ui-reference.md
+++ b/docs/apim/4.11/secure-and-expose-apis/api-products/console-ui-reference.md
@@ -12,8 +12,8 @@ After opening an API Product, the detail page displays a left sidebar with the f
 
 | Menu item | Description |
 |:----------|:------------|
-| **Configuration** | Edit the product name, version, and description |
-| **APIs** | Add or remove APIs from the product |
+| **Configuration** | Edit the API Product name, version, and description |
+| **APIs** | Add or remove APIs from the API Product |
 | **Consumers** | Manage plans and subscriptions (contains **Plans** and **Subscriptions** tabs) |
 
 <figure><img src="../../.gitbook/assets/api-product-detail.png" alt=""><figcaption><p>API Product detail page with navigation menu</p></figcaption></figure>
@@ -26,11 +26,11 @@ The **Configuration** tab displays editable fields for:
 - **Version** — required
 - **Description** — optional
 
-A danger zone at the bottom of the page provides options to remove all APIs from the product or delete the product entirely.
+A danger zone at the bottom of the page provides options to remove all APIs from the API Product or delete the API Product entirely.
 
 ## APIs tab
 
-The **APIs** tab lists all APIs included in the product with the following columns: Name, Context Path, Definition, and Version.
+The **APIs** tab lists all APIs included in the API Product with the following columns: Name, Context Path, Definition, and Version.
 
 - Click **Add API** to open the **Add API** dialog and search for eligible APIs.
 - The info banner in the dialog states: "APIs must have API products enabled before they appear in the list."

--- a/docs/apim/4.11/secure-and-expose-apis/api-products/consuming-api-products.md
+++ b/docs/apim/4.11/secure-and-expose-apis/api-products/consuming-api-products.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Clients consume APIs within an API Product using the same authentication mechanisms as individual API subscriptions. A single API Product subscription grants access to all APIs contained in the product.
+Clients consume APIs within an API Product using the same authentication mechanisms as individual API subscriptions. A single API Product subscription grants access to all APIs contained in the API Product.
 
 ## Authentication methods
 
@@ -26,7 +26,7 @@ When a request reaches the gateway, the gateway validates subscriptions in the f
 1. The gateway checks the request against the API Product plan subscription first.
 2. If no valid API Product subscription exists, the gateway falls back to validating against the individual API plan.
 
-API Product plans take priority, but access through API-level plans is still possible when no product-level subscription applies. APIs within a product retain their own plans and subscriptions, so consumers can continue to subscribe to individual API plans independently of the product.
+API Product plans take priority, but access through API-level plans is still possible when no API Product-level subscription applies. APIs within an API Product retain their own plans and subscriptions, so consumers can continue to subscribe to individual API plans independently of the API Product.
 
 ## Gateway context attributes
 
@@ -34,7 +34,7 @@ For API Product subscriptions, the gateway sets the following context attributes
 
 - `apiProductId`: The API Product ID, exposed in the Expression Language context
 
-To execute product-specific policies, use flow conditions that reference the `apiProductId` attribute.
+To execute API Product-specific policies, use flow conditions that reference the `apiProductId` attribute.
 
 ## Subscribe to an API Product
 

--- a/docs/apim/4.11/secure-and-expose-apis/api-products/manage-api-products-via-management-api.md
+++ b/docs/apim/4.11/secure-and-expose-apis/api-products/manage-api-products-via-management-api.md
@@ -86,7 +86,7 @@ Manage subscription lifecycle using these endpoints:
 
 ## Plan and subscription reference model
 
-Plans and subscriptions use a reference model to distinguish between API-level and product-level resources:
+Plans and subscriptions use a reference model to distinguish between API-level and API Product-level resources:
 
 - `referenceType`: `API` or `API_PRODUCT`
 - `referenceId`: The ID of the parent API or API Product

--- a/docs/apim/4.11/secure-and-expose-apis/api-products/restrictions-and-licensing.md
+++ b/docs/apim/4.11/secure-and-expose-apis/api-products/restrictions-and-licensing.md
@@ -33,15 +33,15 @@ If a duplicate name is submitted, the system rejects it with the error: "API Pro
 
 APIs added to an API Product have the following requirements:
 
-- The **Allow in API Products** toggle on the API's General Info page is set to enabled. APIs with this toggle disabled or not set can't be added to products.
-- The **Allow in API Products** toggle can't be disabled once an API is included in a product. The toggle is greyed out in the Console when the API is used in products.
+- The **Allow in API Products** toggle on the API's General Info page is set to enabled. APIs with this toggle disabled or not set can't be added to API Products.
+- The **Allow in API Products** toggle can't be disabled once an API is included in an API Product. The toggle is greyed out in the Console when the API is used in API Products.
 - The **Allow in API Products** toggle is unavailable for read-only APIs (for example, Kubernetes-managed APIs).
 
-APIs within a product retain their own plans and subscriptions. Consumers can subscribe to an individual API's plans independently of the product.
+APIs within an API Product retain their own plans and subscriptions. Consumers can subscribe to an individual API's plans independently of the API Product.
 
 ## Policy and flow restrictions
 
-API Products can't include flows or policies at the product level. Define policies at the API or plan level. To execute product-specific policies, use flow conditions that reference the API Product ID via the `apiProductId` Expression Language attribute.
+API Products can't include flows or policies at the API Product level. Define policies at the API or plan level. To execute API Product-specific policies, use flow conditions that reference the API Product ID via the `apiProductId` Expression Language attribute.
 
 ## Gateway subscription validation order
 
@@ -50,4 +50,4 @@ The gateway validates subscriptions in the following priority order:
 1. The gateway checks the request against the API Product plan subscription first.
 2. If no valid API Product subscription exists, the gateway falls back to validating against the individual API plan.
 
-API Product plans take priority, but access through API-level plans is still possible when no product-level subscription applies.
+API Product plans take priority, but access through API-level plans is still possible when no API Product-level subscription applies.

--- a/docs/apim/4.11/secure-and-expose-apis/subscriptions/manage-subscriptions.md
+++ b/docs/apim/4.11/secure-and-expose-apis/subscriptions/manage-subscriptions.md
@@ -21,7 +21,7 @@ From the **Subscriptions** header of this page, you can view, filter, and delete
 
 As of version 4.11.0, subscriptions use a reference model that supports both API and API Product subscriptions. Each subscription includes a `referenceType` field (`API` or `API_PRODUCT`) and a `referenceId` pointing to the parent resource. The legacy `api` field is deprecated as of version 4.11.0 and shouldn't be used for new subscriptions.
 
-When validating subscriptions, the gateway checks API Product subscriptions first before checking API-level plans. This allows organizations to manage access at the product level while maintaining backward compatibility with existing API subscriptions.
+When validating subscriptions, the gateway checks API Product subscriptions first before checking API-level plans. This allows organizations to manage access at the API Product level while maintaining backward compatibility with existing API subscriptions.
 
 <figure><img src="../../.gitbook/assets/1 app sub 1.png" alt=""><figcaption></figcaption></figure>
 


### PR DESCRIPTION
- Replaces standalone "product" / "products" with "API Product" / "API Products" across all API Products documentation pages