### PR TITLE
[sync] am: 4.11 → 4.12

### DIFF
--- a/docs/am/4.12/releases-and-changelog/changelog/am-4.11.x.md
+++ b/docs/am/4.12/releases-and-changelog/changelog/am-4.11.x.md
@@ -16,10 +16,6 @@ description: >-
 
 * OIDC IdP error response (query string) not propagated to client redirect URI in Auth Code PKCE flow [#11499](https://github.com/gravitee-io/issues/issues/11499)
 
-
-
-
-
 **Other**
 
 * Search Domain doesn't work with '_' [#11508](https://github.com/gravitee-io/issues/issues/11508)
@@ -29,6 +25,23 @@ description: >-
 * Missing user.groups property in EL [#11524](https://github.com/gravitee-io/issues/issues/11524)
 * Add userId/username to error SCIM response  [#11539](https://github.com/gravitee-io/issues/issues/11539)
 * Extension Grant is not managing PS256 [#11542](https://github.com/gravitee-io/issues/issues/11542)
+
+</details>
+
+## Gravitee Access Management 4.11.7 - June 8, 2026
+
+<details>
+
+<summary>Bug fixes</summary>
+
+**Gateway**
+
+* Parameterized scope are not properly managed during TokenExchange [#11448](https://github.com/gravitee-io/issues/issues/11448)
+* Request-object signature pre-check NPE [#11486](https://github.com/gravitee-io/issues/issues/11486)
+
+**Other**
+
+* Kafka Client OAUTH not working [#11501](https://github.com/gravitee-io/issues/issues/11501)
 
 </details>
 


### PR DESCRIPTION
Auto-synced changes from `docs/am/4.11/` to `docs/am/4.12/`.

Triggered by push to `main` (db97ec9c36b435d4936012de947e2c9ee6dce373).