### PR TITLE
[sync] apim: 4.11 → 4.12

### DIFF
--- a/docs/apim/4.12/configure-and-manage-the-platform/node-logging-configuration.md
+++ b/docs/apim/4.12/configure-and-manage-the-platform/node-logging-configuration.md
@@ -6,42 +6,7 @@ Configure MDC filtering, log patterns, and Logback overrides for the Gravitee Ga
 
 The `%mdcList` custom Logback converter formats selected MDC keys into log output. Configure which keys to include, how to format each entry, and how to separate entries.
 
-<table>
-    <thead>
-        <tr>
-            <th width="280">Property</th>
-            <th width="120">Type</th>
-            <th width="150">Default</th>
-            <th>Description</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td><code>node.logging.mdc.format</code></td>
-            <td>String</td>
-            <td><code>{key}: {value}</code></td>
-            <td>Template for formatting each MDC key-value pair</td>
-        </tr>
-        <tr>
-            <td><code>node.logging.mdc.separator</code></td>
-            <td>String</td>
-            <td><code>" "</code> (space)</td>
-            <td>Separator between formatted MDC entries</td>
-        </tr>
-        <tr>
-            <td><code>node.logging.mdc.nullValue</code></td>
-            <td>String</td>
-            <td><code>""</code> (empty)</td>
-            <td>Placeholder when an MDC value is null</td>
-        </tr>
-        <tr>
-            <td><code>node.logging.mdc.include</code></td>
-            <td>List&lt;String&gt;</td>
-            <td><code>[]</code> (empty — all keys included)</td>
-            <td>MDC keys to include in <code>%mdcList</code> output. When empty, all available MDC keys are included.</td>
-        </tr>
-    </tbody>
-</table>
+<table><thead><tr><th width="280">Property</th><th width="120">Type</th><th width="150">Default</th><th>Description</th></tr></thead><tbody><tr><td><code>node.logging.mdc.format</code></td><td>String</td><td><code>{key}: {value}</code></td><td>Template for formatting each MDC key-value pair</td></tr><tr><td><code>node.logging.mdc.separator</code></td><td>String</td><td><code>" "</code> (space)</td><td>Separator between formatted MDC entries</td></tr><tr><td><code>node.logging.mdc.nullValue</code></td><td>String</td><td><code>""</code> (empty)</td><td>Placeholder when an MDC value is null</td></tr><tr><td><code>node.logging.mdc.include</code></td><td>List&#x3C;String></td><td><code>[]</code> (empty — all keys included)</td><td>MDC keys to include in <code>%mdcList</code> output. When empty, all available MDC keys are included.</td></tr></tbody></table>
 
 **Example Gateway `gravitee.yml`:**
 
@@ -69,36 +34,7 @@ With this configuration and a request to an API called "my-api", the `%mdcList` 
 
 Override Logback appender patterns at runtime without modifying `logback.xml`.
 
-<table>
-    <thead>
-        <tr>
-            <th width="350">Property</th>
-            <th width="100">Type</th>
-            <th width="100">Default</th>
-            <th>Description</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td><code>node.logging.pattern.overrideLogbackXml</code></td>
-            <td>Boolean</td>
-            <td><code>false</code></td>
-            <td>Override logback.xml patterns at runtime</td>
-        </tr>
-        <tr>
-            <td><code>node.logging.pattern.console</code></td>
-            <td>String</td>
-            <td>-</td>
-            <td>Console (STDOUT) appender pattern when override is enabled</td>
-        </tr>
-        <tr>
-            <td><code>node.logging.pattern.file</code></td>
-            <td>String</td>
-            <td>-</td>
-            <td>File appender pattern when override is enabled</td>
-        </tr>
-    </tbody>
-</table>
+<table><thead><tr><th width="350">Property</th><th width="100">Type</th><th width="100">Default</th><th>Description</th></tr></thead><tbody><tr><td><code>node.logging.pattern.overrideLogbackXml</code></td><td>Boolean</td><td><code>false</code></td><td>Override logback.xml patterns at runtime</td></tr><tr><td><code>node.logging.pattern.console</code></td><td>String</td><td>-</td><td>Console (STDOUT) appender pattern when override is enabled</td></tr><tr><td><code>node.logging.pattern.file</code></td><td>String</td><td>-</td><td>File appender pattern when override is enabled</td></tr></tbody></table>
 
 **Example `gravitee.yml`:**
 
@@ -178,32 +114,27 @@ This approach works in `logback.xml` directly without requiring the pattern over
 
 For Kubernetes deployments using the Gravitee Helm chart, logging is configured through three independent blocks in `values.yaml`. The legacy `logging` block is deprecated in favor of the new `logback` and `node.logging` blocks.
 
