### PR TITLE
[sync] apim: 4.10 → 4.11

### DIFF
--- a/docs/apim/4.11/release-information/changelog/apim-4.10.x.md
+++ b/docs/apim/4.11/release-information/changelog/apim-4.10.x.md
@@ -1,5 +1,73 @@
 # APIM 4.10.x
  
+## Gravitee API Management 4.10.9 - March 27, 2026
+<details>
+
+<summary>Bug Fixes</summary>
+
+**Gateway**
+
+* SSL enforcement policy will return a 403 if if the SSL connection is terminated at the ingress level [#11234](https://github.com/gravitee-io/issues/issues/11234)
+* Dynamic dictionary not deployed when environment is not the default one [#11236](https://github.com/gravitee-io/issues/issues/11236)
+* JWT plans can only have one subscription transfer [#11246](https://github.com/gravitee-io/issues/issues/11246)
+* Duplicate traceparent header [#11248](https://github.com/gravitee-io/issues/issues/11248)
+* The Health Check of the API V4 is not working as expected with tenant [#11275](https://github.com/gravitee-io/issues/issues/11275)
+* Secret resolution failure in SPG when combined with multiple policies [#11279](https://github.com/gravitee-io/issues/issues/11279)
+
+**Management API**
+
+* Promotion Button in UI Yields Parsing Error [#11277](https://github.com/gravitee-io/issues/issues/11277)
+
+**Console**
+
+* Missing fields when creating an alert [#10802](https://github.com/gravitee-io/issues/issues/10802)
+* Locations in Admin Console time out due to requests being sent to old Groups API Endpoint where pagination is not implemented [#10843](https://github.com/gravitee-io/issues/issues/10843)
+* \[Logging] API Level logs missing details if one of the checkbox is unchecked [#11116](https://github.com/gravitee-io/issues/issues/11116)
+* Error when importing an API from OpenAPI Spec & "Add OpenAPI Specification Validation" enabled [#11128](https://github.com/gravitee-io/issues/issues/11128)
+* Not able search/filter logs by path [#11255](https://github.com/gravitee-io/issues/issues/11255)
+* v4 API promotions are stuck in a pending state [#11281](https://github.com/gravitee-io/issues/issues/11281)
+
+**Portal**
+
+* Portal-Next: MCP functionalities no longer shown [#11187](https://github.com/gravitee-io/issues/issues/11187)
+
+**Other**
+
+* Bootstrap URL for Kafka DLQ endpoint does not support Expression Language [#10906](https://github.com/gravitee-io/issues/issues/10906)
+* Application menu not showing up on first login [#10951](https://github.com/gravitee-io/issues/issues/10951)
+* Promotion request is not found in Audit of the target environment. [#11065](https://github.com/gravitee-io/issues/issues/11065)
+* json-validation policy error key [#11152](https://github.com/gravitee-io/issues/issues/11152)
+* Agent Mesh - Generate Tools from OpenAPI [#11165](https://github.com/gravitee-io/issues/issues/11165)
+* \[V4 Emulation] IllegalStateException: HTTP/2 streams failing due to missing Content-Length validation [#11191](https://github.com/gravitee-io/issues/issues/11191)
+* FreeMarker template error in v4-message-log.ftl when Kafka metadata contains byte\[] [#11220](https://github.com/gravitee-io/issues/issues/11220)
+* OpenAPI Specification Validation Policy - Validation errors [#11223](https://github.com/gravitee-io/issues/issues/11223)
+* MCP Tool Generation: Operation descriptions and business rules are missing from generated tools [#11226](https://github.com/gravitee-io/issues/issues/11226)
+* Detaching an API looses API context after confirmation [#11239](https://github.com/gravitee-io/issues/issues/11239)
+* Kafka gateways is throwing recurrent "Thread blocked" errors [#11242](https://github.com/gravitee-io/issues/issues/11242)
+* Changing plan order removes the plan flows [#11247](https://github.com/gravitee-io/issues/issues/11247)
+* OAuth2 token acquisition failure is silently swallowed [#11250](https://github.com/gravitee-io/issues/issues/11250)
+* Webhook Logs toggle not updated after save/publish [#11257](https://github.com/gravitee-io/issues/issues/11257)
+* Once I migrate certain V2 APIs to V4, they disappear from the list (/apis) in the UI [#11268](https://github.com/gravitee-io/issues/issues/11268)
+* Migration to v4 engine : flows on deprecated plans not visible anymore [#11269](https://github.com/gravitee-io/issues/issues/11269)
+
+</details>
+
+<details>
+
+<summary>Improvements</summary>
+
+**Other**
+
+* Api Categories exported by IDs instead of names [#10944](https://github.com/gravitee-io/issues/issues/10944)
+* Allow for larger values in APIM Dictionary properties [#11047](https://github.com/gravitee-io/issues/issues/11047)
+* \[gravitee-policy-aws-lambda] Unexpected Retry and Duplicate Invocation of AWS Lambda via Gravitee API Gateway [#11096](https://github.com/gravitee-io/issues/issues/11096)
+* "Thread blocked" error received when invalid creadentials set for Elastic Search [#11184](https://github.com/gravitee-io/issues/issues/11184)
+* Support client_secret_basic authentication for OAuth2 token endpoint [#11249](https://github.com/gravitee-io/issues/issues/11249)
+
+</details>
+
+
+ 
 ## Gravitee API Management 4.10.8 - March 12, 2026
 <details>
 


### PR DESCRIPTION
Auto-synced changes from `docs/apim/4.10/` to `docs/apim/4.11/`.

Triggered by push to `main` (25308411bcad34c4edec27016be2e4f2e2a7d515).