### PR TITLE
add proxy config YAML snippets to all installation guides

### DIFF
--- a/docs/apim/4.11/hybrid-installation-and-configuration-guides/next-gen-cloud/docker/docker-cli.md
+++ b/docs/apim/4.11/hybrid-installation-and-configuration-guides/next-gen-cloud/docker/docker-cli.md
@@ -209,7 +209,18 @@ To shut down the Gateway, choose one of the following options.
 
 ## Proxy configuration
 
-To route Gateway traffic through a corporate proxy (for example, for backend API calls or JWKS retrieval from external identity providers like Microsoft Entra ID), configure the system proxy using `gravitee_system_proxy_*` environment variables on the Gateway container. For detailed instructions, see [Proxy Configuration](../../proxy-configuration/).
+To route Gateway traffic through a corporate proxy (for example, for backend API calls or JWKS retrieval from external identity providers like Microsoft Entra ID), add the following `gravitee_system_proxy_*` environment variables to the Gateway container:
+
+```
+gravitee_system_proxy_enabled=true
+gravitee_system_proxy_type=HTTP
+gravitee_system_proxy_host=<proxy-host>
+gravitee_system_proxy_port=<proxy-port>
+gravitee_system_proxy_https_host=<proxy-host>
+gravitee_system_proxy_https_port=<proxy-port>
+```
+
+For the full configuration reference including proxy authentication, see [System Proxy for Backend APIs](../../proxy-configuration/system-proxy-for-backend-apis.md). For an overview of all proxy methods, see [Proxy Configuration](../../proxy-configuration/).
 
 ## Next steps
 

--- a/docs/apim/4.11/hybrid-installation-and-configuration-guides/next-gen-cloud/docker/docker-compose.md
+++ b/docs/apim/4.11/hybrid-installation-and-configuration-guides/next-gen-cloud/docker/docker-compose.md
@@ -169,7 +169,18 @@ To shut down the Gateway, choose one of the following options.
 
 ## Proxy configuration
 
-To route Gateway traffic through a corporate proxy (for example, for backend API calls or JWKS retrieval from external identity providers like Microsoft Entra ID), configure the system proxy using `gravitee_system_proxy_*` environment variables on the Gateway container. For detailed instructions, see [Proxy Configuration](../../proxy-configuration/).
+To route Gateway traffic through a corporate proxy (for example, for backend API calls or JWKS retrieval from external identity providers like Microsoft Entra ID), add the following `gravitee_system_proxy_*` environment variables to the Gateway container:
+
+```
+gravitee_system_proxy_enabled=true
+gravitee_system_proxy_type=HTTP
+gravitee_system_proxy_host=<proxy-host>
+gravitee_system_proxy_port=<proxy-port>
+gravitee_system_proxy_https_host=<proxy-host>
+gravitee_system_proxy_https_port=<proxy-port>
+```
+
+For the full configuration reference including proxy authentication, see [System Proxy for Backend APIs](../../proxy-configuration/system-proxy-for-backend-apis.md). For an overview of all proxy methods, see [Proxy Configuration](../../proxy-configuration/).
 
 ### Next steps
 

--- a/docs/apim/4.11/hybrid-installation-and-configuration-guides/next-gen-cloud/kubernetes/README.md
+++ b/docs/apim/4.11/hybrid-installation-and-configuration-guides/next-gen-cloud/kubernetes/README.md
@@ -17,7 +17,26 @@ metaLinks:
 
 ## Proxy configuration
 
