### PR TITLE
[sync] apim: 4.11 → 4.12

### DIFF
--- a/docs/apim/4.12/hybrid-installation-and-configuration-guides/proxy-configuration/README.md
+++ b/docs/apim/4.12/hybrid-installation-and-configuration-guides/proxy-configuration/README.md
@@ -4,10 +4,11 @@
 
 In enterprise environments, Gravitee components often communicate through corporate proxy servers. This section covers proxy configuration for hybrid deployment scenarios.
 
-| Guide                         | Use Case                                                                                   |
-| ----------------------------- | ------------------------------------------------------------------------------------------ |
-| Hybrid Gateway Proxy          | Configure a Hybrid Gateway to connect to a Bridge Server or Gravitee Cloud through a proxy |
-| System Proxy for Backend APIs | Configure a Gateway to route backend API calls through a system proxy                      |
+| Guide                          | Use Case                                                                                                                    |
+| ------------------------------ | --------------------------------------------------------------------------------------------------------------------------- |
+| Configure Cloud Gateway Client | Configure HTTP, proxy, and SSL settings for every component that connects to Gravitee Cloud Gateway from a single namespace |
+| Hybrid Gateway Proxy           | Configure a Hybrid Gateway to connect to a Bridge Server or Gravitee Cloud through a proxy                                  |
+| System Proxy for Backend APIs  | Configure a Gateway to route backend API calls through a system proxy                                                       |
 
 ## Proxy Types
 
@@ -33,14 +34,14 @@ Used by the Gateway to route API calls to backend services through a centralized
 
 Gravitee supports several proxy configuration approaches. The following table describes each method and when to use it:
 
-| Method | Environment variables | Use case |
-| --- | --- | --- |
-| **System proxy** | `gravitee_system_proxy_*` | Route Gateway outbound calls through a proxy, including backend API calls and JWKS retrieval from external identity providers. This is the correct method for Helm-based Kubernetes and OpenShift deployments. |
-| **HTTP Repository proxy** | `gateway.management.http.proxy` | Route Hybrid Gateway connections to the Bridge Server or Gravitee Cloud Platform through a proxy. |
-| **Cloud Reporter proxy** | `gravitee_cloud_client_proxy_*` | Route Gateway metrics and log reporting to Gravitee Cloud through a proxy. |
-| **HTTP Client proxy** | `gravitee_httpClient_proxy_*` | Route Management API outbound HTTP calls (webhooks, API imports, external notifications) through a proxy. This doesn't affect Gateway traffic. |
-| **JVM flags** | `-Dhttp.proxyHost`, `-Dhttps.proxyHost` | Standard Java proxy flags. These aren't used by Gravitee's internal HTTP clients and aren't recommended for Gravitee proxy configuration. |
-| **OS environment variables** | `HTTP_PROXY`, `HTTPS_PROXY` | Standard OS-level proxy variables. These aren't used by Gravitee internally and don't configure Gravitee components. |
+| Method                       | Environment variables                   | Use case                                                                                                                                                                                                       |
+| ---------------------------- | --------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **System proxy**             | `gravitee_system_proxy_*`               | Route Gateway outbound calls through a proxy, including backend API calls and JWKS retrieval from external identity providers. This is the correct method for Helm-based Kubernetes and OpenShift deployments. |
+| **HTTP Repository proxy**    | `gateway.management.http.proxy`         | Route Hybrid Gateway connections to the Bridge Server or Gravitee Cloud Platform through a proxy.                                                                                                              |
+| **Cloud Reporter proxy**     | `gravitee_cloud_client_proxy_*`         | Route Gateway metrics and log reporting to Gravitee Cloud through a proxy.                                                                                                                                     |
+| **HTTP Client proxy**        | `gravitee_httpClient_proxy_*`           | Route Management API outbound HTTP calls (webhooks, API imports, external notifications) through a proxy. This doesn't affect Gateway traffic.                                                                 |
+| **JVM flags**                | `-Dhttp.proxyHost`, `-Dhttps.proxyHost` | Standard Java proxy flags. These aren't used by Gravitee's internal HTTP clients and aren't recommended for Gravitee proxy configuration.                                                                      |
+| **OS environment variables** | `HTTP_PROXY`, `HTTPS_PROXY`             | Standard OS-level proxy variables. These aren't used by Gravitee internally and don't configure Gravitee components.                                                                                           |
 
 {% hint style="warning" %}
 **Use `gravitee_system_proxy_*` for Gateway proxy configuration**

