### PR TITLE
docs(apim): fix broken Roles and Groups Mapping link on Microsoft Entra ID page (4.9, 4.11, 4.12)

### DIFF
--- a/docs/apim/4.11/configure-and-manage-the-platform/manage-organizations-and-environments/authentication/microsoft-entra-id.md
+++ b/docs/apim/4.11/configure-and-manage-the-platform/manage-organizations-and-environments/authentication/microsoft-entra-id.md
@@ -134,7 +134,7 @@ To avoid the use of a previous token or misconfiguration, reset the cache of you
 
 ### **Permissions, groups and roles**
 
-You can manually customize permissions, groups, and roles for new users, or use the automatic Roles and Groups Mapping feature. For more information about Roles and Mappings, see [broken-reference](../../../../4.9/configure-and-manage-the-platform/manage-organizations-and-environments/authentication/broken-reference/ "mention").
+You can manually customize permissions, groups, and roles for new users, or use the automatic Roles and Groups Mapping feature. For more information about Roles and Mappings, see [roles-and-groups-mapping.md](roles-and-groups-mapping.md "mention").
 
 ### **Groups Mapping**
 

--- a/docs/apim/4.12/configure-and-manage-the-platform/manage-organizations-and-environments/authentication/microsoft-entra-id.md
+++ b/docs/apim/4.12/configure-and-manage-the-platform/manage-organizations-and-environments/authentication/microsoft-entra-id.md
@@ -134,7 +134,7 @@ To avoid the use of a previous token or misconfiguration, reset the cache of you
 
 ### **Permissions, groups and roles**
 
-You can manually customize permissions, groups, and roles for new users, or use the automatic Roles and Groups Mapping feature. For more information about Roles and Mappings, see [broken-reference](../../../../4.9/configure-and-manage-the-platform/manage-organizations-and-environments/authentication/broken-reference/ "mention").
+You can manually customize permissions, groups, and roles for new users, or use the automatic Roles and Groups Mapping feature. For more information about Roles and Mappings, see [roles-and-groups-mapping.md](roles-and-groups-mapping.md "mention").
 
 ### **Groups Mapping**
 

--- a/docs/apim/4.9/configure-and-manage-the-platform/manage-organizations-and-environments/authentication/microsoft-entra-id.md
+++ b/docs/apim/4.9/configure-and-manage-the-platform/manage-organizations-and-environments/authentication/microsoft-entra-id.md
@@ -103,7 +103,7 @@ To avoid the use of a previous token or misconfiguration, reset the cache of you
 
 ### **Permissions, groups and roles**
 
-You can manually customize permissions, groups, and roles for new users, or use the automatic Roles and Groups Mapping feature. For more information about Roles and Mappings, see [broken-reference](broken-reference/ "mention").
+You can manually customize permissions, groups, and roles for new users, or use the automatic Roles and Groups Mapping feature. For more information about Roles and Mappings, see [roles-and-groups-mapping.md](roles-and-groups-mapping.md "mention").
 
 ### **Groups Mapping**
 


### PR DESCRIPTION
## What

The **Permissions, groups and roles** section on the Microsoft Entra ID authentication page links to a GitBook \`broken-reference\` instead of the **Roles and Groups Mapping** documentation page. On the published site this renders as a dead/incorrect link.

Reported page: https://documentation.gravitee.io/apim/configure-and-manage-the-platform/manage-organizations-and-environments/authentication/microsoft-entra-id#permissions-groups-and-roles

## Fix

Point the link to the sibling \`roles-and-groups-mapping.md\` page, which exists in each affected version's \`authentication/\` folder and is the page the sentence references. This matches the already-correct pattern in APIM 4.7 and 4.8.

| Version | Before | After |
|---------|--------|-------|
| 4.9 | \`[broken-reference](broken-reference/ "mention")\` | \`[roles-and-groups-mapping.md](roles-and-groups-mapping.md "mention")\` |
| 4.11 | \`[broken-reference](../../../../4.9/.../broken-reference/ "mention")\` | \`[roles-and-groups-mapping.md](roles-and-groups-mapping.md "mention")\` |
| 4.12 | \`[broken-reference](../../../../4.9/.../broken-reference/ "mention")\` | \`[roles-and-groups-mapping.md](roles-and-groups-mapping.md "mention")\` |