### PR TITLE
[sync] am: 4.11 → 4.12

### DIFF
--- a/docs/am/4.12/releases-and-changelog/changelog/am-4.11.x.md
+++ b/docs/am/4.12/releases-and-changelog/changelog/am-4.11.x.md
@@ -6,6 +6,26 @@ description: >-
 
 # AM 4.11.x
 
+## Gravitee Access Management 4.11.5 - May 25, 2026
+
+<details>
+
+<summary>Bug fixes</summary>
+
+
+
+
+
+
+
+**Other**
+
+* Sync delay between GW when using DCR [#11443](https://github.com/gravitee-io/issues/issues/11443)
+* UI Crash on Device Deletion [#11446](https://github.com/gravitee-io/issues/issues/11446)
+
+</details>
+
+
 ## Gravitee Access Management 4.11.4 - May 15, 2026
 
 <details>


### PR DESCRIPTION
Auto-synced changes from `docs/am/4.11/` to `docs/am/4.12/`.

Triggered by push to `main` (e27a190605a9010158e272e6c3e4d4c0d8aae4d4).