### PR TITLE
chore(apim-4.7): remove tech preview labels

### DIFF
--- a/docs/apim/4.7/developer-portal/new-developer-portal/configure-the-new-portal.md
+++ b/docs/apim/4.7/developer-portal/new-developer-portal/configure-the-new-portal.md
@@ -4,9 +4,6 @@ description: An overview about configure the new portal.
 
 # Configure the New Portal
 
-{% hint style="warning" %}
-This feature is in tech preview.
-{% endhint %}
 
 ## Overview
 


### PR DESCRIPTION
## Summary

- Removes the Tech Preview `{% hint %}` block from 1 APIM 4.7 docs page (new developer portal)

## Files changed

| Area | Files |
|---|---|
| New Developer Portal | `configure-the-new-portal.md` |

## Test plan

- [ ] Verify no remaining tech preview hint blocks in `docs/apim/4.7`
- [ ] Check rendered page to confirm clean layout after hint block removal

🤖 Generated with [Claude Code](https://claude.com/claude-code)