-<table>
-    <thead>
-        <tr>
-            <th width="180">Block</th>
-            <th>Purpose</th>
-            <th width="150">Status</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td><code>logging</code></td>
-            <td>Conditional logback.xml generation (debug, JSON, ECS, file)</td>
-            <td>Deprecated</td>
-        </tr>
-        <tr>
-            <td><code>logback</code></td>
-            <td>Full logback.xml override with user-provided content</td>
-            <td>New</td>
-        </tr>
-        <tr>
-            <td><code>node.logging</code></td>
-            <td>Application-level config in <code>gravitee.yml</code> (MDC formatting, runtime patterns)</td>
-            <td>New</td>
-        </tr>
-    </tbody>
-</table>
+<table><thead><tr><th width="180">Block</th><th>Purpose</th><th width="150">Status</th></tr></thead><tbody><tr><td><code>logging</code></td><td>Conditional logback.xml generation (debug, JSON, ECS, file)</td><td>Deprecated</td></tr><tr><td><code>logback</code></td><td>Full logback.xml override with user-provided content</td><td>New</td></tr><tr><td><code>node.logging</code></td><td>Application-level config in <code>gravitee.yml</code> (MDC formatting, runtime patterns)</td><td>New</td></tr></tbody></table>
+
+### Legacy stdout encoders: JSON and ECS
+
+Within the deprecated `logging` block, the console appender encoder is selected by two flags, both `false` by default. They apply to both the Management API (`api.logging.stdout`) and the Gateway (`gateway.logging.stdout`).
+
+<table><thead><tr><th width="220">Helm value</th><th width="146.984375">Default</th><th>Effect</th></tr></thead><tbody><tr><td><code>logging.stdout.json</code></td><td><code>false</code></td><td>Emits each log line as JSON.</td></tr><tr><td><code>logging.stdout.ecs</code></td><td><code>false</code></td><td>Emits each log line in Elastic Common Schema (ECS) format.</td></tr></tbody></table>
+
+`json` takes precedence over `ecs`. When `logging.stdout.json` is `true`, JSON output is used and `logging.stdout.ecs` is ignored. ECS output applies only when `logging.stdout.json` is `false` and `logging.stdout.ecs` is `true`. When both are `false`, the console appender falls back to the pattern encoder. When ECS is enabled, the encoder sets a fixed service name: `gravitee-management-api` for the Management API and `gravitee-gateway` for the Gateway.
+
+**Example Gateway `values.yaml`:**
+
+```yaml
+gateway:
+  logging:
+    stdout:
+      json: false
+      ecs: true
+```
+
+For the ECS field reference, see the [Elastic Common Schema documentation](https://www.elastic.co/docs/reference/ecs).
 
 ### Logback override
 

--- a/docs/apim/4.12/create-and-configure-apis/apply-policies/policy-reference/ai-prompt-guard-rails.md
+++ b/docs/apim/4.12/create-and-configure-apis/apply-policies/policy-reference/ai-prompt-guard-rails.md
@@ -13,7 +13,7 @@ This policy uses an AI-powered text classification model to evaluate user prompt
 
 For LLM-backed APIs, the policy supports prompt injection detection using Llama Prompt Guard models (22M and 86M variants). These models identify attempts to override or manipulate system instructions in user prompts, returning `BENIGN` (safe prompt) or `MALICIOUS` (injection/jailbreak attempt). Both variants support 8 languages (English, French, German, Hindi, Italian, Portuguese, Spanish, Thai) and a 512-token context window. The 22M variant is recommended for production use due to superior accuracy and performance.
 
-Depending on configuration, when a prompt is flagged:
+Depending on the configuration, when a prompt is flagged:
 
 * **Blocked and flagged** – the request is denied at the gateway
 * **Allowed but flagged** – the request proceeds but is logged for monitoring
@@ -24,9 +24,9 @@ You may face an error when using this policy using the Gravitee's docker image. 
 
 ## Content Checks
 
-The Content Checks property specifies the classification labels that are applied to evaluate prompts. You should choose Labels in alignment with the selected model's capabilities and the intended filtering goals. For example, filtering for profanity while omitting toxicity checks.
+The `contentChecks` property is a comma-separated list of the classification labels the policy evaluates. The policy compares every label the model returns against this list using an exact, case-sensitive string match. Enter each label exactly as the model returns it, including case (`toxic`, not `TOXIC`). Whitespace around commas is ignored. Leave `contentChecks` empty to evaluate against every label the model returns.
 
-Supported labels are documented in the model’s card or configuration file.
+The valid labels depend on the model selected in the AI Model Text Classification resource. Each model returns its own fixed label set, for example, binary `toxic` / `not-toxic`, the six-label Jigsaw set, or `BENIGN` / `MALICIOUS` for the Llama Prompt Guard models. For the full per-model label list, see[ AI Model Text Classification - Model Reference and Performance Metrics.](ai-model-text-classification-model-reference-and-performance-metrics.md)
 
 ## AI Model Resource
 
@@ -35,7 +35,7 @@ The policy requires an **AI Model Text Classification Resource** to be defined a
 For more information about creating and managing resources, go to [Resources](https://documentation.gravitee.io/apim/policies/resources)
 
 {% hint style="info" %}
-The policy will load the model while handling the first request made to the API. Therefore, this first call will take longer than usual because it includes model loading time. Subsequent requests will be processed faster.  When multiple APIs use the same **AI Model Text Classification Resource**, the gateway will load it into memory only once. So if you have 50 APIs, each with the same resource, then the gateway only loads that model once.
+The policy will load the model while handling the first request made to the API. Therefore, this first call will take longer than usual because it includes model loading time. Subsequent requests will be processed faster. When multiple APIs use the same **AI Model Text Classification Resource**, the gateway will load it into memory only once. So if you have 50 APIs, each with the same resource, then the gateway only loads that model once.
 {% endhint %}
 
 After the resource is created, the policy must be configured with the corresponding name using the **AI Model Resource Name** property.

--- a/docs/apim/4.12/how-to-guides/use-case-tutorials/create-and-publish-an-api-using-the-management-api.md
+++ b/docs/apim/4.12/how-to-guides/use-case-tutorials/create-and-publish-an-api-using-the-management-api.md
@@ -186,6 +186,12 @@ You can now view your API in your Gravitee API Management Console. The API has t
 
 ## 7. (Optional) Publish the API to the Developer Portal
 
+{% hint style="info" %}
+Applies to publishing an API to the Classic Developer Portal
+
+For the New Developer Portal (released in v4.11) please see here: [structure-the-navigation-with-the-management-api.md](../../developer-portal/new-developer-portal/customize-the-navigation/structure-the-navigation-with-the-management-api.md "mention")
+{% endhint %}
+
 If you want to publish your API to the Developer Portal, you must modify its configuration. To modify the APIs configuration, complete the following steps:
 
 1. From the JSON response of the Create API Request, modify the `lifecycleState` attribute to value `PUBLISHED`, and then send the result in a `PUT` request like the following example:

--- a/docs/apim/4.12/release-information/changelog/apim-4.11.x.md
+++ b/docs/apim/4.12/release-information/changelog/apim-4.11.x.md
@@ -1,5 +1,49 @@
 # APIM 4.11.x
  
+## Gravitee API Management 4.11.7 - May 19, 2026
+<details>
+
+<summary>Bug Fixes</summary>
+
+**Gateway**
+
+* Health Check endpoint doesn't execute [#11394](https://github.com/gravitee-io/issues/issues/11394)
+* Gravitee API Product adoption issues [#11417](https://github.com/gravitee-io/issues/issues/11417)
+* Webhook subscriptions fail with NPE [#11419](https://github.com/gravitee-io/issues/issues/11419)
+
+**Management API**
+
+* APIM v4.11.x Failing Changeset || Orphan plans [#11365](https://github.com/gravitee-io/issues/issues/11365)
+* API Proxy deployment using Terraform provider fail [#11378](https://github.com/gravitee-io/issues/issues/11378)
+* Validation of duplicated context paths does not check secondary context paths [#11409](https://github.com/gravitee-io/issues/issues/11409)
+* Shared API key renewal persists new key with environmentId=null [#11439](https://github.com/gravitee-io/issues/issues/11439)
+* JDBC: Liquibase changeset 1.25.2-rebuild-key-pk-other precondition is schema-blind on Postgres/MSSQL/H2 [#11440](https://github.com/gravitee-io/issues/issues/11440)
+
+**Console**
+
+* Unable to Change the Custom Timeframe after Error [#11154](https://github.com/gravitee-io/issues/issues/11154)
+* Deprecated plans missing from Policy Studio for v4 APIs [#11399](https://github.com/gravitee-io/issues/issues/11399)
+* Payload Search Not Working [#11403](https://github.com/gravitee-io/issues/issues/11403)
+
+**Portal**
+
+* Payload Search Not Working [#11403](https://github.com/gravitee-io/issues/issues/11403)
+* Error 500 when trying to filter logs in the developer portal [#11405](https://github.com/gravitee-io/issues/issues/11405)
+
+</details>
+
+<details>
+
+<summary>Improvements</summary>
+
+**Management API**
+
+* Maintain an in-memory API path index to avoid full-catalog scan on path collision check [#11424](https://github.com/gravitee-io/issues/issues/11424)
+
+</details>
+
+
+ 
 ## Gravitee API Management 4.11.6 - May 7, 2026
 <details>
 


### PR DESCRIPTION
Auto-synced changes from `docs/apim/4.11/` to `docs/apim/4.12/`.

Triggered by push to `main` (ff9ef8de67e48e9d603b085d42608a84476168e5).