--- a/docs/apim/4.12/hybrid-installation-and-configuration-guides/proxy-configuration/configure-cloud-gateway-client.md
+++ b/docs/apim/4.12/hybrid-installation-and-configuration-guides/proxy-configuration/configure-cloud-gateway-client.md
@@ -1,0 +1,190 @@
+---
+description: Learn how to configure Cloud gateway client
+---
+
+# Configure Cloud Gateway Client
+
+## Overview
+
+In a hybrid deployment, your Gateway and Management API connect to Gravitee Cloud Gateway through several endpoints. The unified `cloud.client.*` configuration in `gravitee.yml` sets the HTTP, proxy, and SSL options for all of them in one place.
+
+The global configuration applies to the following Cloud Gateway endpoints:
+
+<table><thead><tr><th width="220">Endpoint</th><th>Purpose</th></tr></thead><tbody><tr><td><code>/sync</code></td><td>Repository synchronization</td></tr><tr><td><code>/reports</code></td><td>Analytics and metrics reporting</td></tr><tr><td><code>/apim/integration</code></td><td>Federation agent API discovery</td></tr></tbody></table>
+
+## Configure the Cloud Gateway client
+
+Add the following block to your `gravitee.yml` file. All values shown are defaults except `cloud.enabled` and `cloud.token`:
+
+```yaml
+cloud:
+  enabled: true
+  token: ${CLOUD_TOKEN}
+  client:
+    http:
+      idleTimeout: 60000              # Idle timeout in ms
+      connectTimeout: 5000            # Connection timeout in ms
+      keepAlive: true                 # Enable keep-alive
+      maxConcurrentConnections: 100   # Maximum concurrent connections
+      http2MultiplexingLimit: -1      # HTTP/2 streams per connection; -1 means unlimited
+      version: HTTP_2                 # HTTP_1_1 or HTTP_2
+      clearTextUpgrade: true          # HTTP/2 clear-text upgrade
+    proxy:
+      enabled: false
+      type: HTTP                      # HTTP, SOCKS4, or SOCKS5
+      host: localhost
+      port: 3128
+      username: user                  # Optional
+      password: secret                # Optional
+      useSystemProxy: false
+    ssl:
+      trustAll: false
+      hostnameVerifier: true
+      truststore:
+        type: NONE                    # PEM, PKCS12, JKS, or NONE
+        path:                         # Path to the truststore file
+        content:                      # Base64-encoded content; alternative to path
+        password:                     # Required for PKCS12 and JKS
+        alias:                        # Optional for PKCS12 and JKS
+```
+
+## Common scenarios
+
+Below are common use-cases based on your workflows:
+
+### Route Cloud Gateway traffic through a corporate proxy
+
+Set the proxy block to direct all Cloud Gateway connections through a corporate proxy:
+
+```yaml
+cloud:
+  enabled: true
+  token: ${CLOUD_TOKEN}
+  client:
+    proxy:
+      enabled: true
+      host: corporate-proxy.company.com
+      port: 3128
+      username: ${PROXY_USER}
+      password: ${PROXY_PASSWORD}
+```
+
+### Configure a proxy that performs SSL interception
+
+{% hint style="warning" %}
+**Vert.x limitation with SSL-intercepting proxies**
+
+If your corporate proxy intercepts SSL traffic (for example, Zscaler or Blue Coat), the `cloud.client.ssl.truststore.*` configuration doesn't apply because of a Vert.x limitation. Add the proxy CA certificate to the Java truststore instead.
+{% endhint %}
+
+Import the proxy CA certificate into the JVM `cacerts` truststore:
+
+```sh
+keytool -import -trustcacerts \
+  -alias corporate-proxy-ca \
+  -file /path/to/proxy-ca-cert.pem \
+  -cacerts \
+  -storepass changeit
+```
+
+### Connect to a Cloud Gateway with a custom certificate
+
+When you connect directly to a Cloud Gateway that uses a custom or self-signed certificate without a proxy, configure the truststore.
+
+PEM truststore:
+
+```yaml
+cloud:
+  client:
+    ssl:
+      truststore:
+        type: PEM
+        path: /path/to/custom-ca.pem
+```
+
+PKCS12 or JKS truststore:
+
+```yaml
+cloud:
+  client:
+    ssl:
+      truststore:
+        type: JKS
+        path: /path/to/truststore.jks
+        password: ${TRUSTSTORE_PASSWORD}
+```
+
+## Override the global configuration for a specific component
+
+The global `cloud.client.*` configuration applies to every Cloud Gateway endpoint. To use different settings for a single component, add a per-component block. The per-component block takes precedence over the global one.
+
+### Override settings for the repository bridge
+
+Use `management.http.*` to override settings for the `/sync` endpoint only:
+
+```yaml
+cloud:
+  client:
+    proxy:
+      host: corporate-proxy.com
+management:
+  http:
+    proxy:
+      host: special-proxy.com
+```
+
+### Override settings for the federation agent
+
+Use `integration.connector.ws.*` to override settings for the `/apim/integration` endpoint only:
+
+```yaml
+cloud:
+  client:
+    proxy:
+      host: corporate-proxy.com
+integration:
+  connector:
+    ws:
+      proxy:
+        host: special-proxy.com
+```
+
+## Configuration reference
+
+Below are all the configuration references:&#x20;
+
+### HTTP client properties
+
+<table><thead><tr><th width="300">Property</th><th width="100">Type</th><th width="110">Default</th><th>Description</th></tr></thead><tbody><tr><td><code>cloud.client.http.version</code></td><td>String</td><td><code>HTTP_2</code></td><td>HTTP protocol version. Accepted values: <code>HTTP_1_1</code>, <code>HTTP_2</code></td></tr><tr><td><code>cloud.client.http.idleTimeout</code></td><td>Long</td><td><code>60000</code></td><td>Idle timeout in milliseconds</td></tr><tr><td><code>cloud.client.http.connectTimeout</code></td><td>Long</td><td><code>5000</code></td><td>Connection timeout in milliseconds</td></tr><tr><td><code>cloud.client.http.keepAlive</code></td><td>Boolean</td><td><code>true</code></td><td>Enable HTTP keep-alive</td></tr><tr><td><code>cloud.client.http.maxConcurrentConnections</code></td><td>Integer</td><td><code>100</code></td><td>Maximum concurrent connections</td></tr><tr><td><code>cloud.client.http.http2MultiplexingLimit</code></td><td>Integer</td><td><code>-1</code></td><td>HTTP/2 concurrent streams per connection. <code>-1</code> means unlimited</td></tr><tr><td><code>cloud.client.http.clearTextUpgrade</code></td><td>Boolean</td><td><code>true</code></td><td>Enable HTTP/2 clear-text upgrade</td></tr></tbody></table>
+
+### Proxy properties
+
+<table><thead><tr><th width="300">Property</th><th width="100">Type</th><th width="110">Default</th><th>Description</th></tr></thead><tbody><tr><td><code>cloud.client.proxy.enabled</code></td><td>Boolean</td><td><code>false</code></td><td>Enable the proxy</td></tr><tr><td><code>cloud.client.proxy.type</code></td><td>String</td><td><code>HTTP</code></td><td>Proxy type. Accepted values: <code>HTTP</code>, <code>SOCKS4</code>, <code>SOCKS5</code></td></tr><tr><td><code>cloud.client.proxy.host</code></td><td>String</td><td>-</td><td>Proxy hostname</td></tr><tr><td><code>cloud.client.proxy.port</code></td><td>Integer</td><td><code>3128</code></td><td>Proxy port</td></tr><tr><td><code>cloud.client.proxy.username</code></td><td>String</td><td>-</td><td>Proxy username. Optional</td></tr><tr><td><code>cloud.client.proxy.password</code></td><td>String</td><td>-</td><td>Proxy password. Optional</td></tr><tr><td><code>cloud.client.proxy.useSystemProxy</code></td><td>Boolean</td><td><code>false</code></td><td>Use system proxy settings</td></tr></tbody></table>
+
+### SSL properties
+
+<table><thead><tr><th width="320">Property</th><th width="100">Type</th><th width="110">Default</th><th>Description</th></tr></thead><tbody><tr><td><code>cloud.client.ssl.trustAll</code></td><td>Boolean</td><td><code>false</code></td><td>Trust all certificates. Not recommended for production</td></tr><tr><td><code>cloud.client.ssl.hostnameVerifier</code></td><td>Boolean</td><td><code>true</code></td><td>Enable hostname verification</td></tr><tr><td><code>cloud.client.ssl.truststore.type</code></td><td>String</td><td><code>NONE</code></td><td>Truststore type. Accepted values: <code>PEM</code>, <code>PKCS12</code>, <code>JKS</code>, <code>NONE</code></td></tr><tr><td><code>cloud.client.ssl.truststore.path</code></td><td>String</td><td>-</td><td>Path to the truststore file</td></tr><tr><td><code>cloud.client.ssl.truststore.content</code></td><td>String</td><td>-</td><td>Base64-encoded truststore content. Alternative to <code>path</code></td></tr><tr><td><code>cloud.client.ssl.truststore.password</code></td><td>String</td><td>-</td><td>Truststore password. Required for PKCS12 and JKS</td></tr><tr><td><code>cloud.client.ssl.truststore.alias</code></td><td>String</td><td>-</td><td>Certificate alias. Optional for PKCS12 and JKS</td></tr></tbody></table>
+
+{% hint style="warning" %}
+**SSL truststore and intercepting proxies**
+
+The `cloud.client.ssl.truststore.*` configuration doesn't work with proxies that perform SSL interception. For those environments, add the proxy CA certificate to the Java truststore as described in Configure a proxy that performs SSL interception.
+{% endhint %}
+
+## Verification
+
+To verify the Cloud Gateway client configuration is applied as expected, follow these steps:
+
+1.  Confirm that the Gateway and Management API pods read the `cloud.client.*` settings from `gravitee.yml`:
+
+    ```sh
+    kubectl get pod -n gravitee-apim -l app.kubernetes.io/component=gateway \
+      -o jsonpath='{.items[0].spec.containers[0].env}' | \
+      jq '.[] | select(.name | startswith("gravitee_cloud_client"))'
+    ```
+2.  Check the Gateway logs for Cloud Gateway connection messages:
+
+    ```sh
+    kubectl logs -n gravitee-apim -l app.kubernetes.io/component=gateway | grep -i "cloud"
+    ```
+3. Confirm that traffic flows through the proxy by checking the proxy server access log for connections to the Cloud Gateway hostname.

