### PR TITLE
[sync] apim: 4.11 → 4.12

### DIFF
--- a/docs/apim/4.12/analyze-and-monitor-apis/execution-transparency-analytics.md
+++ b/docs/apim/4.12/analyze-and-monitor-apis/execution-transparency-analytics.md
@@ -48,16 +48,38 @@ Execution transparency analytics requires the following components before you ca
 
 ## Configure Execution Transparency
 
-* Warning reporting is enabled by default in your environment. Here is what the default configuration looks like in the Gateway section of your `gravitee.yml` file:
+Warning reporting is enabled by default. To disable it or re-enable it  use the tab that matches your deployment method.
+
+{% tabs %}
+{% tab title="gravitee.yaml" %}
+Update the Gateway `gravitee.yml` file:
 
 ```yaml
-# gravitee.yml
+reporters:
+  warnings:
+    enabled: true
+```
+{% endtab %}
 
+{% tab title=".env" %}
+Add the following variable to the `.env` file loaded by `docker-compose.yml`, or to the `environment:` block of the Gateway service:
+
+```bash
+gravitee_reporters_warnings_enabled=true
+```
+{% endtab %}
+
+{% tab title="Helm values.yaml" %}
+Update the `gateway:` section of your `values.yaml` file. The APIM Helm chart renders these values into the Gateway `gravitee.yml` at install time:
+
+```yaml
 gateway:
   reporters:
     warnings:
       enabled: true
 ```
+{% endtab %}
+{% endtabs %}
 
 ## How Execution Transparency Analytics Works
 

--- a/docs/apim/4.12/configure-and-manage-the-platform/manage-organizations-and-environments/apim-console.md
+++ b/docs/apim/4.12/configure-and-manage-the-platform/manage-organizations-and-environments/apim-console.md
@@ -330,12 +330,37 @@ This file is located in the `/dashboards` folder of the Management API distribut
 
 To customize the Home dashboard you can either modify this file or specify a new folder in the `gravitee.yml` file:
 
-```
+{% tabs %}
+{% tab title="gravitee.yaml" %}
+Update the `console:` section of the Management API `gravitee.yml` file:
+
+```yaml
 # Console dashboards
 console:
   dashboards:
     path: ${gravitee.home}/dashboards
 ```
+{% endtab %}
+
+{% tab title=".env" %}
+Add the following variable to the `.env` file loaded by `docker-compose.yml`, or to the `environment:` block of the Management API service:
+
+```bash
+gravitee_console_dashboards_path=/opt/graviteeio-management-api/dashboards
+```
+{% endtab %}
+
+{% tab title="Helm values.yaml" %}
+The APIM Helm chart doesn't expose `console.dashboards.path` as a structured value, so set it through the Management API container environment under `api.env`:
+
+```yaml
+api:
+  env:
+    - name: gravitee_console_dashboards_path
+      value: /opt/graviteeio-management-api/dashboards
+```
+{% endtab %}
+{% endtabs %}
 
 By default, this section is commented out and the path is `${gravitee.home}/dashboards`
 
@@ -343,7 +368,7 @@ Charts are generated with [Highcharts](https://api.highcharts.com/highcharts/). 
 
 For example:
 
-```
+```json
 [
   {
     "row": 0,

--- a/docs/apim/4.12/configure-and-manage-the-platform/manage-organizations-and-environments/smtp-configuration.md
+++ b/docs/apim/4.12/configure-and-manage-the-platform/manage-organizations-and-environments/smtp-configuration.md
@@ -20,7 +20,11 @@ SMTP can be applied at two different levels:
 
 where the more specific level overrides the broader level: Environment > Organization.
 
-Here's an example of configuring SMTP using the `gravitee.yml` file:
+Use the tab that matches your deployment method.
+
+{% tabs %}
+{% tab title="gravitee.yaml" %}
+Update the `email:` section of the Management API `gravitee.yml` file:
 
 ```yaml
 email:
@@ -31,6 +35,36 @@ email:
   username: user@my.domain
   password: password
 ```
+{% endtab %}
+
+{% tab title=".env" %}
+Add the following variables to the `.env` file loaded by `docker-compose.yml`, or to the `environment:` block of the Management API service:
+
+```bash
+gravitee_email_host=smtp.my.domain
+gravitee_email_port=465
+gravitee_email_from=noreply@my.domain
+gravitee_email_subject=[Gravitee.io] %s
+gravitee_email_username=user@my.domain
+gravitee_email_password=password
+```
+{% endtab %}
+
+{% tab title="Helm values.yaml" %}
+Set the top-level `smtp:` section of your `values.yaml`. The APIM Helm chart renders the `smtp:` values into the Management API `gravitee.yml` `email:` block at install time:
+
+```yaml
+smtp:
+  enabled: true
+  host: smtp.my.domain
+  port: 465
+  from: noreply@my.domain
+  subject: "[Gravitee.io] %s"
+  username: user@my.domain
+  password: password
+```
+{% endtab %}
+{% endtabs %}
 
 ## Configure in APIM Console
 
@@ -48,7 +82,11 @@ Or at the environment level in the **Settings > Settings** section of the APIM C
 
 ## Configure the Gmail SMTP server
 
-If required, you can configure the GMAIL SMTP server in `gravitee.yml` as follows:
+Configure the Gmail SMTP server using the tab that matches your deployment method.
+
+{% tabs %}
+{% tab title="gravitee.yaml" %}
+Update the `email:` section of the Management API `gravitee.yml` file:
 
 ```yaml
 email:
