### PR TITLE
docs(vale): accept all casings of redis, OIDC, cursor; add cron to accept.txt

### DIFF
--- a/vale/styles/config/vocabularies/docs/accept.txt
+++ b/vale/styles/config/vocabularies/docs/accept.txt
@@ -32,7 +32,7 @@ AsyncAPI
 OpenAPI
 OpenID
 OAuth2?
-OIDC
+OIDC|oidc
 OID
 OIDs
 SAML
@@ -127,7 +127,7 @@ MySQL
 MariaDB
 Elasticsearch
 Hazelcast
-Redis
+[Rr]edis
 DocumentDB
 R2DBC
 RDBMS
@@ -407,6 +407,7 @@ GPG
 [Aa]uth[Nn]
 A2A
 bool
+[Cc]ron[s]?
 
 # ============================================
 # Cloud Providers & Services
@@ -527,7 +528,7 @@ ChatGPT
 Bedrock
 Vertex
 Foundry
-Cursor
+[Cc]ursor
 Copilot
 LangChain
 FastMCP


### PR DESCRIPTION
## What

Updates the Vale vocabulary (`vale/styles/config/vocabularies/docs/accept.txt`) so these terms are accepted in **all casings**, and adds `cron` which was missing entirely.

| Term | Before | After | Why it was flagged |
|------|--------|-------|--------------------|
| OIDC | `OIDC` | `OIDC\|oidc` | `oidc`→`OIDC` (Vale.Terms) |
| Redis | `Redis` | `[Rr]edis` | `redis`→`Redis` (Vale.Terms) |
| Cursor | `Cursor` | `[Cc]ursor` | `cursor`→`Cursor` (Vale.Terms) |
| cron | _(absent)_ | `[Cc]ron[s]?` | "Did you really mean 'cron'?" (docs.Spelling) |

## Why

Several open docs PRs surfaced these as Vale errors that are really just casing/vocab gaps, not content problems. Lowercase `redis`, `oidc`, and `cursor` are all legitimate in config keys, repository type values, protocol references, and "cursor pagination" prose. `cron` was not in the vocabulary at all.

This mirrors the existing all-casings idiom already used in this file (for example `REST|rest`, `[Ee]mail[s]?|EMAIL`, `[Aa][Pp][Ii]`).

## Verification

Vale 3.13.1 run on a test file containing every casing (`redis`, `Redis`, `oidc`, `OIDC`, `cursor`, `Cursor`, `cron`, `Cron`, `crons`): **0 errors, 0 warnings, 0 suggestions**.
