### PR TITLE
[sync] gko: 4.10 → 4.11

### DIFF
--- a/docs/gko/4.11/getting-started/installation/README.md
+++ b/docs/gko/4.11/getting-started/installation/README.md
@@ -1,7 +1,6 @@
 # Installation
 
-This section covers the available methods for installing GKO:
+Helm is the preferred method for installing GKO. This section contains the following guides to help you get GKO up and running with Helm:
 
-* [Install from OperatorHub](install-from-operatorhub.md)
 * [Install with Helm](install-with-helm.md)
 * [Cluster vs namespaced install](cluster-vs-namespaced-install.md)

--- a/docs/gko/4.11/gko-4.10.md
+++ b/docs/gko/4.11/gko-4.10.md
@@ -1,0 +1,29 @@
+# GKO 4.10
+
+## Highlights
+
+This release brings bug fixes and new features focused on HTTP Client configuration, and **official Gateway API v1.3 partial conformance** recognition.
+
+## New Features
+
+**GKO HTTP Client configuration enhancements**
+
+* Management APIs connection through proxy.
+* Support for custom CA certificates outside of `/etc/ssl/certs`.
+* Connection timeout
+
+Refer to the Helm Chart section to know how to configure proxy URL & auth, timeouts and CAs. All of the above were back-ported to 4.8.x and 4.9.x versions of GKO.
+
+**Windowed Count Sample Strategy**
+
+This release adds support for the Windowed Count sampling strategy for message APIs.
+
+## Gateway API Conformance
+
+We're excited to announce that **Gravitee Kubernetes Operator 4.10 is now officially recognized** as a **Partially Conformant** implementation of the Kubernetes Gateway API specification version 1.3! The Gravitee Kubernetes Operator is now officially listed on the [Gateway API implementations page](https://gateway-api.sigs.k8s.io/implementations/#gravitee-kubernetes-operator), joining a select group of gateway providers recognized by the Kubernetes community.
+
+This milestone, first achieved in version 4.8.5, recognizes our commitment to providing a standards-compliant API gateway solution for Kubernetes environments.
+
+### What This Means for You
+
+**Gravitee Kubernetes Operator 4.10** delivers partial conformance for Gateway and HTTPRoute resources, enabling you to leverage the Gateway API standard for managing your API infrastructure. While the current implementation focuses on core Gateway and HTTPRoute functionality with Kubernetes Core v1 services, we're working on expanding support for additional matching rules across routes and alternative service types in upcoming releases.

--- a/docs/gko/4.11/guides/publish-apis-to-the-portal.md
+++ b/docs/gko/4.11/guides/publish-apis-to-the-portal.md
@@ -82,15 +82,15 @@ spec:
         type: "KEY_LESS"
 ```
 
-* **DEPRECATED**: The API is no longer visible to consumers. New plans can't be created on it. Existing subscriptions and Gateway traffic aren't affected.
+* **DEPRECATED**: The API is no longer visible to consumers. New plans can't be created on it. Existing subscriptions and Gateway traffic aren't affected. This is a terminal state.
 * **ARCHIVED**: The API is fully retired. It can't be started or stopped through the Management API. This is a terminal state.
 
-{% hint style="info" %}
-The operator supports transitioning from DEPRECATED to ARCHIVED. To archive a deprecated API, update the `lifecycleState` field to `ARCHIVED`. The Console and Management API don't allow this transition directly.
+{% hint style="warning" %}
+Both DEPRECATED and ARCHIVED are terminal states. Once applied, the lifecycle state can't be changed. Plan the retirement workflow carefully before applying these states.
 {% endhint %}
 
 {% hint style="info" %}
-For the full list of allowed lifecycle state transitions and validation rules, see [API lifecycle states](../../../apim/4.11/create-and-configure-apis/configure-v4-apis/api-lifecycle-states.md) in the APIM documentation.
+For the full list of allowed lifecycle state transitions and validation rules, see [API lifecycle states](../../../apim/4.10/create-and-configure-apis/configure-v4-apis/api-lifecycle-states.md) in the APIM documentation.
 {% endhint %}
 
 ## Setting a category for an API

--- a/docs/gko/4.11/new-release.md
+++ b/docs/gko/4.11/new-release.md
@@ -1,0 +1,1 @@
+placeholder for the 4.10 release

--- a/docs/gko/4.11/releases-and-changelog/changelog/gko-4.10.x.md
+++ b/docs/gko/4.11/releases-and-changelog/changelog/gko-4.10.x.md
@@ -1,0 +1,84 @@
+# GKO 4.10.x
+
+## Gravitee Kubernetes Operator 4.10.8 - March 16, 2026
+    
+<details>
+<summary>Improvements</summary>
+
+  **Others**
+
+  * Add LLM and MCP to v4 API types [#11151](https://github.com/gravitee-io/issues/issues/11151)
+
+</details>
+
+
+## Gravitee Kubernetes Operator 4.10.7 - March 2, 2026
+    
+<details>
+<summary>Bug fixes</summary>
+
+  **GKO**
+
+  * Helm web hook port is not exposed by the service [#11169](https://github.com/gravitee-io/issues/issues/11169)
+
+</details>
+
+## Gravitee Kubernetes Operator 4.10.6 - February 16, 2026
+
+There is nothing new in version 4.10.6.
+
+> This version was generated to keep the kubernetes operator in sync with other gravitee products.
+
+
+
+## Gravitee Kubernetes Operator 4.10.5 - February 16, 2026
+
+<details>
+<summary>Improvements</summary>
+
+  **GKO**
+
+  * Add archived state to v4 API [#11124](https://github.com/gravitee-io/issues/issues/11124)
+  * Allow to configure autoscaling when deploying gateway-api gateways [#11120](https://github.com/gravitee-io/issues/issues/11120)
+
+  **APIM**
+
+  * Add break glass mode for automation APIs [#11099](https://github.com/gravitee-io/issues/issues/11099)
+
+</details>
+
+## Gravitee Kubernetes Operator 4.10.4 - February 10, 2026
+
+<details>
+<summary>Improvements</summary>
+
+  **GKO**
+
+  * Support deprecated state for v4 APIS [#11068](https://github.com/gravitee-io/issues/issues/11068)
+  * Gateway class parameters annotations are not applied to gateway service [#11114](https://github.com/gravitee-io/issues/issues/11114)
+  * CRD export contains null fields and extra properties after GKO deployment [#11031](https://github.com/gravitee-io/issues/issues/11031)
+
+</details>
+
+## Gravitee Kubernetes Operator 4.10.3 - January 30, 2026
+
+<details>
+<summary>Bug fixes</summary>
+
+  **GKO**
+
+  * Importing a v4 can throw a NoSuchElementException when no default role is associated to a scope [#11098](https://github.com/gravitee-io/issues/issues/11098)
+
+</details>
+
+## Gravitee Kubernetes Operator 4.10.2 - January 22, 2026
+
+This version does not introduce any new features or bug fixes.
+
+> This version was generated to keep the Kubernetes Operator in sync with other Gravitee products.
+
+## Gravitee Kubernetes Operator 4.10.1 - January 22, 2026
+
+This version does not introduce any new features or bug fixes.
+
+> This version was generated to keep the Kubernetes Operator in sync with other Gravitee products.


### PR DESCRIPTION
Auto-synced changes from `docs/gko/4.10/` to `docs/gko/4.11/`.

Triggered by push to `main` (7264d204b4abc6c1160ec153d9c05100a23e5b35).