### PR TITLE
[sync] apim: 4.11 → 4.12

### DIFF
--- a/docs/apim/4.12/configure-and-manage-the-platform/gravitee-gateway/gateway-cluster-sync-with-redis/README.md
+++ b/docs/apim/4.12/configure-and-manage-the-platform/gravitee-gateway/gateway-cluster-sync-with-redis/README.md
@@ -1,16 +1,18 @@
 # Gateway Cluster sync with Redis
 
-<table data-view="cards"><thead><tr><th></th><th data-hidden data-card-target data-type="content-ref"></th></tr></thead><tbody><tr><td>Gateway Cluster sync with Redis using Docker</td><td><a href="/pages/hdA1xgOXoQv3F8mMtmu6">/pages/hdA1xgOXoQv3F8mMtmu6</a></td></tr><tr><td>Gateway Cluster sync with Redis using Kubernetes (Helm)</td><td><a href="/pages/U7yxqaXkRHlwXHforlVl">/pages/U7yxqaXkRHlwXHforlVl</a></td></tr></tbody></table>
+## Gateway Cluster sync with Redis
 
-## Overview
+<table data-view="cards"><thead><tr><th></th><th data-hidden data-card-target data-type="content-ref"></th></tr></thead><tbody><tr><td>Gateway Cluster sync with Redis using Docker</td><td><a href="gateway-cluster-sync-with-redis-using-docker.md">gateway-cluster-sync-with-redis-using-docker.md</a></td></tr><tr><td>Gateway Cluster sync with Redis using Kubernetes (Helm)</td><td><a href="gateway-cluster-sync-with-redis-using-kubernetes-helm.md">gateway-cluster-sync-with-redis-using-kubernetes-helm.md</a></td></tr></tbody></table>
 
-### What is Gateway Cluster sync with Redis?
+### Overview
+
+#### What is Gateway Cluster sync with Redis?
 
 This guide explains how to enable and configure the Gateway Cluster sync with Redis.
 
 The Gateway Cluster sync uses Redis to synchronize the state of APIs, API Keys, Subscriptions, Dictionaries, and Organizations across your API Gateways. This process maintains the state in memory, which ensures that API Gateways remain resilient and high-performing, even if the main repository is down.
 
-### What issue does it solve?
+#### What issue does it solve?
 
 The Gateway Cluster sync improves both scalability and resilience.
 
@@ -18,7 +20,7 @@ The Gateway Cluster sync improves both scalability and resilience.
 
 **Resilience & High Availability**: By maintaining the state in Redis, new API Gateway instances can start and serve API traffic even if the central management repository or control plane is down. This ensures that you do not risk API outages during database maintenance or network disruptions.
 
-### How does it work?
+#### How does it work?
 
 The new repository scope, `Distributed Sync`, is responsible for keeping the sync state for a cluster.
 
@@ -28,9 +30,7 @@ This allows another node to take over if the current primary node goes down with
 
 When you enable the Gateway Cluster sync on your API Gateways, the primary node fetches the API definitions from the management repository, and then stores them in the Redis distributed sync repository. The other API Gateways read the API definitions from the Redis distributed sync repository.
 
-<figure><img src="/files/cUt5d0QSrBaEhYroyb9M" alt="Gateway Cluster sync with Redis architecture diagram"><figcaption><p>Gateway Cluster sync architecture</p></figcaption></figure>
-
-### Distributed Synchronization State
+#### Distributed Synchronization State
 
 The Synchronization State tracks the current sync process. It contains the following information:
 
@@ -39,7 +39,7 @@ The Synchronization State tracks the current sync process. It contains the follo
 * Node ID.
 * Last successful synchronization timeframe.
 
-### Distributed Synchronization Event
+#### Distributed Synchronization Event
 
 The objects are used to know what needs to be deployed or undeployed across the cluster. They contain the following information:
 
@@ -51,10 +51,9 @@ The objects are used to know what needs to be deployed or undeployed across the 
 
 After any business object is deployed, and only if distributed sync is enabled, the primary node stores those objects in the new distributed sync repository.
 
+***
 
----
-
-# Agent Instructions: Querying This Documentation
+## Agent Instructions: Querying This Documentation
 
 If you need additional information that is not directly available in this page, you can query the documentation dynamically by asking a question.
 
