### PR TITLE
[sync] gko: 4.11 → 4.12

### DIFF
--- a/docs/gko/4.12/releases-and-changelog/changelog/gko-4.11.x.md
+++ b/docs/gko/4.12/releases-and-changelog/changelog/gko-4.11.x.md
@@ -2,15 +2,20 @@
 hidden: true
 noIndex: true
 ---
-
 # GKO 4.11.x
+
+## Gravitee Kubernetes Operator 4.11.8 - June 1, 2026
+
+There is nothing new in version 4.11.8.
+
+> This version was generated to keep the kubernetes operator in sync with other gravitee products.
+
 
 ## Gravitee Kubernetes Operator 4.11.7 - May 20, 2026
 
 There is nothing new in version 4.11.7.
 
 > This version was generated to keep the kubernetes operator in sync with other gravitee products.
-
 
 ## Gravitee Kubernetes Operator 4.11.6 - May 7, 2026
 
@@ -31,22 +36,16 @@ There is nothing new in version 4.11.3.
 > This version was generated to keep the kubernetes operator in sync with other gravitee products.
 
 ## Gravitee Kubernetes Operator 4.11.2 - April 21, 2026
-    
+
 <details>
+
 <summary>Bug fixes</summary>
 
-  **GKO**
+**GKO**
 
-  * Impossible to remove API or Application after subscription is updated  [#11331](https://github.com/gravitee-io/issues/issues/11331)
-  * Updating `ApiV4Definition` to change plan `generalConditions` to a new page HRID causes reconciliation failure (HTTP 500) [#11327](https://github.com/gravitee-io/issues/issues/11327)
+* Impossible to remove API or Application after subscription is updated [#11331](https://github.com/gravitee-io/issues/issues/11331)
+* Updating `ApiV4Definition` to change plan `generalConditions` to a new page HRID causes reconciliation failure (HTTP 500) [#11327](https://github.com/gravitee-io/issues/issues/11327)
 
-## Gravitee Kubernetes Operator 4.11.1 - April 21, 2026
-    
-<details>
-<summary>Improvements</summary>
-
-  **GKO**
-
-  * Allow HTTP route to shortcut the API controller [#11342](https://github.com/gravitee-io/issues/issues/11342)
+### Gravitee Kubernetes Operator 4.11.1 - April 21, 2026
 
 </details>


### PR DESCRIPTION
Auto-synced changes from `docs/gko/4.11/` to `docs/gko/4.12/`.

Triggered by push to `main` (a85bd059b3033c3597f20eda42888bf51730d678).