### PR TITLE
[sync] apim: 4.11 → 4.12

### DIFF
--- a/docs/apim/4.12/self-hosted-installation-guides/kubernetes/README.md
+++ b/docs/apim/4.12/self-hosted-installation-guides/kubernetes/README.md
@@ -38,6 +38,55 @@ gateway:
 
 For the full configuration reference including proxy authentication and `gravitee.yml` equivalents, see [Configure Helm values](../proxy-configuration/system-proxy-for-backend-apis.md#configure-helm-values). For an overview of all proxy methods, see [Proxy Configuration](../proxy-configuration/).
 
+## Ingress body size limit
+
+Kubernetes deployments that front APIM components with the NGINX Ingress Controller are subject to a request body size limit enforced by the ingress, not by Gravitee. When a client sends a request larger than this limit, the ingress rejects it with `413 Request Entity Too Large` before the request reaches any Gravitee component.
+
+The APIM Helm chart doesn't set a body size annotation on any ingress by default. If requests to the Gateway, the Management API, or the Portal API exceed the limit configured on your ingress controller, raise the limit by setting the `nginx.ingress.kubernetes.io/proxy-body-size` annotation on the affected ingress.
+
+The APIM Helm chart doesn't set a body size annotation on any ingress by default. If requests to the Gateway, the Management API, or the Portal API exceed the limit configured on your ingress controller, raise the limit by setting the `nginx.ingress.kubernetes.io/proxy-body-size` annotation on the affected ingress.
+
+{% hint style="info" %}
+`nginx.ingress.kubernetes.io/proxy-body-size` is an annotation of the NGINX Ingress Controller. For the annotation's default, accepted value format, and the `0` setting that disables the check entirely, see the [NGINX Ingress Controller annotation reference](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#custom-max-body-size). If your cluster uses a different ingress controller, refer to that controller's documentation for the equivalent setting.
+{% endhint %}
+
+### Apply the annotation to each ingress
+
+Each APIM component exposes its ingress through a separate Helm value path. Set `proxy-body-size` on every ingress whose traffic carries request bodies you need to accept:
+
+| Ingress           | Helm value path                      | Traffic                                                                                                                                                                      |
+| ----------------- | ------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Gateway dataplane | `gateway.ingress.annotations`        | Incoming API calls from consumers to the Gateway. Size this to the largest request body an API on the Gateway accepts.                                                       |
+| Management API    | `api.ingress.management.annotations` | Calls to the Management REST API, including API imports, policy definitions, and configuration uploads. Size this to the largest import or configuration payload you submit. |
+| Portal API        | `api.ingress.portal.annotations`     | Calls to the Portal REST API from the Developer Portal. Size this if consumers submit large payloads through the Portal.                                                     |
+
+The following excerpt shows the annotation applied to the Gateway and Management API ingresses in `values.yaml`:
+
+```yaml
+api:
+  ingress:
+    management:
+      annotations:
+        kubernetes.io/ingress.class: nginx
+        nginx.ingress.kubernetes.io/proxy-body-size: "50m"
+    portal:
+      annotations:
+        kubernetes.io/ingress.class: nginx
+        nginx.ingress.kubernetes.io/proxy-body-size: "50m"
+
+gateway:
+  ingress:
+    annotations:
+      kubernetes.io/ingress.class: nginx
+      nginx.ingress.kubernetes.io/proxy-body-size: "50m"
+```
+
+The `50m` value is an example, not a recommended default. Set each limit based on the largest payload you expect to send through that ingress.
+
+### Hybrid Gateway deployments
+
+In a Hybrid Gateway deployment, only the Gateway ingress runs in your cluster. The Management API and Portal API run in the Gravitee Cloud control plane, so their ingresses aren't part of your Helm values. Apply `proxy-body-size` to `gateway.ingress.annotations` to raise the Gateway dataplane limit for the Hybrid cluster you manage. For the body size limits enforced by Gravitee Cloud on the control-plane side, contact Gravitee support.
+
 ## Harden the security context
 
 All APIM container images run as non-root users by default. The Helm chart configures a `securityContext` on each component's deployment that enforces non-root execution.

--- a/docs/apim/4.12/self-hosted-installation-guides/kubernetes/azure-aks.md
+++ b/docs/apim/4.12/self-hosted-installation-guides/kubernetes/azure-aks.md
@@ -927,6 +927,12 @@ gateway:
 
 For the full configuration reference including proxy authentication and `gravitee.yml` equivalents, see [Configure Helm values](../proxy-configuration/system-proxy-for-backend-apis.md#configure-helm-values). For an overview of all proxy methods, see [Proxy Configuration](../proxy-configuration/).
 
+## Ingress body size limit
+
+The reference `values.yaml` in this guide sets `nginx.ingress.kubernetes.io/proxy-body-size: "50m"` as a starting point on the NGINX ingresses that accept request bodies: Management API (`api.ingress.management.annotations`), Portal API (`api.ingress.portal.annotations`), Gateway (`gateway.ingress.annotations`), and Developer Portal (`portal.ingress.annotations`). This annotation raises the NGINX Ingress Controller's body size limit for each affected ingress so clients aren't rejected with `413 Request Entity Too Large` for payloads up to 50 MB.
+
+Adjust the `50m` value on each ingress to match the largest payload you expect to send through it. For the role each ingress plays and guidance for Hybrid Gateway deployments, see [Ingress body size limit](./#ingress-body-size-limit) in the Kubernetes overview.
+
 ## Next steps <a href="#next-steps" id="next-steps"></a>
 
 * Create your first API. For more information about creating your first API, see [Create & Publish Your First API](../../getting-started/create-and-publish-your-first-api/).

--- a/docs/apim/4.12/self-hosted-installation-guides/kubernetes/vanilla-kubernetes/README.md
+++ b/docs/apim/4.12/self-hosted-installation-guides/kubernetes/vanilla-kubernetes/README.md
@@ -903,6 +903,12 @@ gateway:
 
 For the full configuration reference including proxy authentication and `gravitee.yml` equivalents, see [Configure Helm values](../../proxy-configuration/system-proxy-for-backend-apis.md#configure-helm-values). For an overview of all proxy methods, see [Proxy Configuration](../../proxy-configuration/).
 
+## Ingress body size limit
+
+This guide installs the NGINX Ingress Controller to route external traffic into APIM. NGINX enforces a request body size limit on every ingress it fronts, and the APIM Helm chart doesn't set this limit by default. Requests to the Gateway, the Management API, or the Portal API that exceed the limit are rejected with `413 Request Entity Too Large` before they reach any Gravitee component.
+
+To raise the limit, set the `nginx.ingress.kubernetes.io/proxy-body-size` annotation on each affected ingress in your `values.yaml`. For the list of ingress Helm paths, example annotation values, and guidance for Hybrid Gateway deployments, see [Ingress body size limit](../#ingress-body-size-limit) in the Kubernetes overview.
+
 ## Next steps
 
 * Create your first API. For more information about creating your first API, see [create-and-publish-your-first-api](../../../getting-started/create-and-publish-your-first-api/ "mention").


### PR DESCRIPTION
Auto-synced changes from `docs/apim/4.11/` to `docs/apim/4.12/`.

Triggered by push to `main` (97fae7446d6c1f4f1a43f335eb9bfce781d92489).