### PR TITLE
[sync] gko: 4.11 → 4.12

### DIFF
--- a/docs/gko/4.12/releases-and-changelog/changelog/gko-4.11.x.md
+++ b/docs/gko/4.12/releases-and-changelog/changelog/gko-4.11.x.md
@@ -4,6 +4,13 @@ noIndex: true
 ---
 # GKO 4.11.x
 
+## Gravitee Kubernetes Operator 4.11.9 - June 2, 2026
+
+There is nothing new in version 4.11.9.
+
+> This version was generated to keep the kubernetes operator in sync with other gravitee products.
+
+
 ## Gravitee Kubernetes Operator 4.11.8 - June 1, 2026
 
 There is nothing new in version 4.11.8.


### PR DESCRIPTION
Auto-synced changes from `docs/gko/4.11/` to `docs/gko/4.12/`.

Triggered by push to `main` (6a2fcc4c9f795a4348f130cc976d5c0dcd27db23).