### PR TITLE
Fix "Regisitry" typo on Terraform overview pages

### DIFF
--- a/docs/apim/4.10/terraform/README.md
+++ b/docs/apim/4.10/terraform/README.md
@@ -13,7 +13,7 @@ The Gravitee Terraform Provider is an open source plugin that is publicly availa
 
 Terraform configuration files are written in HashiCorp Configuration Language (HCL). They define the properties of providers and resources, which Terraform stores as the desired state of the system. When you update a configuration file, Terraform detects the changes to your resources and applies them automatically.
 
-Click on the cards below to learn more about Gravitee's Terraform provider. If you are familiar with Terraform, you can visit the [Gravitee "apim" Terraform Regisitry documentation](https://registry.terraform.io/providers/gravitee-io/apim/latest/docs/guides/setup) to get started.
+Click on the cards below to learn more about Gravitee's Terraform provider. If you are familiar with Terraform, you can visit the [Gravitee "apim" Terraform Registry documentation](https://registry.terraform.io/providers/gravitee-io/apim/latest/docs/guides/setup) to get started.
 
 {% hint style="info" %}
 Users of OpenTofu can use APIM provider as well\

--- a/docs/apim/4.11/terraform/README.md
+++ b/docs/apim/4.11/terraform/README.md
@@ -13,7 +13,7 @@ The Gravitee Terraform Provider is an open source plugin that is publicly availa
 
 Terraform configuration files are written in HashiCorp Configuration Language (HCL). They define the properties of providers and resources, which Terraform stores as the desired state of the system. When you update a configuration file, Terraform detects the changes to your resources and applies them automatically.
 
-Click on the cards below to learn more about Gravitee's Terraform provider. If you are familiar with Terraform, you can visit the [Gravitee "apim" Terraform Regisitry documentation](https://registry.terraform.io/providers/gravitee-io/apim/latest/docs/guides/setup) to get started.
+Click on the cards below to learn more about Gravitee's Terraform provider. If you are familiar with Terraform, you can visit the [Gravitee "apim" Terraform Registry documentation](https://registry.terraform.io/providers/gravitee-io/apim/latest/docs/guides/setup) to get started.
 
 {% hint style="info" %}
 Users of OpenTofu can use the APIM provider as well: [https://search.opentofu.org/provider/gravitee-io/apim/latest](https://search.opentofu.org/provider/gravitee-io/apim/latest)

--- a/docs/apim/4.12/terraform/README.md
+++ b/docs/apim/4.12/terraform/README.md
@@ -13,7 +13,7 @@ The Gravitee Terraform Provider is an open source plugin that is publicly availa
 
 Terraform configuration files are written in HashiCorp Configuration Language (HCL). They define the properties of providers and resources, which Terraform stores as the desired state of the system. When you update a configuration file, Terraform detects the changes to your resources and applies them automatically.
 
-Click on the cards below to learn more about Gravitee's Terraform provider. If you are familiar with Terraform, you can visit the [Gravitee "apim" Terraform Regisitry documentation](https://registry.terraform.io/providers/gravitee-io/apim/latest/docs/guides/setup) to get started.
+Click on the cards below to learn more about Gravitee's Terraform provider. If you are familiar with Terraform, you can visit the [Gravitee "apim" Terraform Registry documentation](https://registry.terraform.io/providers/gravitee-io/apim/latest/docs/guides/setup) to get started.
 
 {% hint style="info" %}
 Users of OpenTofu can use the APIM provider as well: [https://search.opentofu.org/provider/gravitee-io/apim/latest](https://search.opentofu.org/provider/gravitee-io/apim/latest)

--- a/docs/apim/4.8/terraform/README.md
+++ b/docs/apim/4.8/terraform/README.md
@@ -13,6 +13,6 @@ The Gravitee Terraform Provider is an open source plugin that is publicly availa
 
 Terraform configuration files are written in HashiCorp Configuration Language (HCL). They define the properties of providers and resources, which Terraform stores as the desired state of the system. When you update a configuration file, Terraform detects the changes to your resources and applies them automatically.
 
-Click on the cards below to learn more about Gravitee's Terraform provider. If you are familiar with Terraform, you can visit the [Gravitee "apim" Terraform Regisitry documentation](https://registry.terraform.io/providers/gravitee-io/apim/latest/docs/guides/setup) to get started.
+Click on the cards below to learn more about Gravitee's Terraform provider. If you are familiar with Terraform, you can visit the [Gravitee "apim" Terraform Registry documentation](https://registry.terraform.io/providers/gravitee-io/apim/latest/docs/guides/setup) to get started.
 
 <table data-view="cards"><thead><tr><th data-type="content-ref"></th><th data-hidden data-card-cover data-type="files"></th></tr></thead><tbody><tr><td><a href="quick-start-guide.md">quick-start-guide.md</a></td><td><a href="../.gitbook/assets/0_zbu2Lu5mHT37DPl0.png">0_zbu2Lu5mHT37DPl0.png</a></td></tr><tr><td><a href="example-resource-configurations.md">example-resource-configurations.md</a></td><td><a href="../.gitbook/assets/gravitee+terraform.png">gravitee+terraform.png</a></td></tr></tbody></table>

--- a/docs/apim/4.9/terraform/README.md
+++ b/docs/apim/4.9/terraform/README.md
@@ -16,6 +16,6 @@ The Gravitee Terraform Provider is an open source plugin that is publicly availa
 
 Terraform configuration files are written in HashiCorp Configuration Language (HCL). They define the properties of providers and resources, which Terraform stores as the desired state of the system. When you update a configuration file, Terraform detects the changes to your resources and applies them automatically.
 
-Click on the cards below to learn more about Gravitee's Terraform provider. If you are familiar with Terraform, you can visit the [Gravitee "apim" Terraform Regisitry documentation](https://registry.terraform.io/providers/gravitee-io/apim/latest/docs/guides/setup) to get started.
+Click on the cards below to learn more about Gravitee's Terraform provider. If you are familiar with Terraform, you can visit the [Gravitee "apim" Terraform Registry documentation](https://registry.terraform.io/providers/gravitee-io/apim/latest/docs/guides/setup) to get started.
 
 <table data-view="cards"><thead><tr><th data-type="content-ref"></th><th data-hidden data-card-cover data-type="files"></th></tr></thead><tbody><tr><td><a href="quick-start-guide.md">quick-start-guide.md</a></td><td></td></tr><tr><td><a href="example-resource-configurations.md">example-resource-configurations.md</a></td><td></td></tr></tbody></table>


### PR DESCRIPTION
## What

Corrects the misspelled link text **"Terraform Regisitry documentation"** to **"Terraform Registry documentation"** on the Terraform overview page.

The typo (`Regisitry` → `Registry`) appeared identically in the Terraform `README.md` for every APIM version that has the page:

- `docs/apim/4.8/terraform/README.md`
- `docs/apim/4.9/terraform/README.md`
- `docs/apim/4.10/terraform/README.md`
- `docs/apim/4.11/terraform/README.md`
- `docs/apim/4.12/terraform/README.md`

