### PR TITLE
[sync] am: 4.11 → 4.12

### DIFF
--- a/docs/am/4.12/getting-started/configuration/configure-am-api/README.md
+++ b/docs/am/4.12/getting-started/configuration/configure-am-api/README.md
@@ -661,7 +661,7 @@ If you are planning to use multiple instances, you need to implement sticky sess
 Example using three instances of AM API. We add an additional cookie named ROUTEID. TLS termination is configured in Apache, so we just use HTTP.
 
 {% code overflow="wrap" %}
-```xml
+```
 <Proxy balancer://amm_hcluster>
         BalancerMember http://GRAVITEEIO-AM-MGT-API-HOST1:8093 route=apim1-test
         BalancerMember http://GRAVITEEIO-AM-MGT-API-HOST2:8093 route=apim2-test

--- a/docs/am/4.12/releases-and-changelog/changelog/am-4.11.x.md
+++ b/docs/am/4.12/releases-and-changelog/changelog/am-4.11.x.md
@@ -6,6 +6,33 @@ description: >-
 
 # AM 4.11.x
 
+## Gravitee Access Management 4.11.8 - June 16, 2026
+
+<details>
+
+<summary>Bug fixes</summary>
+
+**Gateway**
+
+* OIDC IdP error response (query string) not propagated to client redirect URI in Auth Code PKCE flow [#11499](https://github.com/gravitee-io/issues/issues/11499)
+
+
+
+
+
+**Other**
+
+* Search Domain doesn't work with '_' [#11508](https://github.com/gravitee-io/issues/issues/11508)
+* OIDC login fails with SignatureException due to kid: "default" collision between System and Own certificates [#11509](https://github.com/gravitee-io/issues/issues/11509)
+* `policy-am-enrich-auth-flow` silently skips [#11521](https://github.com/gravitee-io/issues/issues/11521)
+* Filter out empty scopes in auth request [#11523](https://github.com/gravitee-io/issues/issues/11523)
+* Missing user.groups property in EL [#11524](https://github.com/gravitee-io/issues/issues/11524)
+* Add userId/username to error SCIM response  [#11539](https://github.com/gravitee-io/issues/issues/11539)
+* Extension Grant is not managing PS256 [#11542](https://github.com/gravitee-io/issues/issues/11542)
+
+</details>
+
+
 ## Gravitee Access Management 4.11.6 - June 1, 2026
 
 <details>


### PR DESCRIPTION
Auto-synced changes from `docs/am/4.11/` to `docs/am/4.12/`.

Triggered by push to `main` (3520a2ac9f297415fd730102af7da73d991ebf79).