### PR TITLE
[GKO-2830] Inquiry to add unsupported properties in OAS

### DIFF
--- a/docs/apim/4.11/terraform/example-resource-configurations.md
+++ b/docs/apim/4.11/terraform/example-resource-configurations.md
@@ -70,3 +70,23 @@ The following known limitations apply to the 0.5.x version of the Gravitee Terra
   * State stores the dynamic properties service configuration as an encoded JSON string instead of plain JSON.
   * The encrypted properties payload is marked as changed because encrypted values replace unencrypted values.
 * APIKey subscriptions are not supported.
+
+
+### Automation API — Missing Properties (4.11 / Terraform 0.5.x)
+
+| Resource          | Section                   | Missing Property                   | Type                                  | Supported in Automation API                                           |
+|-------------------|---------------------------|------------------------------------|---------------------------------------|-----------------------------------------------------------------------|
+| apim_apiv4        |                           | `allowedInApiProducts`             | boolean                               | No                                                                    |
+| apim_apiv4        |                           | `allowMultiJwtOauth2Subscriptions` | boolean                               | No                                                                    |
+| apim_apiv4        | `plans`                   | `commentMessage`                   | string                                | Never will, Subscriptions are always auto-accepted                    |
+| apim_apiv4        | `plans`                   | `commentRequired`                  | boolean                               | Never will, Subscriptions are always auto-accepted                    |
+| apim_apiv4        | `plans`                   | `order`                            | integer                               | Never will, mapped to the list index, UI feature only                 |
+| apim_apiv4        | `listeners.kafka` (Kafka) | `port`                             | integer                               | No                                                                    |
+| apim_application  |                           | `apiKeyMode`                       | enum (SHARED, EXCLUSIVE, UNSPECIFIED) | Only EXCLUSIVE is supported, hence property is absent                 |
+| apim_application  |                           | `type`                             | string                                | No (simple applications)                                              |
+| apim_subscription | `apim_subscriptionSpec`   | `consumerConfiguration`            | object                                | 4.12                                                                  |
+| apim_subscription | `apim_subscriptionSpec`   | `apiKeyMode`                       | enum (SHARED, EXCLUSIVE, UNSPECIFIED) | Only EXCLUSIVE is supported, hence property is absent                 |
+| apim_subscription | `apim_subscriptionSpec`   | `startingAt`                       | date-time                             | Never, Subscriptions are always auto-accepted hence started immediatly|
+| apim_subscription | `apim_subscriptionSpec`   | `generalConditionsAccepted`        | boolean                               | Never, Subscriptions are always auto-accepted                         |
+| apim_subscription | `apim_subscriptionSpec`   | `generalConditionsContentRevision` | object (PageRevisionId)               | Never, Subscriptions are always auto-accepted                         |
+

--- a/docs/apim/4.11/terraform/example-resource-configurations.md
+++ b/docs/apim/4.11/terraform/example-resource-configurations.md
@@ -72,7 +72,7 @@ The following known limitations apply to the 0.5.x version of the Gravitee Terra
 * APIKey subscriptions are not supported.
 
 
-### Automation API — Missing Properties (4.11 / Terraform 0.5.x)
+### Automation API: missing properties (4.11, Terraform 0.5.x)
 
 | Resource          | Section                   | Missing Property                   | Type                                  | Supported in Automation API                                           |
 |-------------------|---------------------------|------------------------------------|---------------------------------------|-----------------------------------------------------------------------|
@@ -86,7 +86,7 @@ The following known limitations apply to the 0.5.x version of the Gravitee Terra
 | apim_application  |                           | `type`                             | string                                | No (simple applications)                                              |
 | apim_subscription | `apim_subscriptionSpec`   | `consumerConfiguration`            | object                                | 4.12                                                                  |
 | apim_subscription | `apim_subscriptionSpec`   | `apiKeyMode`                       | enum (SHARED, EXCLUSIVE, UNSPECIFIED) | Only EXCLUSIVE is supported, hence property is absent                 |
-| apim_subscription | `apim_subscriptionSpec`   | `startingAt`                       | date-time                             | Never, Subscriptions are always auto-accepted hence started immediatly|
+| apim_subscription | `apim_subscriptionSpec`   | `startingAt`                       | date-time                             | Never, Subscriptions are always auto-accepted hence started immediately|
 | apim_subscription | `apim_subscriptionSpec`   | `generalConditionsAccepted`        | boolean                               | Never, Subscriptions are always auto-accepted                         |
 | apim_subscription | `apim_subscriptionSpec`   | `generalConditionsContentRevision` | object (PageRevisionId)               | Never, Subscriptions are always auto-accepted                         |
 

--- a/vale/styles/config/vocabularies/docs/accept.txt
+++ b/vale/styles/config/vocabularies/docs/accept.txt
@@ -466,6 +466,9 @@ async
 [Aa]ppId
 [Pp]lanId
 [Oo]rgId
+[Bb]oolean
+apim_application
+apim_subscription
 [Cc]orrelationId
 [Nn]odeId
 [Ii]dempotence


### PR DESCRIPTION
As stated in https://gravitee.atlassian.net/browse/GKO-2830
Some fields are not managed in Terraform, and more specifically Automation API.

The PR adds a table to list them out without engagement to support them in the near future.

We need a solid plan to reduce this difference, as in an automated/AI way to be warned that are differences we can't ignore.

Preview: https://github.com/gravitee-io/gravitee-platform-docs/blob/GKO-2830-unsupported-fields-in-terraform/docs/apim/4.11/terraform/example-resource-configurations.md