### PR TITLE
add loopback, client_id, client_secret to Vale accept.txt

### DIFF
--- a/vale/styles/config/vocabularies/docs/accept.txt
+++ b/vale/styles/config/vocabularies/docs/accept.txt
@@ -199,6 +199,8 @@ Privileged Access Management
 Just-in-Time
 Human-in-the-Loop
 [Pp]asswordless
+client_id
+client_secret
 
 # ============================================
 # Java & JVM
@@ -262,6 +264,7 @@ SMTP
 URIs?
 URLs?
 [Ll]ocalhost
+[Ll]oopback
 Gzip
 CIDR
 SPA


### PR DESCRIPTION
Stops docs.Spelling from flagging these terms in OAuth/OIDC and SSRF-protection prose and surfacing nonsense suggestions like "roorback" for "loopback".