### PR TITLE
[sync] apim: 4.11 → 4.12

### DIFF
--- a/docs/apim/4.12/analyze-and-monitor-apis/logging/expose-metrics-to-prometheus.md
+++ b/docs/apim/4.12/analyze-and-monitor-apis/logging/expose-metrics-to-prometheus.md
@@ -6,8 +6,10 @@ The following sections detail the configurations necessary to expose metrics to 
 
 ## Enable the metrics service
 
-Prometheus support is activated and exposed using the component’s internal API. The metrics service can be enabled in the `gravitee.yml` configuration file:
+Prometheus support is activated and exposed using the component’s internal API. Use the tab that matches your deployment method.
 
+{% tabs %}
+{% tab title="gravitee.yaml" %}
 {% code title="gravitee.yml" %}
 ```yaml
 services:
@@ -17,6 +19,31 @@ services:
       enabled: true
 ```
 {% endcode %}
+{% endtab %}
+
+{% tab title=".env" %}
+Add the following variables to the `.env` file loaded by your `docker-compose.yml`, or to the `environment:` block of the Gateway service:
+
+```bash
+gravitee_services_metrics_enabled=true
+gravitee_services_metrics_prometheus_enabled=true
+```
+{% endtab %}
+
+{% tab title="Helm values.yaml" %}
+Set the `gateway.services.metrics` block in your `values.yaml` file. The APIM Helm chart renders this block directly into the Gateway `gravitee.yml` at install time:
+
+```yaml
+gateway:
+  services:
+    metrics:
+      enabled: true
+      prometheus:
+        enabled: true
+        concurrencyLimit: 3
+```
+{% endtab %}
+{% endtabs %}
 
 {% hint style="info" %}
 * By default, the internal component API is bound to `localhost` only and must not be invoked outside `localhost`. To widely expose the API, you may need to set the `services.core.http.host` property to the correct network interface.

