### PR TITLE
docs(cloud): add guide and diagram for Cloud AWS transit gateways

### DIFF
--- a/docs/gravitee-cloud/.gitbook/assets/aws-transit-gateway-connectivity.svg
+++ b/docs/gravitee-cloud/.gitbook/assets/aws-transit-gateway-connectivity.svg
@@ -1,0 +1,89 @@
+<svg viewBox="0 84 1240 412" xmlns="http://www.w3.org/2000/svg" font-family="Inter, 'Segoe UI', Helvetica, Arial, sans-serif">
+  <defs>
+    <marker id="a" markerWidth="10" markerHeight="10" refX="7" refY="4" orient="auto">
+      <path d="M0,0 L8,4 L0,8 Z" fill="#8A93A3"/>
+    </marker>
+    <filter id="sf" x="-12%" y="-12%" width="124%" height="124%">
+      <feDropShadow dx="0" dy="2" stdDeviation="3" flood-color="#1B1B3A" flood-opacity="0.12"/>
+    </filter>
+    <style>
+      .t{font-size:18px;font-weight:700;fill:#1B1B3A;}
+      .s{font-size:12.5px;fill:#6B7280;}
+      .tab{font-size:12.5px;font-weight:700;fill:#FFFFFF;}
+      .clabel{font-size:11px;font-weight:600;fill:#5B6472;}
+      .conn{stroke:#8A93A3;stroke-width:2;fill:none;}
+      .flow{font-size:11px;font-weight:600;fill:#6B7280;}
+      .att{font-size:10.5px;font-weight:600;fill:#FFFFFF;}
+      .tag{font-size:10px;font-weight:700;fill:#FFFFFF;}
+    </style>
+  </defs>
+
+  <!-- API consumers -->
+  <rect x="40" y="248" width="150" height="84" rx="14" fill="#1B1B3A" filter="url(#sf)"/>
+  <text x="115" y="282" text-anchor="middle" fill="#FFFFFF" font-size="14" font-weight="600">API consumers</text>
+  <text x="115" y="300" text-anchor="middle" fill="#B9BCD8" font-size="11">apps · partners</text>
+  <text x="115" y="315" text-anchor="middle" fill="#B9BCD8" font-size="11">AI agents</text>
+
+  <!-- ===== Gravitee zone ===== -->
+  <rect x="220" y="100" width="360" height="380" rx="18" fill="#FFFFFF" stroke="#6B74F8" stroke-width="1.6"/>
+  <rect x="236" y="114" width="200" height="28" rx="14" fill="#5661F6"/>
+  <text class="tab" x="336" y="132" text-anchor="middle">Managed by Gravitee</text>
+
+  <rect x="240" y="160" width="320" height="230" rx="12" fill="#FAFAFC" stroke="#C7CBD4"/>
+  <text class="clabel" x="252" y="180">Dedicated cluster — your AWS VPC</text>
+  <rect x="486" y="165" width="70" height="18" rx="9" fill="#E07B00"/>
+  <text class="tag" x="521" y="178" text-anchor="middle">AWS</text>
+
+  <rect x="256" y="200" width="80" height="130" rx="10" fill="#FEF6E7" stroke="#E0A21B" filter="url(#sf)"/>
+  <text x="296" y="250" text-anchor="middle" font-size="11.5" font-weight="600" fill="#9A6B05">Secure</text>
+  <text x="296" y="267" text-anchor="middle" font-size="11.5" font-weight="600" fill="#9A6B05">public</text>
+  <text x="296" y="284" text-anchor="middle" font-size="11.5" font-weight="600" fill="#9A6B05">endpoint</text>
+  <text x="296" y="304" text-anchor="middle" font-size="10" fill="#B07F1E">HTTPS</text>
+
+  <rect x="352" y="200" width="192" height="130" rx="12" fill="#E4F7F5" stroke="#14A89F" filter="url(#sf)"/>
+  <text x="448" y="242" text-anchor="middle" font-size="14" font-weight="600" fill="#0B6B65">Your dedicated</text>
+  <text x="448" y="262" text-anchor="middle" font-size="14" font-weight="600" fill="#0B6B65">API Gateway</text>
+  <text x="448" y="285" text-anchor="middle" font-size="10.5" fill="#236F69">Data Plane</text>
+  <text x="448" y="301" text-anchor="middle" font-size="10" fill="#2E8A82">managed by Gravitee</text>
+
+  <rect x="256" y="406" width="288" height="42" rx="8" fill="#475569" stroke="#334155"/>
+  <text class="att" x="400" y="431" text-anchor="middle">Transit Gateway attachment</text>
+
+  <!-- ===== AWS Transit Gateway (neutral hub) ===== -->
+  <rect x="600" y="282" width="150" height="120" rx="16" fill="none" stroke="#5661F6" stroke-width="2" stroke-dasharray="5 4"/>
+  <rect x="610" y="292" width="130" height="100" rx="12" fill="#334155" stroke="#1F2937" filter="url(#sf)"/>
+  <text x="675" y="332" text-anchor="middle" fill="#FFFFFF" font-size="14" font-weight="700">AWS Transit</text>
+  <text x="675" y="350" text-anchor="middle" fill="#FFFFFF" font-size="14" font-weight="700">Gateway</text>
+  <text x="675" y="370" text-anchor="middle" fill="#AEB7C6" font-size="9.5">private VPC-to-VPC</text>
+  <text x="675" y="383" text-anchor="middle" fill="#AEB7C6" font-size="9.5">routing</text>
+
+  <!-- ===== Customer zone ===== -->
+  <rect x="780" y="100" width="440" height="380" rx="18" fill="#FFFFFF" stroke="#34A853" stroke-width="1.6"/>
+  <rect x="796" y="114" width="160" height="28" rx="14" fill="#34A853"/>
+  <text class="tab" x="876" y="132" text-anchor="middle">Managed by you</text>
+
+  <rect x="800" y="160" width="400" height="280" rx="12" fill="#F1FAF3" stroke="#34A853" stroke-width="1.1"/>
+  <text x="812" y="180" font-size="11" font-weight="600" fill="#1E6B36">Your AWS VPC / network</text>
+
+  <rect x="816" y="198" width="368" height="36" rx="7" fill="#475569"/>
+  <text class="att" x="1000" y="221" text-anchor="middle">Transit Gateway attachment</text>
+
+  <rect x="880" y="252" width="240" height="64" rx="10" fill="#EEF1F5" stroke="#8A95A5"/>
+  <text x="1000" y="280" text-anchor="middle" font-size="13" font-weight="600" fill="#3B4453">Your gateway</text>
+  <text x="1000" y="297" text-anchor="middle" font-size="9.5" fill="#5B6472">entry point in your network</text>
+
+  <rect x="880" y="340" width="240" height="64" rx="10" fill="#E7F6EC" stroke="#34A853"/>
+  <text x="1000" y="368" text-anchor="middle" font-size="13" font-weight="600" fill="#1E6B36">Upstream services</text>
+  <text x="1000" y="385" text-anchor="middle" font-size="9.5" fill="#3E8C57">your backend systems</text>
+
+  <!-- ===== Flows ===== -->
+  <path class="conn" d="M190,288 C215,278 236,252 256,250" marker-end="url(#a)"/>
+  <text class="flow" x="196" y="276">requests</text>
+  <path class="conn" d="M336,265 L352,265" marker-end="url(#a)"/>
+  <path class="conn" d="M448,330 L412,404" marker-end="url(#a)"/>
+  <path class="conn" d="M544,427 C575,420 588,360 600,352" marker-end="url(#a)"/>
+  <path class="conn" d="M750,338 C772,300 792,250 816,220" marker-end="url(#a)"/>
+  <path class="conn" d="M1000,234 L1000,252" marker-end="url(#a)"/>
+  <path class="conn" d="M1000,316 L1000,340" marker-end="url(#a)"/>
+
+</svg>

--- a/docs/gravitee-cloud/SUMMARY.md
+++ b/docs/gravitee-cloud/SUMMARY.md
@@ -27,6 +27,7 @@
   * [Add a service attachment to your private network](guides/establish-private-networks-with-gcp/add-a-service-attachment-to-your-private-network.md)
   * [Connect a Gateway to your private network](guides/establish-private-networks-with-gcp/connect-a-gateway-to-your-private-network.md)
   * [Disconnect a Gateway from your private network](guides/establish-private-networks-with-gcp/disconnect-a-gateway-from-your-private-network.md)
+* [Establish private networks with AWS](guides/establish-private-networks-with-aws.md)
 * [Configure TCP Reporter](guides/configure-tcp-reporter/README.md)
   * [Create and configure custom reporters](guides/configure-tcp-reporter/create-and-configure-custom-reporters.md)
   * [Custom reporters reference](guides/configure-tcp-reporter/custom-reporters-reference.md)

--- a/docs/gravitee-cloud/guides/establish-private-networks-with-aws.md
+++ b/docs/gravitee-cloud/guides/establish-private-networks-with-aws.md
@@ -8,10 +8,10 @@ description: Privately connect your dedicated Gravitee-hosted API Gateways to yo
 
 A private network creates a secure connection between your Gravitee-hosted, software-as-a-service (SaaS) API Gateways and your own infrastructure. API traffic reaches your backend services without crossing the public internet.
 
-On AWS, Gravitee establishes this connection using an **[AWS Transit Gateway](https://docs.aws.amazon.com/vpc/latest/tgw/what-is-transit-gateway.html)**—a network transit hub that interconnects Virtual Private Clouds (VPCs) and routes traffic between them. It links the dedicated cluster where Gravitee runs your API Gateways to a gateway in your own AWS environment.
+On AWS, Gravitee establishes this connection using an **[AWS Transit Gateway](https://docs.aws.amazon.com/vpc/latest/tgw/what-is-transit-gateway.html)**, which is a network transit hub that interconnects Virtual Private Clouds (VPCs) and routes traffic between them. It links the dedicated cluster where Gravitee runs your API Gateways to a Gateway in your own AWS environment.
 
 {% hint style="info" %}
-This capability is available on **AWS only** and is established **on demand**: it is configured manually for your account rather than self-service. To enable it, [contact Gravitee](/gravitee-cloud/community-and-support/enterprise-support).
+This capability is available on **AWS only** and is set up **on demand**: it is configured manually for your account rather than self-service. To enable it, [contact Gravitee](/gravitee-cloud/community-and-support/enterprise-support).
 {% endhint %}
 
 ## How it works
@@ -22,12 +22,12 @@ The following describes the connection at a high level:
 
 * Gravitee provisions and manages your API Gateways in a dedicated, isolated cluster inside AWS. These API Gateways are the **Data Plane**.
 * That cluster attaches to an **AWS Transit Gateway**, which provides private, VPC-to-VPC routing.
-* Through the Transit Gateway, the cluster reaches a gateway in your own AWS infrastructure, which fronts your upstream backend services.
-* Consumers keep calling your APIs through your Gateway's public HTTPS endpoint; from there, requests travel to your backend privately over the Transit Gateway.
+* Through the Transit Gateway, the cluster reaches a Gateway in your own AWS infrastructure, which fronts your upstream backend services.
+* Consumers keep calling your APIs through your Gateway's public HTTPS endpoint. From there, requests travel to your backend privately over the Transit Gateway.
 
-## Establish a private network on AWS
+## Set up a private network on AWS
 
-Setup requires manual configuration on both Gravitee's side and within your AWS environment. To begin, [contact Gravitee](/gravitee-cloud/community-and-support/enterprise-support)—the team aligns with you on your requirements, such as region and network details, and completes the setup.
+Setup requires manual configuration on both Gravitee's side and within your AWS environment. To begin, [contact Gravitee](/gravitee-cloud/community-and-support/enterprise-support). The team aligns with you on your requirements, such as region and network details, and then completes the setup.
 
 ## Next steps
 

--- a/docs/gravitee-cloud/guides/establish-private-networks-with-aws.md
+++ b/docs/gravitee-cloud/guides/establish-private-networks-with-aws.md
@@ -1,0 +1,36 @@
+---
+description: >-
+  Privately connect your dedicated Gravitee-hosted API Gateways to your own AWS
+  network using an AWS Transit Gateway. Available on AWS, on demand.
+---
+
+# Establish private networks with AWS
+
+## Overview
+
+A private network creates a secure connection between your Gravitee-hosted (SaaS) API Gateways and your own infrastructure, so API traffic reaches your backend services without crossing the public internet.
+
+On AWS, Gravitee establishes this connection using an **[AWS Transit Gateway](https://docs.aws.amazon.com/vpc/latest/tgw/what-is-transit-gateway.html)** — a network transit hub that interconnects Virtual Private Clouds (VPCs) and routes traffic between them. It links the dedicated cluster where Gravitee runs your API Gateways to a gateway in your own AWS environment.
+
+{% hint style="info" %}
+This capability is available on **AWS only** and is set up **on demand**: it is configured manually for your account rather than self-served. To enable it, [contact Gravitee](/gravitee-cloud/community-and-support/enterprise-support).
+{% endhint %}
+
+## How it works
+
+<figure><img src="../.gitbook/assets/aws-transit-gateway-connectivity.svg" alt="Gravitee's dedicated API Gateway cluster connects to your own AWS network over an AWS Transit Gateway, keeping backend traffic private."><figcaption><p>Gravitee runs your API Gateways in a dedicated AWS cluster that connects to your own network over an AWS Transit Gateway. Internal traffic stays private and never crosses the public internet.</p></figcaption></figure>
+
+At a high level:
+
+* Gravitee provisions and manages your API Gateways — the **Data Plane** — in a dedicated, isolated cluster inside AWS.
+* That cluster attaches to an **AWS Transit Gateway**, which provides private, VPC-to-VPC routing.
+* Through the Transit Gateway, the cluster reaches a gateway in your own AWS infrastructure, which fronts your upstream (backend) services.
+* Consumers keep calling your APIs through your Gateway's public HTTPS endpoint; from there, requests travel to your backend privately over the Transit Gateway.
+
+## Set up a private network on AWS
+
+Setup requires manual configuration on both Gravitee's side and within your AWS environment. To get started, [contact Gravitee](/gravitee-cloud/community-and-support/enterprise-support) — the team will align with you on your requirements (such as region and network details) and carry out the setup.
+
+## Related
+
+<table data-view="cards"><thead><tr><th></th><th data-hidden data-card-target data-type="content-ref"></th></tr></thead><tbody><tr><td>Establish private networks with GCP</td><td><a href="/gravitee-cloud/guides/establish-private-networks-with-gcp">/gravitee-cloud/guides/establish-private-networks-with-gcp</a></td></tr><tr><td>Gravitee Cloud Geography and Provider Support</td><td><a href="/gravitee-cloud/reference/geography-and-provider-support">/gravitee-cloud/reference/geography-and-provider-support</a></td></tr></tbody></table>

--- a/docs/gravitee-cloud/guides/establish-private-networks-with-aws.md
+++ b/docs/gravitee-cloud/guides/establish-private-networks-with-aws.md
@@ -1,36 +1,36 @@
 ---
-description: >-
-  Privately connect your dedicated Gravitee-hosted API Gateways to your own AWS
-  network using an AWS Transit Gateway. Available on AWS, on demand.
+description: Privately connect your dedicated Gravitee-hosted API Gateways to your own AWS network using an AWS Transit Gateway, available on AWS on demand.
 ---
 
 # Establish private networks with AWS
 
 ## Overview
 
-A private network creates a secure connection between your Gravitee-hosted (SaaS) API Gateways and your own infrastructure, so API traffic reaches your backend services without crossing the public internet.
+A private network creates a secure connection between your Gravitee-hosted, software-as-a-service (SaaS) API Gateways and your own infrastructure. API traffic reaches your backend services without crossing the public internet.
 
-On AWS, Gravitee establishes this connection using an **[AWS Transit Gateway](https://docs.aws.amazon.com/vpc/latest/tgw/what-is-transit-gateway.html)** — a network transit hub that interconnects Virtual Private Clouds (VPCs) and routes traffic between them. It links the dedicated cluster where Gravitee runs your API Gateways to a gateway in your own AWS environment.
+On AWS, Gravitee establishes this connection using an **[AWS Transit Gateway](https://docs.aws.amazon.com/vpc/latest/tgw/what-is-transit-gateway.html)**—a network transit hub that interconnects Virtual Private Clouds (VPCs) and routes traffic between them. It links the dedicated cluster where Gravitee runs your API Gateways to a gateway in your own AWS environment.
 
 {% hint style="info" %}
-This capability is available on **AWS only** and is set up **on demand**: it is configured manually for your account rather than self-served. To enable it, [contact Gravitee](/gravitee-cloud/community-and-support/enterprise-support).
+This capability is available on **AWS only** and is established **on demand**: it is configured manually for your account rather than self-service. To enable it, [contact Gravitee](/gravitee-cloud/community-and-support/enterprise-support).
 {% endhint %}
 
 ## How it works
 
 <figure><img src="../.gitbook/assets/aws-transit-gateway-connectivity.svg" alt="Gravitee's dedicated API Gateway cluster connects to your own AWS network over an AWS Transit Gateway, keeping backend traffic private."><figcaption><p>Gravitee runs your API Gateways in a dedicated AWS cluster that connects to your own network over an AWS Transit Gateway. Internal traffic stays private and never crosses the public internet.</p></figcaption></figure>
 
-At a high level:
+The following describes the connection at a high level:
 
-* Gravitee provisions and manages your API Gateways — the **Data Plane** — in a dedicated, isolated cluster inside AWS.
+* Gravitee provisions and manages your API Gateways in a dedicated, isolated cluster inside AWS. These API Gateways are the **Data Plane**.
 * That cluster attaches to an **AWS Transit Gateway**, which provides private, VPC-to-VPC routing.
-* Through the Transit Gateway, the cluster reaches a gateway in your own AWS infrastructure, which fronts your upstream (backend) services.
+* Through the Transit Gateway, the cluster reaches a gateway in your own AWS infrastructure, which fronts your upstream backend services.
 * Consumers keep calling your APIs through your Gateway's public HTTPS endpoint; from there, requests travel to your backend privately over the Transit Gateway.
 
-## Set up a private network on AWS
+## Establish a private network on AWS
 
-Setup requires manual configuration on both Gravitee's side and within your AWS environment. To get started, [contact Gravitee](/gravitee-cloud/community-and-support/enterprise-support) — the team will align with you on your requirements (such as region and network details) and carry out the setup.
+Setup requires manual configuration on both Gravitee's side and within your AWS environment. To begin, [contact Gravitee](/gravitee-cloud/community-and-support/enterprise-support)—the team aligns with you on your requirements, such as region and network details, and completes the setup.
 
-## Related
+## Next steps
+
+The following resources provide additional context:
 
 <table data-view="cards"><thead><tr><th></th><th data-hidden data-card-target data-type="content-ref"></th></tr></thead><tbody><tr><td>Establish private networks with GCP</td><td><a href="/gravitee-cloud/guides/establish-private-networks-with-gcp">/gravitee-cloud/guides/establish-private-networks-with-gcp</a></td></tr><tr><td>Gravitee Cloud Geography and Provider Support</td><td><a href="/gravitee-cloud/reference/geography-and-provider-support">/gravitee-cloud/reference/geography-and-provider-support</a></td></tr></tbody></table>


### PR DESCRIPTION
Related Issue: https://gravitee.atlassian.net/browse/CJ-4365