### PR TITLE
[sync] am: 4.11 → 4.12

### DIFF
--- a/docs/am/4.12/releases-and-changelog/changelog/am-4.11.x.md
+++ b/docs/am/4.12/releases-and-changelog/changelog/am-4.11.x.md
@@ -6,6 +6,41 @@ description: >-
 
 # AM 4.11.x
 
+## Gravitee Access Management 4.11.4 - May 15, 2026
+
+<details>
+
+<summary>What's new !</summary>
+
+=**What's new!**
+
+* UserProfile claims extension
+
+</details>
+
+
+<details>
+
+<summary>Bug fixes</summary>
+
+
+
+
+
+
+
+**Other**
+
+* User profile not accessible in the context during token exchange [#11317](https://github.com/gravitee-io/issues/issues/11317)
+* Improve CPU consumption with thousand of domain [#11411](https://github.com/gravitee-io/issues/issues/11411)
+* Addition of access log for the Gateway [#11415](https://github.com/gravitee-io/issues/issues/11415)
+* 'Master' attribute value is inconsistent when listing domains vs retrieving a specific domain [#11422](https://github.com/gravitee-io/issues/issues/11422)
+* SCIM PUT/PATCH switches internal flag to false [#11425](https://github.com/gravitee-io/issues/issues/11425)
+* JWT tokens are invalid with multiple values in the aud claim [#11427](https://github.com/gravitee-io/issues/issues/11427)
+
+</details>
+
+
 ## Gravitee Access Management 4.11.3 - May 1, 2026
 
 <details>


### PR DESCRIPTION
Auto-synced changes from `docs/am/4.11/` to `docs/am/4.12/`.

Triggered by push to `main` (9fe6fddab0ad94eabe15d4b50fa61365eace6f2f).