-To route Gateway traffic through a corporate proxy (for example, for backend API calls or JWKS retrieval from external identity providers), see [Proxy Configuration](../../proxy-configuration/).
+To route Gateway traffic through a corporate proxy (for example, for backend API calls or JWKS retrieval from external identity providers like Microsoft Entra ID), add the following `gravitee_system_proxy_*` environment variables to the Gateway section of your `values.yaml`:
+
+```yaml
+gateway:
+  env:
+    - name: gravitee_system_proxy_enabled
+      value: "true"
+    - name: gravitee_system_proxy_type
+      value: "HTTP"
+    - name: gravitee_system_proxy_host
+      value: "<proxy-host>"
+    - name: gravitee_system_proxy_port
+      value: "<proxy-port>"
+    - name: gravitee_system_proxy_https_host
+      value: "<proxy-host>"
+    - name: gravitee_system_proxy_https_port
+      value: "<proxy-port>"
+```
+
+For the full configuration reference including proxy authentication and `gravitee.yml` equivalents, see [Configure Helm values](../../proxy-configuration/system-proxy-for-backend-apis.md#configure-helm-values). For an overview of all proxy methods, see [Proxy Configuration](../../proxy-configuration/).
 
 ## Overview
 

--- a/docs/apim/4.11/hybrid-installation-and-configuration-guides/next-gen-cloud/kubernetes/aws-eks.md
+++ b/docs/apim/4.11/hybrid-installation-and-configuration-guides/next-gen-cloud/kubernetes/aws-eks.md
@@ -887,7 +887,26 @@ You can now create and deploy APIs to your hybrid Gateway.
 
 ## Proxy configuration
 
-To route Gateway traffic through a corporate proxy (for example, for backend API calls or JWKS retrieval from external identity providers like Microsoft Entra ID), configure the system proxy using `gravitee_system_proxy_*` environment variables in the Gateway section of your `values.yaml`. For detailed instructions, see [Proxy Configuration](../../proxy-configuration/).
+To route Gateway traffic through a corporate proxy (for example, for backend API calls or JWKS retrieval from external identity providers like Microsoft Entra ID), add the following `gravitee_system_proxy_*` environment variables to the Gateway section of your `values.yaml`:
+
+```yaml
+gateway:
+  env:
+    - name: gravitee_system_proxy_enabled
+      value: "true"
+    - name: gravitee_system_proxy_type
+      value: "HTTP"
+    - name: gravitee_system_proxy_host
+      value: "<proxy-host>"
+    - name: gravitee_system_proxy_port
+      value: "<proxy-port>"
+    - name: gravitee_system_proxy_https_host
+      value: "<proxy-host>"
+    - name: gravitee_system_proxy_https_port
+      value: "<proxy-port>"
+```
+
+For the full configuration reference including proxy authentication and `gravitee.yml` equivalents, see [Configure Helm values](../../proxy-configuration/system-proxy-for-backend-apis.md#configure-helm-values). For an overview of all proxy methods, see [Proxy Configuration](../../proxy-configuration/).
 
 ### Next steps
 

--- a/docs/apim/4.11/hybrid-installation-and-configuration-guides/next-gen-cloud/kubernetes/azure-aks.md
+++ b/docs/apim/4.11/hybrid-installation-and-configuration-guides/next-gen-cloud/kubernetes/azure-aks.md
@@ -554,7 +554,26 @@ You can now create and deploy APIs to your hybrid Gateway.
 
 ## Proxy configuration
 
-To route Gateway traffic through a corporate proxy (for example, for backend API calls or JWKS retrieval from external identity providers like Microsoft Entra ID), configure the system proxy using `gravitee_system_proxy_*` environment variables in the Gateway section of your `values.yaml`. For detailed instructions, see [Proxy Configuration](../../proxy-configuration/).
+To route Gateway traffic through a corporate proxy (for example, for backend API calls or JWKS retrieval from external identity providers like Microsoft Entra ID), add the following `gravitee_system_proxy_*` environment variables to the Gateway section of your `values.yaml`:
+
+```yaml
+gateway:
+  env:
+    - name: gravitee_system_proxy_enabled
+      value: "true"
+    - name: gravitee_system_proxy_type
+      value: "HTTP"
+    - name: gravitee_system_proxy_host
+      value: "<proxy-host>"
+    - name: gravitee_system_proxy_port
+      value: "<proxy-port>"
+    - name: gravitee_system_proxy_https_host
+      value: "<proxy-host>"
+    - name: gravitee_system_proxy_https_port
+      value: "<proxy-port>"
+```
+
+For the full configuration reference including proxy authentication and `gravitee.yml` equivalents, see [Configure Helm values](../../proxy-configuration/system-proxy-for-backend-apis.md#configure-helm-values). For an overview of all proxy methods, see [Proxy Configuration](../../proxy-configuration/).
 
 ## Next steps
 

--- a/docs/apim/4.11/hybrid-installation-and-configuration-guides/next-gen-cloud/kubernetes/gcp-gke.md
+++ b/docs/apim/4.11/hybrid-installation-and-configuration-guides/next-gen-cloud/kubernetes/gcp-gke.md
@@ -546,7 +546,26 @@ You can now create and deploy APIs to your hybrid Gateway.
 
 ## Proxy configuration
 
-To route Gateway traffic through a corporate proxy (for example, for backend API calls or JWKS retrieval from external identity providers like Microsoft Entra ID), configure the system proxy using `gravitee_system_proxy_*` environment variables in the Gateway section of your `values.yaml`. For detailed instructions, see [Proxy Configuration](../../proxy-configuration/).
+To route Gateway traffic through a corporate proxy (for example, for backend API calls or JWKS retrieval from external identity providers like Microsoft Entra ID), add the following `gravitee_system_proxy_*` environment variables to the Gateway section of your `values.yaml`:
+
+```yaml
+gateway:
+  env:
+    - name: gravitee_system_proxy_enabled
+      value: "true"
+    - name: gravitee_system_proxy_type
+      value: "HTTP"
+    - name: gravitee_system_proxy_host
+      value: "<proxy-host>"
+    - name: gravitee_system_proxy_port
+      value: "<proxy-port>"
+    - name: gravitee_system_proxy_https_host
+      value: "<proxy-host>"
+    - name: gravitee_system_proxy_https_port
+      value: "<proxy-port>"
+```
+
+For the full configuration reference including proxy authentication and `gravitee.yml` equivalents, see [Configure Helm values](../../proxy-configuration/system-proxy-for-backend-apis.md#configure-helm-values). For an overview of all proxy methods, see [Proxy Configuration](../../proxy-configuration/).
 
 ## Next steps
 

--- a/docs/apim/4.11/hybrid-installation-and-configuration-guides/next-gen-cloud/kubernetes/openshift.md
+++ b/docs/apim/4.11/hybrid-installation-and-configuration-guides/next-gen-cloud/kubernetes/openshift.md
@@ -141,4 +141,23 @@ You can now create and deploy APIs to your hybrid Gateway.
 
 ## Proxy configuration
 
-To route Gateway traffic through a corporate proxy (for example, for backend API calls or JWKS retrieval from external identity providers like Microsoft Entra ID), configure the system proxy using `gravitee_system_proxy_*` environment variables in the Gateway section of your `values.yaml`. For detailed instructions, see [Proxy Configuration](../../proxy-configuration/).
+To route Gateway traffic through a corporate proxy (for example, for backend API calls or JWKS retrieval from external identity providers like Microsoft Entra ID), add the following `gravitee_system_proxy_*` environment variables to the Gateway section of your `values.yaml`:
+
+```yaml
+gateway:
+  env:
+    - name: gravitee_system_proxy_enabled
+      value: "true"
+    - name: gravitee_system_proxy_type
+      value: "HTTP"
+    - name: gravitee_system_proxy_host
+      value: "<proxy-host>"
+    - name: gravitee_system_proxy_port
+      value: "<proxy-port>"
+    - name: gravitee_system_proxy_https_host
+      value: "<proxy-host>"
+    - name: gravitee_system_proxy_https_port
+      value: "<proxy-port>"
+```
+
+For the full configuration reference including proxy authentication and `gravitee.yml` equivalents, see [Configure Helm values](../../proxy-configuration/system-proxy-for-backend-apis.md#configure-helm-values). For an overview of all proxy methods, see [Proxy Configuration](../../proxy-configuration/).

--- a/docs/apim/4.11/hybrid-installation-and-configuration-guides/next-gen-cloud/kubernetes/vanilla-kubernetes/README.md
+++ b/docs/apim/4.11/hybrid-installation-and-configuration-guides/next-gen-cloud/kubernetes/vanilla-kubernetes/README.md
@@ -501,7 +501,26 @@ You can now create and deploy APIs to your Hybrid Gateway.
 
 ## Proxy configuration
 
-To route Gateway traffic through a corporate proxy (for example, for backend API calls or JWKS retrieval from external identity providers like Microsoft Entra ID), configure the system proxy using `gravitee_system_proxy_*` environment variables in the Gateway section of your `values.yaml`. For detailed instructions, see [Proxy Configuration](../../../proxy-configuration/).
+To route Gateway traffic through a corporate proxy (for example, for backend API calls or JWKS retrieval from external identity providers like Microsoft Entra ID), add the following `gravitee_system_proxy_*` environment variables to the Gateway section of your `values.yaml`:
+
+```yaml
+gateway:
+  env:
+    - name: gravitee_system_proxy_enabled
+      value: "true"
+    - name: gravitee_system_proxy_type
+      value: "HTTP"
+    - name: gravitee_system_proxy_host
+      value: "<proxy-host>"
+    - name: gravitee_system_proxy_port
+      value: "<proxy-port>"
+    - name: gravitee_system_proxy_https_host
+      value: "<proxy-host>"
+    - name: gravitee_system_proxy_https_port
+      value: "<proxy-port>"
+```
+
+For the full configuration reference including proxy authentication and `gravitee.yml` equivalents, see [Configure Helm values](../../../proxy-configuration/system-proxy-for-backend-apis.md#configure-helm-values). For an overview of all proxy methods, see [Proxy Configuration](../../../proxy-configuration/).
 
 ## Next steps
 

--- a/docs/apim/4.11/self-hosted-installation-guides/docker/docker-cli.md
+++ b/docs/apim/4.11/self-hosted-installation-guides/docker/docker-cli.md
@@ -366,4 +366,15 @@ If APIM is running with high availability, you need to set up cluster mode. To s
 
 ## Proxy configuration
 
-To route Gateway traffic through a corporate proxy (for example, for backend API calls or JWKS retrieval from external identity providers like Microsoft Entra ID), configure the system proxy using `gravitee_system_proxy_*` environment variables on the Gateway container. For detailed instructions, see [Proxy Configuration](../proxy-configuration/).
+To route Gateway traffic through a corporate proxy (for example, for backend API calls or JWKS retrieval from external identity providers like Microsoft Entra ID), add the following `gravitee_system_proxy_*` environment variables to the Gateway container:
+
+```
+gravitee_system_proxy_enabled=true
+gravitee_system_proxy_type=HTTP
+gravitee_system_proxy_host=<proxy-host>
+gravitee_system_proxy_port=<proxy-port>
+gravitee_system_proxy_https_host=<proxy-host>
+gravitee_system_proxy_https_port=<proxy-port>
+```
+
+For the full configuration reference including proxy authentication, see [System Proxy for Backend APIs](../proxy-configuration/system-proxy-for-backend-apis.md). For an overview of all proxy methods, see [Proxy Configuration](../proxy-configuration/).

--- a/docs/apim/4.11/self-hosted-installation-guides/docker/docker-compose.md
+++ b/docs/apim/4.11/self-hosted-installation-guides/docker/docker-compose.md
@@ -631,4 +631,15 @@ If APIM is running with high availability, you need to set up cluster mode. To s
 
 ## Proxy configuration
 
-To route Gateway traffic through a corporate proxy (for example, for backend API calls or JWKS retrieval from external identity providers like Microsoft Entra ID), configure the system proxy using `gravitee_system_proxy_*` environment variables on the Gateway container. For detailed instructions, see [Proxy Configuration](../proxy-configuration/).
+To route Gateway traffic through a corporate proxy (for example, for backend API calls or JWKS retrieval from external identity providers like Microsoft Entra ID), add the following `gravitee_system_proxy_*` environment variables to the Gateway container:
+
+```
+gravitee_system_proxy_enabled=true
+gravitee_system_proxy_type=HTTP
+gravitee_system_proxy_host=<proxy-host>
+gravitee_system_proxy_port=<proxy-port>
+gravitee_system_proxy_https_host=<proxy-host>
+gravitee_system_proxy_https_port=<proxy-port>
+```
+
+For the full configuration reference including proxy authentication, see [System Proxy for Backend APIs](../proxy-configuration/system-proxy-for-backend-apis.md). For an overview of all proxy methods, see [Proxy Configuration](../proxy-configuration/).

--- a/docs/apim/4.11/self-hosted-installation-guides/kubernetes/README.md
+++ b/docs/apim/4.11/self-hosted-installation-guides/kubernetes/README.md
@@ -17,4 +17,23 @@ metaLinks:
 
 ## Proxy configuration
 
-To route Gateway traffic through a corporate proxy (for example, for backend API calls or JWKS retrieval from external identity providers), see [Proxy Configuration](../proxy-configuration/).
+To route Gateway traffic through a corporate proxy (for example, for backend API calls or JWKS retrieval from external identity providers like Microsoft Entra ID), add the following `gravitee_system_proxy_*` environment variables to the Gateway section of your `values.yaml`:
+
+```yaml
+gateway:
+  env:
+    - name: gravitee_system_proxy_enabled
+      value: "true"
+    - name: gravitee_system_proxy_type
+      value: "HTTP"
+    - name: gravitee_system_proxy_host
+      value: "<proxy-host>"
+    - name: gravitee_system_proxy_port
+      value: "<proxy-port>"
+    - name: gravitee_system_proxy_https_host
+      value: "<proxy-host>"
+    - name: gravitee_system_proxy_https_port
+      value: "<proxy-port>"
+```
+
+For the full configuration reference including proxy authentication and `gravitee.yml` equivalents, see [Configure Helm values](../proxy-configuration/system-proxy-for-backend-apis.md#configure-helm-values). For an overview of all proxy methods, see [Proxy Configuration](../proxy-configuration/).

--- a/docs/apim/4.11/self-hosted-installation-guides/kubernetes/aws-eks.md
+++ b/docs/apim/4.11/self-hosted-installation-guides/kubernetes/aws-eks.md
@@ -1175,7 +1175,26 @@ To validate the Gateway URL, complete the following steps:
 
 ## Proxy configuration
 
-To route Gateway traffic through a corporate proxy (for example, for backend API calls or JWKS retrieval from external identity providers like Microsoft Entra ID), configure the system proxy using `gravitee_system_proxy_*` environment variables in the Gateway section of your `values.yaml`. For detailed instructions, see [Proxy Configuration](../proxy-configuration/).
+To route Gateway traffic through a corporate proxy (for example, for backend API calls or JWKS retrieval from external identity providers like Microsoft Entra ID), add the following `gravitee_system_proxy_*` environment variables to the Gateway section of your `values.yaml`:
+
+```yaml
+gateway:
+  env:
+    - name: gravitee_system_proxy_enabled
+      value: "true"
+    - name: gravitee_system_proxy_type
+      value: "HTTP"
+    - name: gravitee_system_proxy_host
+      value: "<proxy-host>"
+    - name: gravitee_system_proxy_port
+      value: "<proxy-port>"
+    - name: gravitee_system_proxy_https_host
+      value: "<proxy-host>"
+    - name: gravitee_system_proxy_https_port
+      value: "<proxy-port>"
+```
+
+For the full configuration reference including proxy authentication and `gravitee.yml` equivalents, see [Configure Helm values](../proxy-configuration/system-proxy-for-backend-apis.md#configure-helm-values). For an overview of all proxy methods, see [Proxy Configuration](../proxy-configuration/).
 
 ## Next steps <a href="#next-steps" id="next-steps"></a>
 

--- a/docs/apim/4.11/self-hosted-installation-guides/kubernetes/azure-aks.md
+++ b/docs/apim/4.11/self-hosted-installation-guides/kubernetes/azure-aks.md
@@ -896,7 +896,26 @@ To validate the Gateway URL, complete the following steps:
 
 ## Proxy configuration
 
-To route Gateway traffic through a corporate proxy (for example, for backend API calls or JWKS retrieval from external identity providers like Microsoft Entra ID), configure the system proxy using `gravitee_system_proxy_*` environment variables in the Gateway section of your `values.yaml`. For detailed instructions, see [Proxy Configuration](../proxy-configuration/).
+To route Gateway traffic through a corporate proxy (for example, for backend API calls or JWKS retrieval from external identity providers like Microsoft Entra ID), add the following `gravitee_system_proxy_*` environment variables to the Gateway section of your `values.yaml`:
+
+```yaml
+gateway:
+  env:
+    - name: gravitee_system_proxy_enabled
+      value: "true"
+    - name: gravitee_system_proxy_type
+      value: "HTTP"
+    - name: gravitee_system_proxy_host
+      value: "<proxy-host>"
+    - name: gravitee_system_proxy_port
+      value: "<proxy-port>"
+    - name: gravitee_system_proxy_https_host
+      value: "<proxy-host>"
+    - name: gravitee_system_proxy_https_port
+      value: "<proxy-port>"
+```
+
+For the full configuration reference including proxy authentication and `gravitee.yml` equivalents, see [Configure Helm values](../proxy-configuration/system-proxy-for-backend-apis.md#configure-helm-values). For an overview of all proxy methods, see [Proxy Configuration](../proxy-configuration/).
 
 ## Next steps <a href="#next-steps" id="next-steps"></a>
 

--- a/docs/apim/4.11/self-hosted-installation-guides/kubernetes/openshift.md
+++ b/docs/apim/4.11/self-hosted-installation-guides/kubernetes/openshift.md
@@ -532,4 +532,23 @@ To install the Gravitee Helm Chart, complete the following steps:
 
 ## Proxy configuration
 
-To route Gateway traffic through a corporate proxy (for example, for backend API calls or JWKS retrieval from external identity providers like Microsoft Entra ID), configure the system proxy using `gravitee_system_proxy_*` environment variables in the Gateway section of your `values.yaml`. For detailed instructions, see [Proxy Configuration](../proxy-configuration/).
+To route Gateway traffic through a corporate proxy (for example, for backend API calls or JWKS retrieval from external identity providers like Microsoft Entra ID), add the following `gravitee_system_proxy_*` environment variables to the Gateway section of your `values.yaml`:
+
+```yaml
+gateway:
+  env:
+    - name: gravitee_system_proxy_enabled
+      value: "true"
+    - name: gravitee_system_proxy_type
+      value: "HTTP"
+    - name: gravitee_system_proxy_host
+      value: "<proxy-host>"
+    - name: gravitee_system_proxy_port
+      value: "<proxy-port>"
+    - name: gravitee_system_proxy_https_host
+      value: "<proxy-host>"
+    - name: gravitee_system_proxy_https_port
+      value: "<proxy-port>"
+```
+
+For the full configuration reference including proxy authentication and `gravitee.yml` equivalents, see [Configure Helm values](../proxy-configuration/system-proxy-for-backend-apis.md#configure-helm-values). For an overview of all proxy methods, see [Proxy Configuration](../proxy-configuration/).

--- a/docs/apim/4.11/self-hosted-installation-guides/kubernetes/vanilla-kubernetes/README.md
+++ b/docs/apim/4.11/self-hosted-installation-guides/kubernetes/vanilla-kubernetes/README.md
@@ -876,7 +876,26 @@ To validate the Gateway URL, complete the following steps:
 
 ## Proxy configuration
 
-To route Gateway traffic through a corporate proxy (for example, for backend API calls or JWKS retrieval from external identity providers like Microsoft Entra ID), configure the system proxy using `gravitee_system_proxy_*` environment variables in the Gateway section of your `values.yaml`. For detailed instructions, see [Proxy Configuration](../../proxy-configuration/).
+To route Gateway traffic through a corporate proxy (for example, for backend API calls or JWKS retrieval from external identity providers like Microsoft Entra ID), add the following `gravitee_system_proxy_*` environment variables to the Gateway section of your `values.yaml`:
+
+```yaml
+gateway:
+  env:
+    - name: gravitee_system_proxy_enabled
+      value: "true"
+    - name: gravitee_system_proxy_type
+      value: "HTTP"
+    - name: gravitee_system_proxy_host
+      value: "<proxy-host>"
+    - name: gravitee_system_proxy_port
+      value: "<proxy-port>"
+    - name: gravitee_system_proxy_https_host
+      value: "<proxy-host>"
+    - name: gravitee_system_proxy_https_port
+      value: "<proxy-port>"
+```
+
+For the full configuration reference including proxy authentication and `gravitee.yml` equivalents, see [Configure Helm values](../../proxy-configuration/system-proxy-for-backend-apis.md#configure-helm-values). For an overview of all proxy methods, see [Proxy Configuration](../../proxy-configuration/).
 
 ## Next steps
 


### PR DESCRIPTION
Add the actual gravitee_system_proxy_* env var configuration directly in every installation guide's Proxy configuration section, with links to both Configure Helm values and Proxy Configuration overview.