### PR TITLE
Add ENUM, lowercase "rest", and "enablement" to Vale vocabulary

### DIFF
--- a/vale/styles/config/vocabularies/docs/accept.txt
+++ b/vale/styles/config/vocabularies/docs/accept.txt
@@ -26,6 +26,8 @@ APIs
 API's
 REST
 RESTful
+# allow the lowercase English word "rest" so Vale.Terms stops treating it as the REST acronym
+rest
 GraphQL
 gRPC
 AsyncAPI
@@ -449,7 +451,7 @@ async
 [Mm]anagement [Cc]onsole
 [Aa]llows?
 [Aa]gainst
-[Ee]num[s]?
+[Ee]num[s]?|ENUM
 [Rr]eorderable
 [Dd]rag and [Dd]rop
 [Cc]allout[s]?
@@ -558,6 +560,7 @@ Snappy
 # ============================================
 Jira
 GAP
+enablement
 
 # ============================================
 # Spell-check sweep additions (2026-05-29)


### PR DESCRIPTION
## What

Three additions to the Vale `docs` vocabulary (`vale/styles/config/vocabularies/docs/accept.txt`) to stop false positives that have been blocking docs PRs:

| Term | Change | Why |
|------|--------|-----|
| `ENUM` | Widened the entry `[Ee]num[s]?` to `[Ee]num[s]?\|ENUM` | The all-caps literal `ENUM` is a filter field **type token** in tables (alongside `KEYWORD`). Vale.Terms matched it case-insensitively against the existing regex and parroted the regex back as the "fix". A standalone `ENUM` line does **not** work — the existing regex keeps firing — so the regex itself had to be widened. |
| `rest` | Added lowercase `rest` | Vale.Terms was flagging the ordinary English word "rest" (for example, "a `+N` badge for the rest") as the `REST` acronym. |
| `enablement` | Added to the spelling vocabulary | `docs.Spelling` flagged it as not in the approved vocabulary. |


