### PR TITLE
docs(cloud): document HTTP proxy config for self-hosted Cloud connector

### DIFF
--- a/docs/gravitee-cloud/self-hosted/register-installations.md
+++ b/docs/gravitee-cloud/self-hosted/register-installations.md
@@ -24,6 +24,30 @@ To register new APIM or AM installations with GC, you need to:
 
 These steps are explained in detail when you register the installation.
 
+{% hint style="info" %}
+
+**Connecting through an HTTP proxy**
+
+If your self-hosted installation cannot reach Gravitee Cloud directly and must route outbound traffic through a corporate HTTP proxy, configure the Gravitee Cloud connector to use that proxy in your installation's `gravitee.yaml`:
+
+```yaml
+cloud:
+  enabled: true
+  connector:
+    ws:
+      proxy:
+        enabled: true
+        host: <proxy-host>
+        port: <proxy-port>
+        type: HTTP
+        username: <proxy-username>   # optional, if the proxy requires authentication
+        password: <proxy-password>   # optional, if the proxy requires authentication
+```
+
+The `username` and `password` fields are only required when the proxy enforces authentication. The WebSocket connection to Gravitee Cloud remains secured with TLS when routed through the proxy.
+
+{% endhint %}
+
 Register the installation using the detailed instructions in the **How to register a new installation** link, below **Installations** in the dashboard. After registration, the installation is displayed as a pending installation in GC:
 
 ![pending installations](../.gitbook/assets/pending-installations.png)


### PR DESCRIPTION
## Why

Give visibility to the proxy configuration, required by on-premise client installs connected to Cockpit.

Related issue: https://gravitee.atlassian.net/browse/CJ-4715

## What

Adds a small info callout to the self-hosted **Register installations** page explaining how to route the Gravitee Cloud (Cockpit) connector's WebSocket connection through a corporate HTTP proxy.

The new section documents the `cloud.connector.ws.proxy.*` settings in `gravitee.yaml`:

```yaml
cloud:
  enabled: true
  connector:
    ws:
      proxy:
        enabled: true
        host: <proxy-host>
        port: <proxy-port>
        type: HTTP
        username: <proxy-username>   # optional
        password: <proxy-password>   # optional
```
