### PR TITLE
fix label linting

### DIFF
--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -1,6 +1,7 @@
 name: Vale Linting
 on:
   pull_request:
+    types: [labeled, synchronize]
     paths:
       - 'docs/**.md'
       - 'docs/**.mdx'
@@ -11,6 +12,7 @@ permissions:
 
 jobs:
   vale:
+    if: contains(github.event.pull_request.labels.*.name, 'vale integration')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
  ## Summary

  - Vale was running on every push to PRs that touch docs files, creating too much noise on pipeline-generated PRs
  - Now Vale only runs when the `vale integration` label is added to a PR
  - Subsequent pushes to a labeled PR still trigger Vale automatically

  ## Changes
  - Added `types: [labeled, synchronize]` to the pull_request trigger
  - Added `if: contains(github.event.pull_request.labels.*.name, 'vale integration')` condition on the job
  - Created the `vale integration` label in the repo