### PR TITLE
[sync] apim: 4.11 → 4.12

### DIFF
--- a/docs/apim/4.12/release-information/changelog/apim-4.11.x.md
+++ b/docs/apim/4.12/release-information/changelog/apim-4.11.x.md
@@ -1,5 +1,55 @@
 # APIM 4.11.x
  
+## Gravitee API Management 4.11.10 - June 8, 2026
+<details>
+
+<summary>Bug Fixes</summary>
+
+**Gateway**
+
+* BUG: LLM_PROXY, Bedrock streaming [#11426](https://github.com/gravitee-io/issues/issues/11426)
+* \[Kafka Topic Mapping policy] OffsetFetch fails with UNKNOWN_SERVER_ERROR when client requests offsets for all topics of a group [#11495](https://github.com/gravitee-io/issues/issues/11495)
+
+**Management API**
+
+* MCP Tool Generation – Nullable field handling in generated inputSchema (OpenAPI import) [#11340](https://github.com/gravitee-io/issues/issues/11340)
+* API rollback of undeployed changes leaves API in "out of sync" state [#11459](https://github.com/gravitee-io/issues/issues/11459)
+* V4 _import/crd create path ignores flowExecution and persists defaults (mode=default, matchRequired=false) [#11476](https://github.com/gravitee-io/issues/issues/11476)
+* encodage UTF-8 [#11480](https://github.com/gravitee-io/issues/issues/11480)
+* JDBC: gateway warmup ApiKey appender Seq-scans key_subscriptions (missing subscription_id index) [#11494](https://github.com/gravitee-io/issues/issues/11494)
+* Group error when updating V2 API settings after upgrade to 4.11.9, 4.10.16, 4.9.21 or 4.8.28 [#11510](https://github.com/gravitee-io/issues/issues/11510)
+
+**Console**
+
+* SharedPolicyGroup for API Message are undeployable [#11182](https://github.com/gravitee-io/issues/issues/11182)
+* Platform alert API filter dropdown fails to load any APIs (v2 or v4) in v4.8.8 [#11466](https://github.com/gravitee-io/issues/issues/11466)
+* Documentation - Swagger viewing issue  [#11485](https://github.com/gravitee-io/issues/issues/11485)
+* Observability & Analytics Sidebar Navigation Broken in APIM 4.11.x [#11505](https://github.com/gravitee-io/issues/issues/11505)
+
+**Portal**
+
+* Query params for Try it out does not work [#11481](https://github.com/gravitee-io/issues/issues/11481)
+
+**Other**
+
+* Allow default role mapping through API V2 group endpoint [#11300](https://github.com/gravitee-io/issues/issues/11300)
+* Token type validation disabled still rejects tokens with typ: JWS due to restrictive Nimbus default verifier [#11380](https://github.com/gravitee-io/issues/issues/11380)
+* SSO Icon icons/thirdparty.svg not displaying in dev portal -> login [#11418](https://github.com/gravitee-io/issues/issues/11418)
+
+</details>
+
+<details>
+
+<summary>Improvements</summary>
+
+**Other**
+
+* HTTP Callout Policy "Request body" needs to support multi-line UI. [#11504](https://github.com/gravitee-io/issues/issues/11504)
+
+</details>
+
+
+ 
 ## Gravitee API Management 4.11.9 - June 1, 2026
 <details>
 

--- a/docs/apim/4.12/terraform/README.md
+++ b/docs/apim/4.12/terraform/README.md
@@ -19,9 +19,15 @@ Click on the cards below to learn more about Gravitee's Terraform provider. If y
 Users of OpenTofu can use the APIM provider as well: [https://search.opentofu.org/provider/gravitee-io/apim/latest](https://search.opentofu.org/provider/gravitee-io/apim/latest)
 {% endhint %}
 
-<table data-view="cards"><thead><tr><th data-type="content-ref"></th><th data-hidden data-card-cover data-type="files"></th></tr></thead><tbody>
-<tr><td><a href="quick-start-guide.md">quick-start-guide.md</a></td><td></td></tr>
-<tr><td><a href="example-resource-configurations.md">example-resource-configurations.md</a></td><td></td></tr>
-<tr><td><a href="release-notes.md">release-notes.md</a></td><td></td></tr>
-<tr><td><a href="changelog.md">changelog.md</a></td><td></td></tr>
-</tbody></table>
+## Compatibility matrix
+
+As it remains a tech preview, support is done in best effort mode where fixes are mainly done on the latest version or the provider.
+
+| Provider version | APIM version                                                                | Terraform/OpenTofu qualified versions |
+| ---------------- | --------------------------------------------------------------------------- | ------------------------------------- |
+| 0.5.x            | <p>4.11.x <br><sub><em>(4.10.x / 4.9.x without new features)</em></sub></p> | 1.9 + latest / latest                 |
+| 0.4.x            | 4.10.x / 4.9.x                                                              | 1.10 to latest / latest               |
+| 0.3.x            | 4.9.x / 4.10.x                                                              | 1.10 to latest / latest               |
+| 0.2.x            | 4.8.x                                                                       | 1.10 to 1.12 / not supported          |
+
+<table data-view="cards"><thead><tr><th data-type="content-ref"></th><th data-hidden data-card-cover data-type="files"></th></tr></thead><tbody><tr><td><a href="quick-start-guide.md">quick-start-guide.md</a></td><td></td></tr><tr><td><a href="example-resource-configurations.md">example-resource-configurations.md</a></td><td></td></tr></tbody></table>

--- a/docs/apim/4.12/terraform/example-resource-configurations.md
+++ b/docs/apim/4.12/terraform/example-resource-configurations.md
@@ -22,15 +22,12 @@ Terraform uses your configuration files to track the state of your infrastructur
 
 The Gravitee Terraform provider supports the following Gravitee resource types:
 
-* HTTP proxy API
-* Message API (protocol mediation)
-* Kafka Native API
-* AI proxy APIs (MCP, A2A, LLM)
+* v4 HTTP proxy API
+* v4 message API
+* v4 Native Kafka API
 * Shared Policy Group
 * Application
 * Subscription
-* Group
-* Dictionary
 
 Terraform can create, update, or delete these resources as part of its workflow.
 
@@ -38,18 +35,53 @@ Terraform can create, update, or delete these resources as part of its workflow.
 Guides and examples can be found in the [Gravitee "apim" Terraform Registry documentation](https://registry.terraform.io/providers/gravitee-io/apim/latest/docs).
 {% endhint %}
 
+## Release notes
 
-## Automation API gaps
+These are the changes for version 0.5.x
 
-Missing properties or values in regards of the Management API:
+### Features
+
+* Application supports multiple mTLS client certificates with optional start/end dates
+* Subscription metadata support
+* Experimental: API HCL export
+
+### Improvements
+
+* More tutorials in the registry docs
+* `failure_condition` and `force_next_endpoint_on_failure` have been added to the API's failover configuration
+
+### Bugs
+
+* Subscription `plan_hrid` update is silently ignored by the API
+
+### Notable changes
+
+* The endpoint name is now mandatory
+* Flow phase, hence flow property `connect` has been renamed to `entrypoint_connect` for `NATIVE` APIs
+
+### Known limitations
+
+The following known limitations apply to the 0.5.x version of the Gravitee Terraform provider:
+
+* When you run `terraform plan` for APIs, several differences exist between state and remote. These do not impact runtime and will be fixed in upcoming patches.
+  * State stores the dynamic properties service configuration as an encoded JSON string instead of plain JSON.
+  * The encrypted properties payload is marked as changed because encrypted values replace unencrypted values.
+* APIKey subscriptions are not supported.
+
+
+### Automation API: missing properties (4.11, Terraform 0.5.x)
 
 | Resource          | Section                   | Missing Property                   | Type                                  | Supported in Automation API                                           |
 |-------------------|---------------------------|------------------------------------|---------------------------------------|-----------------------------------------------------------------------|
+| apim_apiv4        |                           | `allowedInApiProducts`             | boolean                               | No                                                                    |
+| apim_apiv4        |                           | `allowMultiJwtOauth2Subscriptions` | boolean                               | No                                                                    |
 | apim_apiv4        | `plans`                   | `commentMessage`                   | string                                | Never will, Subscriptions are always auto-accepted                    |
 | apim_apiv4        | `plans`                   | `commentRequired`                  | boolean                               | Never will, Subscriptions are always auto-accepted                    |
 | apim_apiv4        | `plans`                   | `order`                            | integer                               | Never will, mapped to the list index, UI feature only                 |
+| apim_apiv4        | `listeners.kafka` (Kafka) | `port`                             | integer                               | No                                                                    |
 | apim_application  |                           | `apiKeyMode`                       | enum (SHARED, EXCLUSIVE, UNSPECIFIED) | Only EXCLUSIVE is supported, hence property is absent                 |
 | apim_application  |                           | `type`                             | string                                | No (simple applications)                                              |
+| apim_subscription | `apim_subscriptionSpec`   | `consumerConfiguration`            | object                                | 4.12                                                                  |
 | apim_subscription | `apim_subscriptionSpec`   | `apiKeyMode`                       | enum (SHARED, EXCLUSIVE, UNSPECIFIED) | Only EXCLUSIVE is supported, hence property is absent                 |
 | apim_subscription | `apim_subscriptionSpec`   | `startingAt`                       | date-time                             | Never, Subscriptions are always auto-accepted hence started immediately|
 | apim_subscription | `apim_subscriptionSpec`   | `generalConditionsAccepted`        | boolean                               | Never, Subscriptions are always auto-accepted                         |


### PR DESCRIPTION
Auto-synced changes from `docs/apim/4.11/` to `docs/apim/4.12/`.

Triggered by push to `main` (e88fcec18a84611934e5b881815fc0fa4af5e746).