@@ -64,5 +102,43 @@ email:
     starttls.enable: true
     ssl.trust: smtp.gmail.com
 ```
+{% endtab %}
+
+{% tab title=".env" %}
+Add the following variables to the `.env` file loaded by `docker-compose.yml`, or to the `environment:` block of the Management API service:
+
+```bash
+gravitee_email_enabled=true
+gravitee_email_host=smtp.gmail.com
+gravitee_email_port=587
+gravitee_email_from=user@gmail.com
+gravitee_email_subject=[Gravitee.io] %s
+gravitee_email_username=user@gmail.com
+gravitee_email_password=xxxxxxxx
+gravitee_email_properties_auth=true
+gravitee_email_properties_starttls_enable=true
+gravitee_email_properties_ssl_trust=smtp.gmail.com
+```
+{% endtab %}
+
+{% tab title="Helm values.yaml" %}
+Set the top-level `smtp:` section of your `values.yaml`:
+
+```yaml
+smtp:
+  enabled: true
+  host: smtp.gmail.com
+  port: 587
+  from: user@gmail.com
+  subject: "[Gravitee.io] %s"
+  username: user@gmail.com
+  password: xxxxxxxx
+  properties:
+    auth: true
+    starttls.enable: true
+    ssl.trust: smtp.gmail.com
+```
+{% endtab %}
+{% endtabs %}
 
 If you are using 2-Factor Authentication (which is recommended), you need to [generate an application password](https://security.google.com/settings/security/apppasswords).

--- a/docs/apim/4.12/secure-and-expose-apis/plans/push.md
+++ b/docs/apim/4.12/secure-and-expose-apis/plans/push.md
@@ -33,7 +33,7 @@ Before you approve a webhook subscription, verify the following field values:
 
 The Gateway automatically retries technical failures occurring between the Gateway and the backend. For example, DNS errors or network transitional issues.
 
-Prior to Gravitee 4.8, the Gateway performed 5 retries at 3s intervals. After 5 retries, the subscription's status was set to FAILURE.
+Prior to Gravitee 4.8, the Gateway performed 5 retries at 3s intervals. After 5 retries, the subscription's status was set to FAILURE.&#x20;
 
 Starting with Gravitee 4.8, the Gateway performs retries indefinitely using exponential retries. With exponential retries, the subscription never fails when an issue occurs between the Gateway and the backend. Instead, the API publisher is notified after every 5 failed retries.
 
@@ -47,7 +47,11 @@ Here is a table that shows the retry configuration for your `gravitee.yml` file.
 | `delayMs`              | 5000        | The initial delay, in milliseconds, for exponential retry, or the delay between retries for linear retry.                                                                           |
 | `notificationInterval` | 5           | The number of retries after which the notification must be sent.                                                                                                                    |
 
-Here is the default configuration in the `gravitee.yml` file:
+Apply the configuration using the tab that matches your deployment method.
+
+{% tabs %}
+{% tab title="gravitee.yaml" %}
+Update the `api:` section of the Gateway `gravitee.yml` file:
 
 ```yaml
 api:
@@ -58,3 +62,32 @@ api:
     delayMs: 5000 # The initial delay in milliseconds for exponential retry or the delay between retries for linear retry
     notificationInterval: 5 # Number of retries after which the notification needs to be sent
 ```
+{% endtab %}
+
+{% tab title=".env" %}
+Add the following variables to the `.env` file loaded by `docker-compose.yml`, or to the `environment:` block of the Gateway service:
+
+```bash
+gravitee_api_subscriptionEndpointRetry_backoffStrategy=EXPONENTIAL
+gravitee_api_subscriptionEndpointRetry_maxRetries=-1
+gravitee_api_subscriptionEndpointRetry_maxDelayMs=-1
+gravitee_api_subscriptionEndpointRetry_delayMs=5000
+gravitee_api_subscriptionEndpointRetry_notificationInterval=5
+```
+{% endtab %}
+
+{% tab title="Helm values.yaml" %}
+Update the `gateway.api:` section of your `values.yaml` file. The APIM Helm chart renders these values into the Gateway `gravitee.yml` `api:` block at install time:
+
+```yaml
+gateway:
+  api:
+    subscriptionEndpointRetry:
+      backoffStrategy: EXPONENTIAL # LINEAR or EXPONENTIAL
+      maxRetries: -1 # The maximum number of retries to attempt. -1 for infinite retries
+      maxDelayMs: -1 # Maximum delay to reach to stop retrying for exponential retry. -1 for infinite retry
+      delayMs: 5000 # The initial delay in milliseconds for exponential retry or the delay between retries for linear retry
+      notificationInterval: 5 # Number of retries after which the notification needs to be sent
+```
+{% endtab %}
+{% endtabs %}


### PR DESCRIPTION
Auto-synced changes from `docs/apim/4.11/` to `docs/apim/4.12/`.

Triggered by push to `main` (bcbc77e5eec898b05aac4517367e3dcd0ef2414c).