### PR TITLE
[sync] am: 4.10 → 4.11

### DIFF
--- a/docs/am/4.11/releases-and-changelog/changelog/am-4.10.x.md
+++ b/docs/am/4.11/releases-and-changelog/changelog/am-4.10.x.md
@@ -6,6 +6,30 @@ description: >-
 
 # AM 4.10.x
 
+## Gravitee Access Management 4.10.6 - March 27, 2026
+
+<details>
+
+<summary>Bug fixes</summary>
+
+**Gateway**
+
+* Upgrade avro dependency [#11228](https://github.com/gravitee-io/issues/issues/11228)
+* Improve logging of AWS HSM plugin [#11240](https://github.com/gravitee-io/issues/issues/11240)
+* Limit the emailLeaseAcquiring attempt for email bulk [#11260](https://github.com/gravitee-io/issues/issues/11260)
+
+**Management API**
+
+* Fix API breaking change on SMTP resource update [#11244](https://github.com/gravitee-io/issues/issues/11244)
+
+**Others**
+
+* Update reporter script [#11262](https://github.com/gravitee-io/issues/issues/11262)
+
+
+</details>
+
+
 ## Gravitee Access Management 4.10.5 - March 13, 2026
 
 <details>


### PR DESCRIPTION
Auto-synced changes from `docs/am/4.10/` to `docs/am/4.11/`.

Triggered by push to `main` (05965c92b561a0b6b43a2d22776a111003c24721).