### PR TITLE
chore(apim-4.8): remove tech preview labels

### DIFF
--- a/docs/apim/4.8/developer-portal/new-developer-portal/4.9-customize-the-homepage.md
+++ b/docs/apim/4.8/developer-portal/new-developer-portal/4.9-customize-the-homepage.md
@@ -8,9 +8,6 @@ noIndex: true
 
 ## Overview
 
-{% hint style="warning" %}
-This feature is in tech preview.
-{% endhint %}
 
 In the New Developer Portal, you can customize the homepage of your Developer Portal with standard Markdown and Gravitee Markdown (GMD). Gravitee Markdown is standard Markdown enriched with custom Gravitee components.
 

--- a/docs/apim/4.8/developer-portal/new-developer-portal/4.9-layout-and-theme.md
+++ b/docs/apim/4.8/developer-portal/new-developer-portal/4.9-layout-and-theme.md
@@ -6,9 +6,6 @@ noIndex: true
 
 # 4.9 Layout and Theme
 
-{% hint style="warning" %}
-This feature is in tech preview.
-{% endhint %}
 
 ## Update the Category layout
 

--- a/docs/apim/4.8/developer-portal/new-developer-portal/README.md
+++ b/docs/apim/4.8/developer-portal/new-developer-portal/README.md
@@ -4,9 +4,6 @@ description: Tutorial on new developer portal.
 
 # New Developer Portal
 
-{% hint style="warning" %}
-This feature is in tech preview.
-{% endhint %}
 
 Select from the tiles below for detailed descriptions of the new Developer Portal's features and functionality, as well as step-by-step instructions for how to use them. For more information about the New Developer Portal, see the following articles:
 

--- a/docs/apim/4.8/developer-portal/new-developer-portal/application-logs.md
+++ b/docs/apim/4.8/developer-portal/new-developer-portal/application-logs.md
@@ -4,9 +4,6 @@ description: Documentation about application logs in the context of APIs.
 
 # Application Logs
 
-{% hint style="warning" %}
-This feature is in tech preview.
-{% endhint %}
 
 As an API subscriber, you can view paginated logs for all of the APIs your application has subscribed to. The list of logs displays the name, timestamp, HTTP method, and response status of each API.
 

--- a/docs/apim/4.8/developer-portal/new-developer-portal/configure-the-new-portal.md
+++ b/docs/apim/4.8/developer-portal/new-developer-portal/configure-the-new-portal.md
@@ -4,9 +4,6 @@ description: An overview about configure the new portal.
 
 # Configure the New Portal
 
-{% hint style="warning" %}
-This feature is in tech preview.
-{% endhint %}
 
 ## Overview
 

--- a/docs/apim/4.8/developer-portal/new-developer-portal/configure-webhook-subscriptions.md
+++ b/docs/apim/4.8/developer-portal/new-developer-portal/configure-webhook-subscriptions.md
@@ -4,9 +4,6 @@ description: Configuration guide for configure webhook subscriptions.
 
 # Configure Webhook Subscriptions
 
-{% hint style="warning" %}
-This feature is in tech preview.
-{% endhint %}
 
 ## Prerequisites
 

--- a/docs/apim/4.8/developer-portal/new-developer-portal/layout-and-theme.md
+++ b/docs/apim/4.8/developer-portal/new-developer-portal/layout-and-theme.md
@@ -4,9 +4,6 @@ description: Documentation about layout and theme in the context of APIs.
 
 # Layout and Theme
 
-{% hint style="warning" %}
-This feature is in tech preview.
-{% endhint %}
 
 ## Update the Category layout
 

--- a/docs/apim/4.8/terraform/README.md
+++ b/docs/apim/4.8/terraform/README.md
@@ -4,9 +4,6 @@ description: Configuration guide for terraform.
 
 # Terraform
 
-{% hint style="warning" %}
-This feature is in tech preview.
-{% endhint %}
 
 Terraform lets you use configuration files to build and manage your infrastructure. Starting with Gravitee 4.8, local installations of Gravitee support Terraform for an Infrastructure as Code (IaC) approach to API management. This enables users to automate and version control Gravitee APIs.
 

--- a/docs/apim/4.8/terraform/define-an-apim-service-account-for-terraform.md
+++ b/docs/apim/4.8/terraform/define-an-apim-service-account-for-terraform.md
@@ -6,9 +6,6 @@ description: An overview about define an apim service account for terraform.
 
 ## Overview
 
-{% hint style="warning" %}
-This feature is in tech preview.
-{% endhint %}
 
 For Terraform to use APIM, it needs to authenticate as a user of the APIM instance.
 

--- a/docs/apim/4.8/terraform/example-resource-configurations.md
+++ b/docs/apim/4.8/terraform/example-resource-configurations.md
@@ -6,9 +6,6 @@ description: An overview about gravitee resources.
 
 ## Overview
 
-{% hint style="warning" %}
-This feature is in tech preview.
-{% endhint %}
 
 Terraform defines resources as basic infrastructure elements. It creates and manages these resources as part of its Infrastructure as Code (IaC) workflow. This lets you use configuration files to automate reproducible and version controlled APIs.
 

--- a/docs/apim/4.8/terraform/quick-start-guide.md
+++ b/docs/apim/4.8/terraform/quick-start-guide.md
@@ -6,9 +6,6 @@ description: An overview about quick start guide.
 
 ## Overview
 
-{% hint style="warning" %}
-This feature is in tech preview.
-{% endhint %}
 
 Terraform lets you manage APIs and other entities via configuration instead of through manual updates in the APIM Console. This lets you automate and version changes to your APIM instance for an Infrastructure as Code (IaC) experience.
 


### PR DESCRIPTION
## Summary

- Removes all Tech Preview `{% hint %}` blocks from 11 APIM 4.8 docs pages (terraform, new developer portal)

## Files changed

| Area | Files |
|---|---|
| Terraform | `README.md`, `quick-start-guide.md`, `define-an-apim-service-account-for-terraform.md`, `example-resource-configurations.md` |
| New Developer Portal | `README.md`, `configure-the-new-portal.md`, `application-logs.md`, `4.9-customize-the-homepage.md`, `configure-webhook-subscriptions.md`, `layout-and-theme.md`, `4.9-layout-and-theme.md` |

## Test plan

- [ ] Verify no remaining tech preview hint blocks in `docs/apim/4.8`
- [ ] Check rendered pages for each changed file to confirm clean layout after hint block removal

🤖 Generated with [Claude Code](https://claude.com/claude-code)