### PR TITLE
docs: accept WSDL casing in Vale vocabulary

### DIFF
--- a/vale/styles/config/vocabularies/docs/accept.txt
+++ b/vale/styles/config/vocabularies/docs/accept.txt
@@ -685,7 +685,7 @@ ratelimiting
 goroutines
 classloader
 throwable
-wsdl
+WSDL
 statsd
 healthz
 middleware


### PR DESCRIPTION
## What
Change the Vale vocabulary entry `wsdl` → `WSDL`.

## Why
`Vale.Terms` enforces the casing listed in the vocabulary. The entry was lowercase (`wsdl`), so Vale flagged the uppercase acronym **`WSDL`** and suggested lowercasing it (for example, on #1534).

`WSDL` is an initialism (Web Services Description Language) and is written uppercase across the docs (20+ files), consistent with the other acronyms already in the vocabulary (`API`, `REST`, `OpenAPI`, `SOAP`, `JSON`, `YAML`). There's no legitimate lowercase `wsdl` usage (no `.wsdl` extensions in prose).

Updating the entry to `WSDL` makes the correct uppercase casing pass Vale.

