### PR TITLE
[sync] gko: 4.11 → 4.12

### DIFF
--- a/docs/gko/4.12/getting-started/quickstart-guide.md
+++ b/docs/gko/4.12/getting-started/quickstart-guide.md
@@ -141,7 +141,7 @@ managementcontext.gravitee.io/management-context-1 created
 
 Now that you've defined a way for GKO to communicate with a Gravitee API Management instance, you can create your first GKO-managed API.
 
-### Create an ApiV4Definition
+## Create an ApiV4Definition
 
 The `ApiV4Definition` CRD is used to create modern Gravitee v4 APIs (for all types of APIs, including HTTP, Event APIs, and AI Agentic services). It contains all of the parameters of a Gravitee API such as the entrypoint, endpoint, plans, policies, groups & members, and documentation pages. The CRD also lets you control whether the API is started or stopped, and whether or not it is published to the Developer Portal.
 
@@ -194,7 +194,7 @@ spec:
 There are a few things worth mentioning about the above resource:
 
 * This API definition references the `ManagementContext` we just created. This tells GKO to sync this API definition with the APIM installation referenced in the `ManagementContext`.
-* The API definition specifies that the API should be created in a `STARTED` state (i.e., deployed), and `PUBLISHED` on the Developer Portal with `PUBLIC` visibility.
+* The API definition specifies that the API should be created in a `STARTED` state (that is, deployed), and `PUBLISHED` on the Developer Portal with `PUBLIC` visibility.
 * The backend target (or "endpoint") for this API is a mock service hosted by Gravitee that echoes back information about the incoming call.
 
 Create the resource with the following command:

--- a/docs/gko/4.12/releases-and-changelog/changelog/gko-4.11.x.md
+++ b/docs/gko/4.12/releases-and-changelog/changelog/gko-4.11.x.md
@@ -5,6 +5,13 @@ noIndex: true
 
 # GKO 4.11.x
 
+## Gravitee Kubernetes Operator 4.11.7 - May 20, 2026
+
+There is nothing new in version 4.11.7.
+
+> This version was generated to keep the kubernetes operator in sync with other gravitee products.
+
+
 ## Gravitee Kubernetes Operator 4.11.6 - May 7, 2026
 
 There is nothing new in version 4.11.6.


### PR DESCRIPTION
Auto-synced changes from `docs/gko/4.11/` to `docs/gko/4.12/`.

Triggered by push to `main` (04503112e8632b0c83e1d7e28c3fa4c09e9cfe80).