--- a/docs/apim/4.12/terraform/quick-start-guide.md
+++ b/docs/apim/4.12/terraform/quick-start-guide.md
@@ -13,14 +13,14 @@ metaLinks:
 This feature is in tech preview.
 {% endhint %}
 
-Terraform lets you manage APIs and other entities via configuration instead of through manual updates in the APIM Console. This lets you automate and version changes to your APIM instance for an Infrastructure as Code (IaC) experience.
+Terraform lets you manage APIs and other entities via configuration rather than manual updates in the APIM Console. This lets you automate and version changes to your APIM instance for an Infrastructure as Code (IaC) experience.
 
 You can use Gravitee's Terraform provider to create and manage Gravitee's Terraform resources. The role of the provider is to apply your resources and synchronize them with the Control Plane.
 
 This guide demonstrates Gravitee's Terraform capabilities with a working example.
 
 {% hint style="info" %}
-For schema details, refer to the [Terraform registry documentation](https://registry.terraform.io/providers/gravitee-io/apim).
+For resource setup details, we strongly encourage you to refer to the [Terraform registry documentation.](https://registry.terraform.io/providers/gravitee-io/apim/latest)
 {% endhint %}
 
 ## Prerequisites
@@ -28,20 +28,39 @@ For schema details, refer to the [Terraform registry documentation](https://regi
 Before you can use Terraform with Gravitee, you must install Terraform, have a running APIM environment, and obtain credentials to call the Management API (mAPI). To satisfy these prerequisites, complete the following steps:
 
 * Install Terraform. For more information about installing Terraform, see [Install Terraform](https://developer.hashicorp.com/terraform/tutorials/aws-get-started/install-cli).
-* Install APIM. To quickly get APIM up and running, see the [getting-started](../getting-started/ "mention") guide.
-* Follow the steps in [define-an-apim-service-account-for-terraform.md](define-an-apim-service-account-for-terraform.md "mention") to get mAPI credentials.
+* Install APIM. To quickly get APIM up and running, see the[getting-started](../getting-started/ "mention") guide.
 
 ## Install the Gravitee Terraform provider
 
 To install the Gravitee Terraform provider, complete the following steps:
 
 1. Create a directory.
-2.  Create a Terraform `provider.tf` configuration file with the following content.
+2.  Create a Terraform `provider.tf` configuration file with the following content:
 
-    * Replace `<mAPI host and port>` with the host and port pair corresponding your Management API. For example, `http://localhost:8083/automation`.
-    * Replace xxx with the bearer token you generated in [define-an-apim-service-account-for-terraform.md](define-an-apim-service-account-for-terraform.md "mention").
+    1.  If you are using a local or self-managed instance:&#x20;
 
-    ```hcl
+        * Replace `<mAPI host and port>` with the host and port pair corresponding to your Management API. For example, `http://localhost:8083/automation`.
+        * Replace xxx with the bearer token you generated in[define-an-apim-service-account-for-terraform.md](define-an-apim-service-account-for-terraform.md "mention").
+
+        ```hcl
+        terraform {
+          required_providers {
+            apim = {
+              source  = "gravitee-io/apim"
+            }
+          }
+        }
+
+        provider "apim" {
+          server_url = "http://<mAPI host and port>/automation"
+          bearer_auth = "xxx"
+        }
+        ```
+    2. If you are using Gravitee Cloud
+       * Create a Gravitee Cloud Token
+       * Replace 'xxx' with its content, the rest will be set (server, org, env) automatically
+
+    ```tf
     terraform {
       required_providers {
         apim = {
@@ -51,12 +70,9 @@ To install the Gravitee Terraform provider, complete the following steps:
     }
 
     provider "apim" {
-      server_url = "http://<mAPI host and port>/automation"
-      bearer_auth = "xxx"
+      cloud_auth  = "xxx"
     }
     ```
-
-    <div data-gb-custom-block data-tag="hint" data-style="info" class="hint hint-info"><ul><li>The <code>bearer_auth</code> of Gravitee Cloud users contains the Gravitee Cloud Token</li><li><code>organization_id</code> and <code>environment_id</code> are set from token claims</li><li>URL syntax follows <code>https://eu.cloudgate.gravitee.io/apim/automation</code> (e.g., for Europe)</li></ul></div>
 3.  To start Terraform, run the following command:
 
     ```bash
@@ -69,7 +85,7 @@ To install the Gravitee Terraform provider, complete the following steps:
       # should match the resource name
       hrid            = "quick-start-api"
       name            = "[Terraform] Quick Start PROXY API"
-      description     = "A simple API that routes traffic to gravitee echo API"
+      description     = "A simple API that routes traffic to Gravitee echo API"
       version         = "1.0"
       type            = "PROXY"
       state           = "STARTED"         # API will be deployed
@@ -137,5 +153,7 @@ To install the Gravitee Terraform provider, complete the following steps:
     ```
 
 {% hint style="success" %}
-The API "\[Terraform] Quick Start PROXY API" is created, visible (read only), and deployed to your APIM instance.
+The API "\[Terraform] Quick Start PROXY API" has been created, is visible (read-only), and has been deployed to your APIM instance.
 {% endhint %}
+
+Next, see the [Terraform registry documentation](https://registry.terraform.io/providers/gravitee-io/apim/latest) for the full set of resources and attributes supported by the APIM Terraform provider.


### PR DESCRIPTION
Auto-synced changes from `docs/apim/4.11/` to `docs/apim/4.12/`.

Triggered by push to `main` (35cd9a3c5746de3fef5869a38b99fd4d6dca5b5a).