@@ -64,7 +63,6 @@ Perform an HTTP GET request on the current page URL with the `ask` query paramet
 GET https://documentation.gravitee.io/apim/4.10/configure-and-manage-the-platform/gravitee-gateway/gateway-cluster-sync-with-redis.md?ask=<question>
 ```
 
-The question should be specific, self-contained, and written in natural language.
-The response will contain a direct answer to the question and relevant excerpts and sources from the documentation.
+The question should be specific, self-contained, and written in natural language. The response will contain a direct answer to the question and relevant excerpts and sources from the documentation.
 
 Use this mechanism when the answer is not explicitly present in the current page, you need clarification or additional context, or you want to retrieve related documentation sections.

--- a/docs/apim/4.12/create-and-configure-apis/configure-v2-apis/documentation.md
+++ b/docs/apim/4.12/create-and-configure-apis/configure-v2-apis/documentation.md
@@ -41,9 +41,6 @@ To import documentation:
        * SWAGGER
        * MARKDOWN
      * At the bottom of the configuration page, click **Choose File**.
-     * For OpenAPI Specification imports, configure options:
-       * Enable **Create documentation page from spec** to generate a Documentation page from the imported OpenAPI specification
-       * Enable **Add OpenAPI Specification Validation policy** to attach the OAS Validation policy to generated flows (enabled by default if the policy is installed in the gateway; requires policy installation)
      * After you select your file, click **SAVE**.
 
 ## Create API documentation
@@ -63,7 +60,7 @@ To import documentation:
    3. Define how to create, or get, the documentation content:
       * Fill in the documentation inline yourself: If you select this option, you'll be given the option to start typing your documentation
       * Import the documentation from a file
-      * Import documentation from an external source: Gravitee supports Bitbucket, git repository, GitHub, GitLab, and public URLs
+      * Import documentation from an external source: Gravitee supports Bitbucket, git repository, Github, GitLab, and public URLs
 8. Click **SAVE**
 
 ## Add API metadata

--- a/docs/apim/4.12/create-and-configure-apis/create-apis/import-apis.md
+++ b/docs/apim/4.12/create-and-configure-apis/create-apis/import-apis.md
@@ -17,10 +17,6 @@ All items from the import bundle are imported, for example, groups, members, pag
 
 Additional information that applies to importing an OpenAPI specification can be found [below](import-apis.md#importing-an-openapi-spec).
 
-For v4 APIs, Import on the API details page opens an Update API dialog that replaces the current API from an imported definition. Creating a new API from a file uses the separate Import API wizard, which is Add API, and then Import v4 API. The modal accepts **Gravitee v4 Definition**, which is applicable to all v4 API types except Federated A2A agents and **OpenAPI Specification**, which is applicable to v4 HTTP Proxy APIs only. WSDL is displayed but currently disabled. The imported file fully overwrites the API configuration, including endpoints, flows, plans, pages, and metadata. The API ID, deployment state, and origin metadata are preserved. Plans absent from the import are deleted. Pages and flows are matched by identifier or key and updated in place; unmatched items are removed. The update is atomic.
-
-For v2 APIs, the Import button continues to open the legacy import dialog.
-
 {% hint style="warning" %}
 When you import an API with a JSON payload that has duplicate keys, APIM keeps the last key.
 
@@ -157,7 +153,7 @@ To use a vendor extension, add the `x-graviteeio-definition` field at the root o
   * URL
 * Picture only accepts Data-URI format. Please see the example below.
 
-<pre class="language-yaml" data-title="Example"><code class="lang-yaml"><strong>OpenAPI: "3.0.0"
+<pre class="language-yaml" data-title="Example"><code class="lang-yaml"><strong>openapi: "3.0.0"
 </strong>info:
   version: 1.2.3
   title: Gravitee Echo API

--- a/docs/apim/4.12/create-and-configure-apis/gravitee-api-definitions/execution-engine.md
+++ b/docs/apim/4.12/create-and-configure-apis/gravitee-api-definitions/execution-engine.md
@@ -95,6 +95,7 @@ The following comparisons can be made between the reactive and legacy execution 
 * [Plan selection](execution-engine.md#plan-selection)
 * [Flow](execution-engine.md#flow)
 * [Logging](execution-engine.md#logging)
+* [Client disconnection](execution-engine.md#client-disconnection)
 * [Expression Language](execution-engine.md#expression-language)
 * [Bad requests](execution-engine.md#bad-requests)
 * [Origin validation](execution-engine.md#origin-validation)
@@ -268,6 +269,28 @@ The reactive execution engine implements the following improvements:
 <figure><img src="../../.gitbook/assets/event-native-api-management-logging-2.png" alt=""><figcaption><p>Sample 502 log with the reactive execution engine</p></figcaption></figure>
 {% endtab %}
 {% endtabs %}
+
+### Client disconnection
+
+A client disconnection happens when a client cancels a request before the Gateway receives a response from the backend. The two execution engines record this scenario differently.
+
+{% tabs %}
+{% tab title="Legacy engine behavior" %}
+When using the legacy execution engine, a client disconnection that occurs before the Gateway receives a response from the backend isn't surfaced in the Gateway logs and analytics. The call isn't recorded with a `499` status code.
+{% endtab %}
+
+{% tab title="Reactive engine improvements" %}
+When using the reactive execution engine, a client disconnection that occurs before the Gateway receives a response from the backend is detected and recorded with the HTTP status code `499` in the Gateway logs and analytics. v2 Gateway APIs running in [emulation mode](execution-engine.md#v2-gateway-api-emulation-mode) apply this behavior as well.
+
+This accurately reflects the state of the transaction. A `499` status code that appears after you enable emulation mode isn't necessarily a regression. It surfaces client-side cancellations, such as a proxy timeout, a load balancer timeout, or a manual cancellation, that previously went unrecorded.
+{% endtab %}
+{% endtabs %}
+
+{% hint style="info" %}
+**Migration considerations**
+
+After you enable emulation mode on a v2 Gateway API, the number of `499` status codes in the Gateway logs and analytics often increases. This is expected. The reactive engine records client disconnections that the legacy engine left unrecorded, so these entries reflect existing client-side cancellations rather than a new failure.
+{% endhint %}
 
 ### Expression Language
 

--- a/docs/apim/4.12/release-information/changelog/apim-4.11.x.md
+++ b/docs/apim/4.12/release-information/changelog/apim-4.11.x.md
@@ -60,6 +60,20 @@
 * DCR configuration UI: clarify {#client_id} placeholder and fix example renew secret endpoint [#11430](https://github.com/gravitee-io/issues/issues/11430)
 * Cap `count()` cost on paginated Mongo repository searches with `maxTimeMS` [#11438](https://github.com/gravitee-io/issues/issues/11438)
 
+**New indexes**
+* Added the following indexes, which you can add manually before you upgrade to 4.11.9:
+```bash
+db.apis.createIndex({ environmentId:1, categories:1, name:1 }, { name: "ei1c1n1" });
+  db.apis.createIndex({ environmentId:1, definitionVersion:1, name:1 }, { name: "ei1dv1n1" });
+  db.keys.createIndex({ environmentId:1, updatedAt:1, _id:1 }, { name: "e1ua1i1" });
+  db.keys.createIndex({ revoked:1, expireAt:1 }, { name: "r1ea1" });
+  db.plans.createIndex({ crossId:1 }, { name: "ci1" });
+  db.subscriptions.createIndex({ environmentId:1, updatedAt:1, _id:1 }, { name: "e1ua1i1" });
+  db.subscriptions.createIndex({ plan:1, _id:1 }, { name: "p1i1" });
+  db.subscriptions.createIndex({ plan:1, updatedAt:1 }, { name: "p1ua1" });
+  db.subscriptions.createIndex({ status:1, endingAt:1 }, { name: "s1ea1" });
+  db.audits.createIndex({ environmentId:1, createdAt:1 }, { name: "e1c1" });
+```
 </details>
 
 


### PR DESCRIPTION
Auto-synced changes from `docs/apim/4.11/` to `docs/apim/4.12/`.

Triggered by push to `main` (a8e047edc345bd350ac2c91efb0c644e4fbf5079).