--- a/docs/apim/4.12/analyze-and-monitor-apis/reporters/README.md
+++ b/docs/apim/4.12/analyze-and-monitor-apis/reporters/README.md
@@ -17,8 +17,10 @@ ElasticSearch is the default reporter for gateway runtime data and is required f
 If you want to monitor the **server** logs from the gateway or the management API, you can use an agent for your observability platform (e.g. the [Datadog agent](https://docs.datadoghq.com/agent/?tab=Linux)) to tail the server logs. If you want to monitor the server metrics from your Gravitee infrastructure (e.g. CPU and memory usage), you can instrument the server directly or use the Prometheus endpoint for the Gravitee component.
 {% endhint %}
 
-You can configure various aspects of reporters, such as reporting monitoring data, request metrics, and health checks. All reporters are enabled by default. To stop a reporter, you need to add the property `enabled: false`:
+You can configure various aspects of reporters, such as reporting monitoring data, request metrics, and health checks. All reporters are enabled by default. To stop a reporter, you need to add the property `enabled: false`. Use the tab that matches your deployment method.
 
+{% tabs %}
+{% tab title="gravitee.yaml" %}
 ```yaml
 reporters:
   elasticsearch:
@@ -32,6 +34,41 @@ reporters:
 #       username:
 #       password:
 ```
+{% endtab %}
+
+{% tab title=".env" %}
+Add the following variables to the `.env` file loaded by your `docker-compose.yml`, or to the `environment:` block of the Gateway service:
+
+```bash
+gravitee_reporters_elasticsearch_endpoints_0=http://localhost:9200
+# gravitee_reporters_elasticsearch_index=gravitee
+# gravitee_reporters_elasticsearch_bulk_actions=500
+# gravitee_reporters_elasticsearch_bulk_flush_interval=1
+# gravitee_reporters_elasticsearch_security_username=
+# gravitee_reporters_elasticsearch_security_password=
+```
+{% endtab %}
+
+{% tab title="Helm values.yaml" %}
+The Elasticsearch reporter is enabled by default in the APIM Helm chart. Connection details come from the shared `es:` block; reporter-specific toggles go under `gateway.reporters.elasticsearch`:
+
+```yaml
+gateway:
+  reporters:
+    elasticsearch:
+      enabled: true
+
+es:
+  endpoints:
+    - http://elasticsearch-master:9200
+  index: gravitee
+  security:
+    enabled: false
+    # username:
+    # password:
+```
+{% endtab %}
+{% endtabs %}
 
 This page documents the available reporters and the metrics and logs captured by each reporter, in a generic format. The configuration for each reporter and the format of the metrics in those reporting systems are covered in their own pages.
 
@@ -64,10 +101,10 @@ Some policies emit custom metrics that appear in the API analytics dashboard. Th
 
 The PII Filtering Policy emits the following custom metrics when PII is detected:
 
-| Metric Name              | Type | Purpose                                                                                      |
-| ------------------------ | ---- | -------------------------------------------------------------------------------------------- |
-| `long_pii_total`         | long | Total count of PII detections across all categories                                          |
-| `long_pii_<category>`    | long | Per-category PII detection count (e.g., `long_pii_person`, `long_pii_email`, `long_pii_location`) |
+| Metric Name           | Type | Purpose                                                                                           |
+| --------------------- | ---- | ------------------------------------------------------------------------------------------------- |
+| `long_pii_total`      | long | Total count of PII detections across all categories                                               |
+| `long_pii_<category>` | long | Per-category PII detection count (e.g., `long_pii_person`, `long_pii_email`, `long_pii_location`) |
 
 These metrics are incremented for each detected PII entity and are visible in the API analytics dashboard alongside standard request metrics.
 

--- a/docs/apim/4.12/analyze-and-monitor-apis/reporters/datadog-reporter.md
+++ b/docs/apim/4.12/analyze-and-monitor-apis/reporters/datadog-reporter.md
@@ -9,7 +9,7 @@ metaLinks:
 
 ## Download and install
 
-To configure the Datadog Reporter, download the reporter plugin [here](https://download.gravitee.io/#graviteeio-ee/apim/plugins/reporters/gravitee-reporter-datadog/). Once you’ve downloaded the .ZIP file, you can add it to the Gateway in the same way as [other plugins](../../plugins/). Typically, you’ll install plugins in the `/plugins` directory of your installation. As with other reporters, the Datadog Reporter plugin only needs to be installed on the Gateway, not the Management API.
+To configure the Datadog Reporter, download the reporter plugin [here](https://download.gravitee.io/#graviteeio-ee/apim/plugins/reporters/gravitee-reporter-datadog/). Once you’ve downloaded the `.ZIP` file, you can add it to the Gateway in the same way as [other plugins](../../plugins/). Typically, you’ll install plugins in the `/plugins` directory of your installation. As with other reporters, the Datadog Reporter plugin only needs to be installed on the Gateway, not the Management API.
 
 {% hint style="info" %}
 If you want to collect system metrics and logs from the Management API service, use the [Datadog Agent](https://docs.datadoghq.com/agent/?tab=Linux) to tail the Management API logs or collect them from stdout.
@@ -26,9 +26,10 @@ gateway:
 
 ## Configuration
 
-To configure the Datadog Reporter on a Gateway, enable the `reporters` section in your Helm `values.yaml` or `gravitee.yml`. This will look something like:
+To configure the Datadog Reporter on a Gateway, enable the `reporters.datadog` block. Use the tab that matches your deployment method.
 
-{% code title="Datadog Reporter configuration" %}
+{% tabs %}
+{% tab title="gravitee.yaml" %}
 ```yaml
 reporters:
   datadog:
@@ -69,7 +70,45 @@ reporters:
     #  exclude: # Can be a wildcard (ie '*') to exclude all fields (supports json path)
     #    - apiResponseTimeMs
 ```
-{% endcode %}
+{% endtab %}
+
+{% tab title=".env" %}
+Add the following variables to the `.env` file loaded by your `docker-compose.yml`, or to the `environment:` block of the Gateway service:
+
+```bash
+gravitee_reporters_datadog_enabled=true
+gravitee_reporters_datadog_site=datadoghq.eu
+gravitee_reporters_datadog_authentication_apiKey=YOUR_API_KEY
+# gravitee_reporters_datadog_authentication_appKey=YOUR_APP_KEY
+# gravitee_reporters_datadog_authentication_token=YOUR_TOKEN
+# gravitee_reporters_datadog_bulk_flush_interval=5
+```
+{% endtab %}
+
+{% tab title="Helm values.yaml" %}
+Set the `gateway.reporters.datadog` block in your `values.yaml` file. The APIM Helm chart renders this block directly into the Gateway `gravitee.yml` at install time:
+
+```yaml
+gateway:
+  reporters:
+    datadog:
+      enabled: true
+      site: "datadoghq.eu"
+      authentication:
+        apiKey: "YOUR_API_KEY"
+        # appKey: "YOUR_APP_KEY"
+        # token: "YOUR_TOKEN"
+      # bulk:
+      #   flush_interval: 5
+      #   log:
+      #     size: 5
+      #   metric:
+      #     size: 20
+      # customTags: >
+      #   gateway: s1.company.com:9092
+```
+{% endtab %}
+{% endtabs %}
 
 Authentication is required for the Gateway to send reporting data to Datadog. Gravitee sends data to Datadog as an [API client](https://docs.datadoghq.com/api/latest/) over HTTP, and so needs to authenticate to Datadog. The basic way to do this is via an [API key](https://docs.datadoghq.com/account_management/api-app-keys/), but you can also configure application keys and client tokens, depending on what your Datadog account requires.
 

--- a/docs/apim/4.12/configure-and-manage-the-platform/manage-organizations-and-environments/applications.md
+++ b/docs/apim/4.12/configure-and-manage-the-platform/manage-organizations-and-environments/applications.md
@@ -32,8 +32,10 @@ The default simple application enables an API consumer to define the `client_id`
 <figure><img src="../../.gitbook/assets/0 app.png" alt=""><figcaption></figcaption></figure>
 
 {% hint style="info" %}
-To expedite API consumption, a default application is automatically created for every new user (not including admins). This can be disabled in the `gravitee.yml` file as shown below:
+To expedite API consumption, a default application is automatically created for every new user (not including admins). To disable this behavior, use the tab that matches your deployment method.
 
+{% tabs %}
+{% tab title="gravitee.yaml" %}
 {% code title="gravitee.yml" overflow="wrap" %}
 ```yaml
 user:
@@ -42,6 +44,27 @@ user:
        defaultApplication: false
 ```
 {% endcode %}
+{% endtab %}
+
+{% tab title=".env" %}
+Add the following variable to the `.env` file loaded by your `docker-compose.yml`, or to the `environment:` block of the Management API service:
+
+```bash
+gravitee_user_login_defaultApplication=false
+```
+{% endtab %}
+
+{% tab title="Helm values.yaml" %}
+Set the `api.user.login.defaultApplication` value in your `values.yaml` file. The APIM Helm chart renders this value into the Management API `gravitee.yml` at install time:
+
+```yaml
+api:
+  user:
+    login:
+      defaultApplication: false
+```
+{% endtab %}
+{% endtabs %}
 {% endhint %}
 
 ## DCR application configuration

--- a/docs/apim/4.12/configure-and-manage-the-platform/manage-organizations-and-environments/authentication/authentication-providers.md
+++ b/docs/apim/4.12/configure-and-manage-the-platform/manage-organizations-and-environments/authentication/authentication-providers.md
@@ -10,9 +10,13 @@ The following sections describe how to configure in-memory users, LDAP authentic
 
 ## In-memory users
 
-This example shows a basic in-memory implementation, providing a simple and convenient way to declare advanced users of APIM, such as administrator users. To do this, you could configure the `gravitee.yaml` file as follows:
+This example shows a basic in-memory implementation, providing a simple and convenient way to declare advanced users of APIM, such as administrator users. Use the tab that matches your deployment method.
 
-<pre class="language-yaml"><code class="lang-yaml"># Authentication and identity sources
+{% tabs %}
+{% tab title="gravitee.yaml" %}
+{% code title="gravitee.yml" %}
+```yaml
+# Authentication and identity sources
 # Users can have following roles (authorities):
 #  USER: Can access portal and be a member of an API
 #  API_PUBLISHER: Can create and manage APIs
@@ -22,14 +26,14 @@ security:
   # When using an authentication providers, use trustAll mode for TLS connections
   # trustAll: false
   providers:  # authentication providers
-    - type: <a data-footnote-ref href="#user-content-fn-1">memory</a>
+    - type: memory
       # allow search results to display the user email. Be careful, It may be contrary to the user privacy.
 #      allow-email-in-search-results: true
       # password encoding/hashing algorithm. One of:
       # - bcrypt : passwords are hashed with bcrypt (supports only $2a$ algorithm)
       # - none : passwords are not hashed/encrypted
       # default value is bcrypt
-      pasasword-encoding-algo: bcrypt
+      password-encoding-algo: bcrypt
       users:
         - user:
           username: user
@@ -66,8 +70,57 @@ security:
           password: $2a$10$2gtKPYRB9zaVaPcn5RBx/.3T.7SeZoDGs9GKqbo9G64fKyXFR1He.
           roles: ORGANIZATION:USER,ENVIRONMENT:USER
           #email:
+```
+{% endcode %}
+{% endtab %}
 
-</code></pre>
+{% tab title=".env" %}
+For Docker Compose, in-memory user lists are most reliably defined in `gravitee.yml` mounted into the Management API container. The provider type and password encoding can be set via environment variables in the `.env` file or the `environment:` block of the Management API service:
+
+```bash
+gravitee_security_providers_0_type=memory
+gravitee_security_providers_0_password-encoding-algo=bcrypt
+gravitee_security_providers_0_allow-email-in-search-results=false
+```
+
+For the user list, mount a `gravitee.yml` file containing the `security.providers[].users` block into `/opt/graviteeio-management-api/config/gravitee.yml`.
+{% endtab %}
+
+{% tab title="Helm values.yaml" %}
+Set the `inMemoryAuth` block, the admin account values, and `extraInMemoryUsers` in your `values.yaml` file. The APIM Helm chart renders these values into a `security.providers[]` entry of type `memory` in the Management API `gravitee.yml` at install time:
+
+```yaml
+inMemoryAuth:
+  enabled: true
+  allowEmailInSearchResults: false
+  passwordEncodingAlgo: bcrypt
+
+# Default admin account (set adminAccountEnable=false to disable)
+adminAccountEnable: true
+adminPasswordBcrypt: $2a$10$Ihk05VSds5rUSgMdsMVi9OKMIx2yUvMz7y9VP3rJmQeizZLrhLMyq
+adminEmail:
+adminFirstName:
+adminLastName:
+
+extraInMemoryUsers: |
+  - user:
+    username: user
+    # Password value: password
+    password: $2a$10$9kjw/SH9gucCId3Lnt6EmuFreUAcXSZgpvAYuW2ISv7hSOhHRH1AO
+    roles: ORGANIZATION:USER, ENVIRONMENT:USER
+  - user:
+    username: api1
+    # Password value: api1
+    password: $2a$10$iXdXO4wAYdhx2LOwijsp7.PsoAZQ05zEdHxbriIYCbtyo.y32LTji
+    roles: ORGANIZATION:USER, ENVIRONMENT:API_PUBLISHER
+  - user:
+    username: application1
+    # Password value: application1
+    password: $2a$10$2gtKPYRB9zaVaPcn5RBx/.3T.7SeZoDGs9GKqbo9G64fKyXFR1He.
+    roles: ORGANIZATION:USER, ENVIRONMENT:USER
+```
+{% endtab %}
+{% endtabs %}
 
 ### Generate a new password
 
@@ -79,9 +132,11 @@ htpasswd -bnBC 10 "" new_password | tr -d ':\n'
 
 ## LDAP authentication
 
-There are many ways to configure users via LDAP. To illustrate the basic concepts, here are two examples using the `gravitee.yaml` file and the [Gravitee Helm chart](https://github.com/gravitee-io/gravitee-api-management/blob/master/helm/values.yaml) `values.yml` file:
+There are many ways to configure users via LDAP. The following example illustrates the basic concepts. Use the tab that matches your deployment method.
 
-{% code title="gravitee.yaml" %}
+{% tabs %}
+{% tab title="gravitee.yaml" %}
+{% code title="gravitee.yml" %}
 ```yaml
 # ===================================================================
 # LDAP SECURITY PROPERTIES
@@ -118,8 +173,25 @@ security:
           filter: "(&(objectClass=myObjectClass)(|(cn=*{0}*)(uid={0})))"
 ```
 {% endcode %}
+{% endtab %}
 
-{% code title="values.yml" %}
+{% tab title=".env" %}
+For Docker Compose, LDAP user and group filters are most reliably defined in `gravitee.yml` mounted into the Management API container. The basic LDAP provider settings can be set via environment variables in the `.env` file or the `environment:` block of the Management API service:
+
+```bash
+gravitee_security_providers_0_type=ldap
+gravitee_security_providers_0_context_username=uid=admin,ou=system
+gravitee_security_providers_0_context_password=secret
+gravitee_security_providers_0_context_url=ldap://localhost:389/dc=gravitee,dc=io
+gravitee_security_providers_0_context_base=c=io,o=gravitee
+```
+
+For the full `authentication`, `lookup`, and `role.mapper` blocks, mount a `gravitee.yml` file containing the `security.providers[]` entry into `/opt/graviteeio-management-api/config/gravitee.yml`.
+{% endtab %}
+
+{% tab title="Helm values.yaml" %}
+Set the `ldap` block in your `values.yaml` file. The APIM Helm chart renders these values into a `security.providers[]` entry of type `ldap` in the Management API `gravitee.yml` at install time:
+
 ```yaml
 ldap:
   enabled: true
@@ -165,18 +237,44 @@ ldap:
       # The filter can be any type of complex LDAP query
       filter: (&(objectClass=person)(|(cn=*{0}*)(sAMAccountName={0})))
 ```
-{% endcode %}
+{% endtab %}
+{% endtabs %}
 
 ## APIM data source authentication
 
 APIM allows users to connect using an APIM data source. This is required if you want to add and register users via self-registration.
 
-To activate this provider, all you need to do is declare it in the `gravitee.yaml` file. All data source information is then retrieved from the Management Repository configuration.
+All data source information is retrieved from the Management Repository configuration. Use the tab that matches your deployment method.
 
+{% tabs %}
+{% tab title="gravitee.yaml" %}
+{% code title="gravitee.yml" %}
 ```yaml
 security:
   providers:
     - type: gravitee
 ```
+{% endcode %}
+{% endtab %}
+
+{% tab title=".env" %}
+Add the following variable to the `.env` file loaded by your `docker-compose.yml`, or to the `environment:` block of the Management API service:
+
+```bash
+gravitee_security_providers_0_type=gravitee
+```
+{% endtab %}
+
+{% tab title="Helm values.yaml" %}
+The APIM data source provider is enabled by default. Confirm or set `graviteeRepoAuth.enabled` in your `values.yaml` file:
+
+```yaml
+graviteeRepoAuth:
+  enabled: true
+```
+
+The chart renders this as a `security.providers[]` entry of type `gravitee` in the Management API `gravitee.yml` at install time.
+{% endtab %}
+{% endtabs %}
 
 [^1]: insert memory here.

--- a/docs/apim/4.12/configure-and-manage-the-platform/manage-organizations-and-environments/authentication/openid-connect.md
+++ b/docs/apim/4.12/configure-and-manage-the-platform/manage-organizations-and-environments/authentication/openid-connect.md
@@ -44,11 +44,11 @@ Ensure all prerequisites are satisfied before attempting to configure your OpenI
 
 ### Configuration
 
-You can set up your OpenID Connect authentication using the `gravitee.yaml` file or the API Management (APIM) Console.
+You can set up your OpenID Connect authentication using the `gravitee.yaml` file, the Helm chart, or the API Management (APIM) Console. Use the tab that matches your deployment method.
 
 {% tabs %}
-{% tab title="gravitee.yaml file" %}
-To configure an OpenID Connect authentication provider using the `gravitee.yaml` configuration file, you'll need to update to the file with your client information. You'll need to enter in this information where we have **(enter in client information)** called out in the code block. Depending on your client, this information will be different. To see a real-life example, check out the [Configure Keycloak authentication](openid-connect.md#example-keycloak-authentication) section below.
+{% tab title="gravitee.yaml" %}
+To configure an OpenID Connect authentication provider using the `gravitee.yaml` configuration file, you'll need to update to the file with your client information. You'll need to enter in this information where we have **(enter in client information)** called out in the code block. Depending on your client, this information will be different. To see a real-life example, check out the Configure Keycloak authentication section below.
 
 {% code overflow="wrap" lineNumbers="true" %}
 ```yaml
@@ -87,6 +87,49 @@ security:
             - (enter in client information) #applied to environment whose id is <ENVIRONMENT_ID>
 ```
 {% endcode %}
+{% endtab %}
+
+{% tab title="Helm values.yaml" %}
+Set the `oidcAuth` block in your `values.yaml` file. The APIM Helm chart renders these values into a single `security.providers[]` entry of type `oidc` in the Management API `gravitee.yml` at install time:
+
+```yaml
+oidcAuth:
+  enabled: true
+  id: (enter in client information; defaults to the type when omitted)
+  clientId: (enter in client information)
+  clientSecret: (enter in client information)
+  tokenIntrospectionEndpoint: (enter in client information)
+  tokenEndpoint: (enter in client information)
+  authorizeEndpoint: (enter in client information)
+  userInfoEndpoint: (enter in client information)
+  userLogoutEndpoint: (enter in client information)
+  color: "(enter in client information)"
+  syncMappings: false
+  scopes:
+    - (enter in client information)
+  userMapping:
+    id: (enter in client information)
+    email: (enter in client information)
+    lastname: (enter in client information)
+    firstname: (enter in client information)
+    picture: (enter in client information)
+  groupMapping:
+    - condition: (enter in client information)
+      groups:
+        - (enter in client information) 1
+        - (enter in client information) 2
+  roleMapping:
+    - condition: (enter in client information)
+      roles:
+        - (enter in client information)
+        - (enter in client information)
+        - (enter in client information)
+        - (enter in client information)
+```
+
+{% hint style="info" %}
+The chart's `oidcAuth` block configures one OpenID Connect provider per chart release.
+{% endhint %}
 {% endtab %}
 
 {% tab title="APIM Console" %}
@@ -261,6 +304,48 @@ security:
             - "ENVIRONMENT:API_CONSUMER"                  #applied to the DEFAULT environment
             - "ENVIRONMENT:DEFAULT:API_CONSUMER"          #applied to the DEFAULT environment
             - "ENVIRONMENT:<ENVIRONMENT_ID>:API_CONSUMER" #applied to environment whose id is <ENVIRONMENT_ID>
+```
+{% endcode %}
+{% endtab %}
+
+{% tab title="Helm values.yaml" %}
+To configure Keycloak as an OpenID Connect authentication provider using the APIM Helm chart, set the `oidcAuth` block in your `values.yaml` file:
+
+{% code overflow="wrap" lineNumbers="true" %}
+```yaml
+oidcAuth:
+  enabled: true
+  id: keycloak # defaults to the type when omitted
+  clientId: gravitee
+  clientSecret: 3aea136c-f056-49a8-80f4-a6ea521b0c94
+  tokenIntrospectionEndpoint: http://localhost:8080/auth/realms/master/protocol/openid-connect/token/introspect
+  tokenEndpoint: http://localhost:8080/auth/realms/master/protocol/openid-connect/token
+  authorizeEndpoint: http://localhost:8080/auth/realms/master/protocol/openid-connect/auth
+  userInfoEndpoint: http://localhost:8080/auth/realms/master/protocol/openid-connect/userinfo
+  userLogoutEndpoint: http://localhost:8080/auth/realms/master/protocol/openid-connect/logout
+  color: "#0076b4"
+  syncMappings: false
+  scopes:
+    - openid
+    - profile
+  userMapping:
+    id: sub
+    email: email
+    lastname: family_name
+    firstname: given_name
+    picture: picture
+  groupMapping:
+    - condition: "{#jsonPath(#profile, '$.identity_provider_id') == 'PARTNERS' && #jsonPath(#profile, '$.job_id') != 'API_MANAGER'}"
+      groups:
+        - Group 1
+        - Group 2
+  roleMapping:
+    - condition: "{#jsonPath(#profile, '$.job_id') != 'API_MANAGER'}"
+      roles:
+        - "ORGANIZATION:USER"
+        - "ENVIRONMENT:API_CONSUMER"
+        - "ENVIRONMENT:DEFAULT:API_CONSUMER"
+        - "ENVIRONMENT:<ENVIRONMENT_ID>:API_CONSUMER"
 ```
 {% endcode %}
 {% endtab %}

--- a/docs/apim/4.12/configure-and-manage-the-platform/manage-organizations-and-environments/cors-configuration.md
+++ b/docs/apim/4.12/configure-and-manage-the-platform/manage-organizations-and-environments/cors-configuration.md
@@ -21,7 +21,7 @@ You can apply CORS at following levels:
 
 When you apply CORS configurations, the API level overrides the Environment level, and the environment level overrides the Organization level.
 
-You can configure CORS at the organization level using `gravitee.yml`, environment variables, or directly in APIM Console. Here are examples that configures CORS in the `gravitee.yml` file and with environment variables:
+You can configure CORS at the organization level using `gravitee.yml`, environment variables, the Helm chart, or directly in the APIM Console. Use the tab that matches your deployment method.
 
 {% tabs %}
 {% tab title="gravitee.yaml" %}
@@ -63,20 +63,46 @@ http:
 {% endcode %}
 {% endtab %}
 
-{% tab title="environment variables" %}
+{% tab title=".env" %}
+Add the following variables to the `.env` file loaded by your `docker-compose.yml`, or to the `environment:` block of the Management API service:
+
+```bash
+gravitee_http_api_management_allow-origin=http://developer.mycompany.com
+gravitee_http_api_management_allow-headers=X-Requested-With
+gravitee_http_api_management_allow-methods='OPTIONS; GET; POST; PUT; DELETE'
+gravitee_http_api_management_exposed-headers=
+gravitee_http_api_management_max-age=864000
+
+gravitee_http_api_portal_allow-origin=http://developer.mycompany.com
+gravitee_http_api_portal_allow-headers=X-Requested-With
+gravitee_http_api_portal_allow-methods='OPTIONS; GET; POST; PUT; DELETE'
+gravitee_http_api_portal_exposed-headers=
+gravitee_http_api_portal_max-age=864000
 ```
-gravitee_http_api_management_allow-origin
-gravitee_http_api_management_allow-headers
-gravitee_http_api_management_allow-methods
-gravitee_http_api_management_exposed-headers
-gravitee_http_api_management_max-age
+{% endtab %}
 
+{% tab title="Helm values.yaml" %}
+The APIM Helm chart doesn't expose dedicated CORS keys for the Management API or Portal API. Inject the equivalent environment variables through the `api.env` array of your `values.yaml` file:
 
-gravitee_http_api_portal_allow-origin
-gravitee_http_api_portal_allow-headers
-gravitee_http_api_portal_allow-methods
-gravitee_http_api_portal_exposed-headers
-gravitee_http_api_portal_max-age
+```yaml
+api:
+  env:
+    - name: gravitee_http_api_management_allow-origin
+      value: http://developer.mycompany.com
+    - name: gravitee_http_api_management_allow-headers
+      value: X-Requested-With
+    - name: gravitee_http_api_management_allow-methods
+      value: 'OPTIONS; GET; POST; PUT; DELETE'
+    - name: gravitee_http_api_management_max-age
+      value: "864000"
+    - name: gravitee_http_api_portal_allow-origin
+      value: http://developer.mycompany.com
+    - name: gravitee_http_api_portal_allow-headers
+      value: X-Requested-With
+    - name: gravitee_http_api_portal_allow-methods
+      value: 'OPTIONS; GET; POST; PUT; DELETE'
+    - name: gravitee_http_api_portal_max-age
+      value: "864000"
 ```
 {% endtab %}
 {% endtabs %}

--- a/docs/apim/4.12/prepare-a-production-environment/repositories/README.md
+++ b/docs/apim/4.12/prepare-a-production-environment/repositories/README.md
@@ -13,8 +13,10 @@ Gravitee uses repositories to store different types of data. They are configured
 
 ## Management Repository
 
-The Management repository is used to store global configurations such as APIs, applications, and API keys. The default configuration uses MongoDB (single server). You can configure the Management repository using the `gravitee.yml` file:
+The Management repository is used to store global configurations such as APIs, applications, and API keys. The default configuration uses MongoDB (single server). Use the tab that matches your deployment method.
 
+{% tabs %}
+{% tab title="gravitee.yaml" %}
 {% code title="gravitee.yml" %}
 ```yaml
 management:
@@ -81,13 +83,63 @@ management:
 #    socketTimeout: 250
 ```
 {% endcode %}
+{% endtab %}
+
+{% tab title=".env" %}
+Add the following variables to the `.env` file loaded by your `docker-compose.yml`, or to the `environment:` block of the Management API and Gateway services:
+
+```bash
+gravitee_management_type=mongodb
+gravitee_management_mongodb_dbname=gravitee
+gravitee_management_mongodb_host=mongodb
+gravitee_management_mongodb_port=27017
+# Single MongoDB using URI:
+# gravitee_management_mongodb_uri=mongodb://username:password@host:27017/gravitee
+```
+{% endtab %}
+
+{% tab title="Helm values.yaml" %}
+Set `management.type` and the shared `mongo:` block in your `values.yaml` file. The APIM Helm chart uses the same `mongo:` block to render the Management repository connection in the Management API and Gateway `gravitee.yml` files at install time:
+
+```yaml
+management:
+  type: mongodb
+
+mongo:
+  dbhost: graviteeio-apim-mongodb-replicaset-headless
+  dbname: gravitee
+  dbport: 27017
+  rsEnabled: true
+  rs: rs0
+  connectTimeoutMS: 30000
+  sslEnabled: false
+  socketKeepAlive: false
+  auth:
+    enabled: false
+    source: admin
+    username:
+    password:
+  # Single MongoDB using URI (overrides dbhost/dbport/dbname):
+  # uri: mongodb://username:password@host:27017/gravitee
+  # Clustered MongoDB:
+  # servers: |
+  #   - host: mongo1
+  #     port: 27017
+  #   - host: mongo2
+  #     port: 27017
+```
+{% endtab %}
+{% endtabs %}
 
 ## Analytics Repository
 
-The Analytics repository stores all reporting, metrics, API logs, and health-checks for all APIM Gateway instances. The default configuration uses [Elasticsearch](https://www.elastic.co/products/elasticsearch).
+The Analytics repository stores all reporting, metrics, API logs, and health-checks for all APIM Gateway instances. The default configuration uses [Elasticsearch](https://www.elastic.co/products/elasticsearch). Use the tab that matches your deployment method.
 
+{% tabs %}
+{% tab title="gravitee.yaml" %}
 {% code title="gravitee.yml" %}
 ```yaml
+analytics:
   type: elasticsearch
   elasticsearch:
     endpoints:
@@ -98,10 +150,46 @@ The Analytics repository stores all reporting, metrics, API logs, and health-che
 #       password:
 ```
 {% endcode %}
+{% endtab %}
+
+{% tab title=".env" %}
+Add the following variables to the `.env` file loaded by your `docker-compose.yml`, or to the `environment:` block of the Management API and Gateway services:
+
+```bash
+gravitee_analytics_type=elasticsearch
+gravitee_analytics_elasticsearch_endpoints_0=http://localhost:9200
+# gravitee_analytics_elasticsearch_index=gravitee
+# gravitee_analytics_elasticsearch_security_username=
+# gravitee_analytics_elasticsearch_security_password=
+```
+{% endtab %}
+
+{% tab title="Helm values.yaml" %}
+Set the `es:` block in your `values.yaml` file. The APIM Helm chart renders these values into the `analytics.elasticsearch` section of the Management API and Gateway `gravitee.yml` files at install time:
+
+```yaml
+es:
+  enabled: true
+  endpoints:
+    - http://elasticsearch-master:9200
+  index: gravitee
+  security:
+    enabled: false
+    # username:
+    # password:
+  ssl:
+    enabled: false
+    # keystore:
+    #   type: jks
+    #   path:
+    #   password:
+```
+{% endtab %}
+{% endtabs %}
 
 ## Rate Limit Repository
 
-When defining the Rate Limiting policy, the Gravitee APIM Gateway needs to store data to share with other APIM Gateway instances.
+When defining the rate-limiting policy, the Gravitee APIM Gateway needs to store data to share with other APIM Gateway instances.
 
 For Management repositories, you can define a custom prefix for the Rate Limit table or collection name.
 

--- a/docs/apim/4.12/prepare-a-production-environment/repositories/jdbc.md
+++ b/docs/apim/4.12/prepare-a-production-environment/repositories/jdbc.md
@@ -14,11 +14,11 @@ Gravitee APIM can use a variety of JDBC repositories for its Configuration Datab
 From Gravitee APIM v4.11, the default images now include the following JDBC drivers:
 
 * PostgreSQL JDBC Driver (42.7.7+)
-* MariaDB Connector/J (3.5.6+), and&#x20;
+* MariaDB Connector/J (3.5.6+), and
 * Microsoft JDBC Driver for SQL Server (12.10.2.jre11+)
 
 {% hint style="warning" %}
-Due to licensing restrictions, MySQL drivers are intentionally not bundled in the default images.  You must follow these [steps](jdbc.md#install-the-mysql-jdbc-driver) to manually include the relevant MySQL Connector/J driver.
+Due to licensing restrictions, MySQL drivers are intentionally not bundled in the default images. You must follow these [steps](jdbc.md#install-the-mysql-jdbc-driver) to manually include the relevant MySQL Connector/J driver.
 {% endhint %}
 
 ## Supported Databases
@@ -35,7 +35,7 @@ This section only applies if you want to use MySQL as the Configuration Database
 
 Because licensing restrictions prevent the inclusion of the MySQL JDBC driver in the default Gravitee images, you must manually include the driver.
 
-If you are configuring Gravitee with the Helm chart and using the MySQL JDBC, please refer to these [steps](jdbc.md#mysql-configuration-with-gravitee-helm-chart).  Otherwise, repeat these steps for each component (APIM Gateway and APIM Management API) where the MySQL database is used:
+If you are configuring Gravitee with the Helm chart and using the MySQL JDBC, please refer to these [steps](jdbc.md#mysql-configuration-with-gravitee-helm-chart). Otherwise, repeat these steps for each component (APIM Gateway and APIM Management API) where the MySQL database is used:
 
 1. Download the JDBC driver corresponding to your database version
 2. Place the driver in `$GRAVITEE_HOME/plugins/ext/repository-jdbc`
@@ -51,8 +51,10 @@ If you're using Docker to install and run APIM, place the driver in the `plugins
 
 ### Mandatory configuration
 
-Below is the minimum configuration needed to get started with a JDBC database.
+Below is the minimum configuration needed to get started with a JDBC database. Use the tab that matches your deployment method.
 
+{% tabs %}
+{% tab title="gravitee.yaml" %}
 {% code title="gravitee.yml" %}
 ```yaml
 management:
@@ -61,11 +63,40 @@ management:
     url:                 # jdbc url
 ```
 {% endcode %}
+{% endtab %}
+
+{% tab title=".env" %}
+Add the following variables to the `.env` file loaded by your `docker-compose.yml`, or to the `environment:` block of the Management API and Gateway services:
+
+```bash
+gravitee_management_type=jdbc
+gravitee_management_jdbc_url=
+```
+{% endtab %}
+
+{% tab title="Helm values.yaml" %}
+Set `management.type=jdbc` and the `jdbc:` block in your `values.yaml` file:
+
+```yaml
+management:
+  type: jdbc
+jdbc:
+  driverSource: auto
+  url:
+  username:
+  password:
+```
+
+For a complete per-database example, see the [PostgreSQL](jdbc.md#postgresql-configuration-with-gravitee-helm-chart), [MariaDB](jdbc.md#mariadb-configuration-with-gravitee-helm-chart), [SQL Server](jdbc.md#microsoft-sql-server-configuration-with-gravitee-helm-chart), or [MySQL](jdbc.md#mysql-configuration-with-gravitee-helm-chart) section below.
+{% endtab %}
+{% endtabs %}
 
 ### Optional configuration
 
-You can configure the following additional properties to fine-tune your JDBC connection and control the behavior of your JDBC database.
+You can configure the following additional properties to fine-tune your JDBC connection and control the behavior of your JDBC database. Use the tab that matches your deployment method.
 
+{% tabs %}
+{% tab title="gravitee.yaml" %}
 {% code title="gravitee.yml" %}
 ```yaml
 management:
@@ -84,6 +115,63 @@ management:
         maxPoolSize:            # jdbc max pool size (default 10)
 ```
 {% endcode %}
+{% endtab %}
+
+{% tab title=".env" %}
+Add the following variables to the `.env` file loaded by your `docker-compose.yml`, or to the `environment:` block of the Management API and Gateway services:
+
+```bash
+gravitee_management_type=jdbc
+gravitee_management_jdbc_prefix=
+gravitee_management_jdbc_url=
+gravitee_management_jdbc_username=
+gravitee_management_jdbc_password=
+gravitee_management_jdbc_pool_autoCommit=true
+gravitee_management_jdbc_pool_connectionTimeout=10000
+gravitee_management_jdbc_pool_idleTimeout=600000
+gravitee_management_jdbc_pool_maxLifetime=1800000
+gravitee_management_jdbc_pool_minIdle=10
+gravitee_management_jdbc_pool_maxPoolSize=10
+```
+{% endtab %}
+
+{% tab title="Helm values.yaml" %}
+Set the `jdbc:` block in your `values.yaml` file. The chart renders `jdbc.url`, `jdbc.username`, `jdbc.password`, `jdbc.schema`, `jdbc.liquibase`, and the `jdbc.pool` block into the Management API and Gateway `gravitee.yml` files at install time:
+
+```yaml
+management:
+  type: jdbc
+jdbc:
+  driverSource: auto
+  url:
+  username:
+  password:
+  schema: public
+  liquibase: true
+  pool:
+    autoCommit: true
+    connectionTimeout: 10000
+    idleTimeout: 600000
+    maxLifetime: 1800000
+    minIdle: 10
+    maxPoolSize: 10
+    registerMbeans: true
+```
+
+The chart doesn't expose a dedicated `jdbc.prefix` value. To set a custom table prefix, inject the equivalent environment variables through the `api.env` and `gateway.env` arrays of your `values.yaml` file:
+
+```yaml
+api:
+  env:
+    - name: gravitee_management_jdbc_prefix
+      value: prefix_
+gateway:
+  env:
+    - name: gravitee_management_jdbc_prefix
+      value: prefix_
+```
+{% endtab %}
+{% endtabs %}
 
 ## Gravitee Helm chart JDBC configuration details
 
@@ -299,5 +387,4 @@ Some databases have an option to enforce the use of a primary key on all tables,
 
 During future upgrades, you will need add back `?sessionVariables=sql_require_primary_key=OFF` during the upgrade only.
 
-:information\_source: More information:  [https://dev.mysql.com/doc/connector-j/en/connector-j-connp-props-session.html](https://dev.mysql.com/doc/connector-j/en/connector-j-connp-props-session.html)
-
+:information\_source: More information: [https://dev.mysql.com/doc/connector-j/en/connector-j-connp-props-session.html](https://dev.mysql.com/doc/connector-j/en/connector-j-connp-props-session.html)

--- a/docs/apim/4.12/prepare-a-production-environment/sensitive-data-management/api-secrets/configuration.md
+++ b/docs/apim/4.12/prepare-a-production-environment/sensitive-data-management/api-secrets/configuration.md
@@ -29,14 +29,14 @@ To learn more about Gravitee [Enterprise Edition](../../../readme/enterprise-edi
 ### Known limitations
 
 * Only environment variables and `gravitee.yml` properties can be resolved into secrets.\
-  A secret URL cannot be set using JVM properties, for example:\
-  `-Dsystem.proxy.password=secret://kubernetes/giosecrets:proxypass` **cannot be used**. JVM properties are passed directly to the platform without parsing and will not be detected by Gravitee as secret to resolve.
+  A secret URL can't be set using JVM properties, for example:\
+  `-Dsystem.proxy.password=secret://kubernetes/giosecrets:proxypass` **can't be used**. JVM properties are passed directly to the platform without parsing and will not be detected by Gravitee as secret to resolve.
 * The `vault` plugin watches with polling because Vault Events is an enterprise feature.
-* The `aws` plugin does not support the `watch` feature.
+* The `aws` plugin doesn't support the `watch` feature.
 
 ### Prerequisites to enable this feature <a href="#prerequisites-to-enable-this-feature" id="prerequisites-to-enable-this-feature"></a>
 
-* Configure one of the following secret managers in your `gravitee.yml` file, Helm Chart, or using the equivalent environment variable: Kubernetes, Amazon Secret Manager, or Hashicorp Vault. For more information about these secret managers, see [Integrations](../../../readme/integrations.md#secret-managers-integration).
+* Configure one of the following secret managers in your `gravitee.yml` file, Helm Chart, or using the equivalent environment variable: Kubernetes, Amazon Secret Manager, or HashiCorp Vault. For more information about these secret managers, see [Integrations](../../../readme/integrations.md#secret-managers-integration).
 * Reference those secrets in your API definitions with a specialized syntax. For more information about referencing secrets in API definitions, see [reference-secrets-in-apis.md](reference-secrets-in-apis.md "mention").
 
 ## Configuration for each secret manager <a href="#per-manager-configuration" id="per-manager-configuration"></a>
@@ -45,13 +45,15 @@ A `secret provider` plugin must be either bundled or added to the plugin directo
 
 You can enable `secret-provider` plugins by configuring them in `gravitee.yml`. The configurations for each secret provider plugin are discussed in the following sections.
 
-The following examples are for both `gravitee.yml` and Helm `values.yml`.
+{% hint style="info" %}
+The examples in this section show `gravitee.yml` syntax. For APIM Helm chart deployments, the same blocks must be nested under `api:` or `gateway:` in your `values.yaml` file, depending on which component reads the secret. See [Helm Charts specifics](#helm-charts-specifics) below for the equivalent Helm chart configuration.
+{% endhint %}
 
 ### Kubernetes
 
 The following example is a typical configuration for running Gravitee in Kubernetes. With this configuration, secrets are **resolved in the same namespace:**
 
-{% code title="gravitee.yml/Helm values.yml" %}
+{% code title="gravitee.yml" %}
 ```yaml
 secrets:
   kubernetes:
@@ -61,7 +63,7 @@ secrets:
 
 The following example shows how to add another namespace:
 
-{% code title="gravitee.yml/Helm values.yml" %}
+{% code title="gravitee.yml" %}
 ```yaml
 secrets:
   kubernetes:
@@ -95,8 +97,8 @@ Here is an example configuration:
 With this configuration, Gravitee uses a **secured** connection, a **Vault token** to authenticate, and then **watches** secrets by polling and 2 **retry** attempt to fetch a secret.
 
 {% tabs %}
-{% tab title="gravitee.yml/Helm values.yml" %}
-<pre class="language-yaml" data-title="gravitee.yml/Helm values.yml"><code class="lang-yaml"><strong>api:
+{% tab title="gravitee.yml" %}
+<pre class="language-yaml" data-title="gravitee.yml"><code class="lang-yaml"><strong>api:
 </strong><strong>  secrets:
 </strong><strong>    providers:
 </strong><strong>      - id: vault
@@ -145,7 +147,7 @@ By default, `retry` and `watch` are disabled.
 
 * To use an inline PEM, add the following configuration:
 
-{% code title="gravitee.yml/Helm values.yml" %}
+{% code title="gravitee.yml" %}
 ```yaml
 api:
   secrets:
@@ -168,7 +170,7 @@ api:
 
 * To use a java TrustStore, add the following configuration:
 
-{% code title="gravitee.yml/Helm values.yml" %}
+{% code title="gravitee.yml" %}
 ```yaml
 api:
   secrets:
@@ -197,7 +199,7 @@ Each of these authentication method can be configured in Vault in a non-default 
 
 * GitHub
 
-{% code title="gravitee.yml/Helm values.yml" %}
+{% code title="gravitee.yml" %}
 ```yaml
 api:
   secrets:
@@ -217,7 +219,7 @@ api:
 
 * Username and Password
 
-{% code title="gravitee.yml/Helm values.yml" %}
+{% code title="gravitee.yml" %}
 ```yaml
 api:
   secrets:
@@ -237,7 +239,7 @@ api:
 
 * App role
 
-{% code title="gravitee.yml/Helm values.yml" %}
+{% code title="gravitee.yml" %}
 ```yaml
 api:
   secrets:
@@ -258,7 +260,7 @@ api:
 * mTLS
   * With PEM files
 
-{% code title="gravitee.yml/Helm values.yml" %}
+{% code title="gravitee.yml" %}
 ```yaml
 api:
   secrets:
@@ -283,7 +285,7 @@ api:
 
 * With a Java Keystore
 
-{% code title="gravitee.yml/Helm values.yml" %}
+{% code title="gravitee.yml" %}
 ```yaml
 api:
   secrets:
@@ -305,7 +307,7 @@ api:
 * Kubernetes
   *   (recommended) Here is an example with short lived tokens:
 
-      <pre class="language-yaml" data-title="gravitee.yml/Helm values.yml"><code class="lang-yaml">api:
+      <pre class="language-yaml" data-title="gravitee.yml"><code class="lang-yaml">api:
         secrets:
           providers:
             - id: vault
@@ -322,7 +324,7 @@ api:
       * (Optional) If your pod does not make the token available in `/var/run/secrets/kubernetes.io/serviceaccount/token` , you can add `tokenFile` .
   *   Here is an example with long-lived tokens:
 
-      <pre class="language-yaml" data-title="gravitee.yml/Helm values.yml"><code class="lang-yaml">api:
+      <pre class="language-yaml" data-title="gravitee.yml"><code class="lang-yaml">api:
         secrets:
           providers:
             - id: vault
@@ -343,7 +345,7 @@ api:
 
 Here is a standard configuration when Gravitee runs in AWS EC2 or EKS. For more information about using `"chain"`, go to [Default credentials provider chain](https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/credentials-chain.html).
 
-{% code title="gravitee.yml/Helm values.yml" %}
+{% code title="gravitee.yml" %}
 ```yaml
 api:
   secrets:
@@ -360,7 +362,7 @@ api:
 
 Here is an example when Gravitee runs outside AWS:
 
-{% code title="gravitee.yml/Helm values.yml" %}
+{% code title="gravitee.yml" %}
 ```yaml
 api:
   secrets:
@@ -392,7 +394,7 @@ If you want to hide sensitive information in a secret manager, you must secure c
 
 Here is an example with Kubernetes configured to HashiCorp Vault:
 
-{% code title="gravitee.yml/Helm values.yml" %}
+{% code title="gravitee.yml" %}
 ```yaml
 secrets:
  kubernetes:
@@ -418,7 +420,7 @@ By default, secret providers are available for all environments that the APIM Ga
 
 You can specialize a secret provider to a set of environments. If all providers are configured like this, an API deployed on another environment triggers a secret resolution error.
 
-{% code title="gravitee.yml/Helm values.yml" %}
+{% code title="gravitee.yml" %}
 ```yaml
 api:
   secrets:
@@ -450,7 +452,7 @@ This syntax has a **critical** impact on how you reference secrets. For more inf
 
 For a setup with multiple environments, it is possible to use the same secret manager with different credentials, depending on the environment. Here is an example of a configuration with multiple environments:
 
-{% code title="gravitee.yml/Helm values.yml" %}
+{% code title="gravitee.yml" %}
 ```yaml
 api:
   secrets:
@@ -538,7 +540,7 @@ Retry options are applicable to all secret provider plugins. They are triggered 
 
 Here is an example to that shows the defaults:
 
-{% code title="gravitee.yml/Helm values.yml" %}
+{% code title="gravitee.yml" %}
 ```yaml
 api:
   secrets:
@@ -574,7 +576,7 @@ If a secret reference has the ?`renewable=true` option, you can control the foll
 
 Here is an example that shows the defaults. With this configuration, a check is completed every 15 minutes where secrets older than one day are resolved again:
 
-{% code title="gravitee.yml/Helm values.yml" %}
+{% code title="gravitee.yml" %}
 ```yaml
 api:
   secrets:

--- a/docs/apim/4.12/prepare-a-production-environment/sensitive-data-management/configure-secrets/configuration.md
+++ b/docs/apim/4.12/prepare-a-production-environment/sensitive-data-management/configure-secrets/configuration.md
@@ -24,24 +24,26 @@ To learn more about Gravitee [Enterprise Edition](../../../readme/enterprise-edi
 
 Current limitations are summarized below:
 
-* Only the `http.ssl.keystore.secret` x.509 pairs, in either PEM or KeyStore format, can be watched, and therefore hot-reloaded.
-* Only environment variables and `gravitee.yml` properties can be resolved into secrets.\
-  A secret URL cannot be set using JVM properties, For example:\
-  `-Dsystem.proxy.password=secret://kubernetes/giosecrets:proxypass` **cannot be used**. JVM properties are passed directly to the platform without parsing, and are not detected by Gravitee as secrets to resolve.
+* Only the `http.ssl.keystore.secret` x.509 pairs, in either PEM or keystore format, can be watched, and therefore hot-reloaded.
+* Only environment variables and `gravitee.yml` properties can be resolved into secrets. A secret URL can't be set using JVM properties. For example: `Dsystem.proxy.password=secret://kubernetes/giosecrets:proxypass` **can't be used**. JVM properties are passed directly to the platform without parsing, and are not detected by Gravitee as secrets to resolve.
 * The `vault` plugin watches via polling because Vault Events is an enterprise feature.
-* The `aws` plugin does not support watch. When used in a configuration, the secret is resolved once.
+* The `aws` plugin doesn't support watch. When used in a configuration, the secret is resolved once.
 
-## Configuration for each secret manager <a href="#per-manager-configuration" id="per-manager-configuration"></a>
+### Configuration for each secret manager <a href="#per-manager-configuration" id="per-manager-configuration"></a>
 
 A `secret provider` plugin must be either bundled or added to the plugin directory.
 
 You can enable a `secret-provider` plugin by configuring it in `gravitee.yml`. The configurations for each secret provider plugin are discussed in the following sections.
 
+{% hint style="info" %}
+The examples in this section show `gravitee.yml` syntax. For APIM Helm chart deployments, the same blocks must be nested under `api:` or `gateway:` in your `values.yaml` file, depending on which component reads the secret. See Helm chart specifics below for the equivalent Helm chart configuration.
+{% endhint %}
+
 ### Kubernetes
 
 The following example is a typical configuration for running Gravitee in Kubernetes. With this configuration, secrets are **resolved in the same namespace**.
 
-{% code title="gravitee.yml/Helm values.yml" %}
+{% code title="gravitee.yml" %}
 ```yaml
 secrets:
   kubernetes:
@@ -51,7 +53,7 @@ secrets:
 
 The following example shows how to add another namespace:
 
-{% code title="gravitee.yml/Helm values.yml" %}
+{% code title="gravitee.yml" %}
 ```yaml
 secrets:
   kubernetes:

--- a/docs/apim/4.12/prepare-a-production-environment/sensitive-data-management/configure-secrets/quick-start.md
+++ b/docs/apim/4.12/prepare-a-production-environment/sensitive-data-management/configure-secrets/quick-start.md
@@ -26,50 +26,52 @@ To configure configuration-level secrets, complete the following steps:
 
 ### Configure Gravitee to access a secret manager
 
-Once your instance of HashiCorp Vault is configured, you can then apply the configuration using the  `gravitee.yml` file, the Helm chart, or environment variables.
+Once your instance of HashiCorp Vault is configured, you can then apply the configuration using the `gravitee.yml` file, the Helm chart, or environment variables.
 
-#### Option 1: Configure access to a secret manager with a `gravitee.yml` file
+{% tabs %}
+{% tab title="gravitee.yaml" %}
+In your `gravitee.yml` file, add the following configuration:
 
-*   In your `gravitee.yml` file, add the following configuration:
+```yaml
+secrets:
+  vault:
+    enabled: true
+    host: 127.0.0.1
+    port: 8200
+    ssl:
+      enabled: false
+    auth:
+      method: token
+      config:
+        token: root
+```
+{% endtab %}
 
-    ```yaml
-    secrets:
-      vault:
-        enabled: true
-        host: 127.0.0.1      
-        port: 8200
-        ssl:
-          enabled: false
-        auth:
-          method: token 
-          config:
-            token: root
-    ```
+{% tab title=".env" %}
+In your `docker-compose.yml` file, add the following environment variables to the Gateway service:
 
-#### Option 2: Configure access to a secret manager with a Helm chart
+```bash
+GRAVITEE_SECRETS_VAULT_ENABLED="true"
+GRAVITEE_SECRETS_VAULT_HOST="127.0.0.1"
+GRAVITEE_SECRETS_VAULT_PORT="8200"
+GRAVITEE_SECRETS_VAULT_SSL_ENABLED="true"
+GRAVITEE_SECRETS_VAULT_AUTH_METHOD="token"
+GRAVITEE_SECRETS_VAULT_AUTH_CONFIG_TOKEN="root"
+```
+{% endtab %}
 
-*   In your Helm chart, add the following configuration:
+{% tab title="Helm values.yaml" %}
+In your `values.yaml` file, add the following configuration. Nest under `gateway:` for the Gateway and under `api:` for the Management API:
 
-    ```yaml
-    gateway:
-      secrets:
-        vault:
-          enabled: true
-          ## other properties as listed above
-    ```
-
-#### Option 3: Configure access to a secret manager with environment variables
-
-*   In your `docker-compose.yml` file, add the following configuration:
-
-    ```bash
-    GRAVITEE_SECRETS_VAULT_ENABLED="true"
-    GRAVITEE_SECRETS_VAULT_HOST="127.0.0.1"
-    GRAVITEE_SECRETS_VAULT_PORT="8200"
-    GRAVITEE_SECRETS_VAULT_SSL_ENABLED="true"
-    GRAVITEE_SECRETS_VAULT_AUTH_METHOD="token"
-    GRAVITEE_SECRETS_VAULT_AUTH_CONFIG_TOKEN="root"
-    ```
+```yaml
+gateway:
+  secrets:
+    vault:
+      enabled: true
+      ## other properties as listed in the gravitee.yaml tab
+```
+{% endtab %}
+{% endtabs %}
 
 {% hint style="info" %}
 For more information about configuring access to your secret manager, see [configuration.md](configuration.md "mention").

--- a/docs/apim/4.12/secure-and-expose-apis/plans/jwt.md
+++ b/docs/apim/4.12/secure-and-expose-apis/plans/jwt.md
@@ -9,12 +9,12 @@ metaLinks:
 
 ## Overview
 
-A JSON Web Token (JWT) is an open method for representing claims securely between two parties. It is digitally signed using an HMAC shared key or RSA public/private key pair. The JWT authentication type ensures that a JWT issued by a third party is valid by verifying its signature and expiration date. Only applications with approved JWTs can access APIs associated with a JWT plan.
+A JSON Web Token (JWT) is an open method for representing claims securely between two parties. It's digitally signed using an HMAC shared key or RSA public/private key pair. The JWT authentication type ensures that a JWT issued by a third party is valid by verifying its signature and expiration date. Only applications with approved JWTs can access APIs associated with a JWT plan.
 
 {% hint style="info" %}
-When an Identity Provider does not fully support the [OAuth2](oauth2.md) standard, use the JWT Plan .
+When an Identity Provider doesn't fully support the [OAuth2](oauth2.md) standard, use the JWT Plan .
 
-For example, Azure Entra ID does not provide a token introspection endpoint. So, you must use the JWT Plan with the JWKS\_URL resolver like `https://login.microsoft.com/{tenant_id}/discovery/v2.0/keys` to introspect, validate, and extract token custom claims.
+For example, Azure Entra ID doesn't provide a token introspection endpoint. So, you must use the JWT Plan with the JWKS\_URL resolver like `https://login.microsoft.com/{tenant_id}/discovery/v2.0/keys` to introspect, validate, and extract token custom claims.
 {% endhint %}
 
 ## Configuration
@@ -30,8 +30,6 @@ A JWT plan presents the following configuration options:
   * **GIVEN\_KEY**: Provide a signature key as a resolver parameter according to the signature algorithm (`ssh-rsa`, `pem`, `crt` or `public-key` format
   *   **GATEWAY\_KEYS:** Search for public keys set in the API Gateway `gravitee.yml` configuration that match the authorization server `iss` (issuer) and `kid` (key ID) claims of the incoming JWT
 
-      \{% code title="gravitee.yml" %\}
-
       ```yaml
       jwt:
         issuer:
@@ -40,7 +38,8 @@ A JWT plan presents the following configuration options:
             kid-2016: ssh-rsa myCurrentValidationKey anEmail@domain.com
       ```
 
-      \{% endcode %\} \* **JWKS\_URL**: Provide a URL ending with `/.well-known/jwks.json` from which the Gateway can retrieve the JWKS
+      For Docker Compose, set the equivalent values via environment variables (for example, `gravitee_jwt_issuer_my.authorization.server_default=ssh-rsa myValidationKey anEmail@domain.com`). For Helm deployments, the chart doesn't expose these Gateway-side issuer keys natively, so inject them through the `gateway.env` array of your `values.yaml` file.
+  * **JWKS\_URL**: Provide a URL ending with `/.well-known/jwks.json` from which the Gateway can retrieve the JWKS
 * **Use system proxy:** When using **JWKS\_URL**, optionally route the JWKS retrieval call through the Gateway's [system proxy](../../self-hosted-installation-guides/proxy-configuration/system-proxy-for-backend-apis.md). Enable this option when the Gateway reaches external identity providers (for example, Microsoft Entra ID, Google, or Okta) through a corporate proxy.
 *   **Extract JWT Claims:** Allow claims to be accessed in the `jwt.claims` context attribute during request/response via Gravitee Expression Language (EL), e.g., extract the issuer claim from the JWT:
 

--- a/docs/apim/4.12/secure-and-expose-apis/plans/mtls.md
+++ b/docs/apim/4.12/secure-and-expose-apis/plans/mtls.md
@@ -159,17 +159,23 @@ http:
 {% endcode %}
 {% endtab %}
 
-{% tab title="Kubernetes values.yaml" %}
-{% code title="values.yaml" %}
+{% tab title=".env" %}
+Add the following variable to the `.env` file loaded by your `docker-compose.yml`, or to the `environment:` block of the Gateway service:
+
+```bash
+gravitee_http_ssl_clientAuthHeader_name=X-Gravitee-Client-Cert
+```
+{% endtab %}
+
+{% tab title="Helm values.yaml" %}
+The APIM Helm chart doesn't expose a dedicated `clientAuthHeader` value. Inject the equivalent environment variable through the `gateway.env` array of your `values.yaml` file:
+
 ```yaml
 gateway:
-  # ...
-  ssl:
-    clientAuthHeader:
-      name: X-Gravitee-Client-Cert
-    # ...
+  env:
+    - name: gravitee_http_ssl_clientAuthHeader_name
+      value: X-Gravitee-Client-Cert
 ```
-{% endcode %}
 {% endtab %}
 {% endtabs %}
 


### PR DESCRIPTION
Auto-synced changes from `docs/apim/4.11/` to `docs/apim/4.12/`.

Triggered by push to `main` (fc0a5de0c406cd41a1cfe21248d4d73d489793c0).