### PR TITLE
ci(vale): drop one-click suggestion for remove-action rules (Adverbs, Ellipses)

### DIFF
--- a/vale/to-rdjsonl.jq
+++ b/vale/to-rdjsonl.jq
@@ -7,10 +7,16 @@
 #   2. Vale.Terms (built-in vocab, no action) -> parse "Use 'X' instead of 'Y'."
 #   3. action {name:"edit", params:["truncate", SEP]} -> first SEP-segment of
 #        Match. Vale.Repetition: Match "the the", SEP " " -> "the".
-#   4. action {name:"remove"}             -> delete the word (empty text). The
-#        range is widened one column left to also consume the preceding space
-#        (an adverb is almost always preceded by a space), guarded so it never
-#        underflows column 1. Microsoft.Adverbs and any other remove rule.
+#
+# action {name:"remove"} (Microsoft.Adverbs and any other remove rule) does NOT
+# carry a suggestion. The removal range is built from Vale's character column
+# span, which doesn't line up with the raw source line whenever the line holds
+# TokenIgnores-masked tokens (inline `code`, key=value, +literals+, URLs) or
+# multibyte characters (em dashes). The span then drifts left of the flagged
+# word and the splice corrupts real text -- e.g. "references freely" became
+# "refereeely" and "To deliberately cross it" became "(ly cross it". These
+# alerts post as a plain comment (rule message and link intact) so the writer
+# decides whether to drop the adverb by hand.
 #
 # docs.Spelling never carries a suggestion: Vale's JSON omits spelling
 # candidates, and reconstructing them is unsafe (the guessed replacement plus
@@ -67,11 +73,6 @@ to_entries[]
         then ( .Action.Params[1] as $sep
                | { text: ((.Match // "") | split($sep) | .[0]),
                    s: $pos.scol, e: $pos.ecol } )
-
-        elif (.Action.Name == "remove")
-        then { text: "",
-                s: (if $pos.scol > 1 then $pos.scol - 1 else $pos.scol end),
-                e: $pos.ecol }
 
         else null
         end


### PR DESCRIPTION
## Problem

`Microsoft.Adverbs` and `Microsoft.Ellipses` use `action: remove`. The Vale → reviewdog converter (`vale/to-rdjsonl.jq`) turned that into a GitHub "Apply suggestion" block by splicing an empty string at Vale's reported character column span.

That column span doesn't line up with the raw source line whenever the line contains:

- `TokenIgnores`-masked tokens (inline `` `code` ``, `key=value`, `+literals+`, URLs), or
- multibyte characters (em dashes).

The removal range then drifts left of the flagged word, so the splice deletes the wrong characters and corrupts real text. Observed on PR #1718 (AM-6850):

- `references freely` → `refereeely`
- `To deliberately cross it` → `(ly cross it`

## Change

Drop the `remove`-action branch in `vale/to-rdjsonl.jq`. The two `remove` rules (`Microsoft.Adverbs`, `Microsoft.Ellipses`) now post as **plain comments** with the rule message and Microsoft link intact, and no broken one-click fix. The writer decides whether to drop the word by hand.

Everything else is unchanged:

- `action: replace` rules (`Wordiness`, `Terms`, `GenderBias`, `URLFormat`, `docs.word-choice`) keep their button.
- `Vale.Terms` and `action: edit`/truncate rules (`Hyphens`, `Negative`, `Ordinal`, `RangeTime`) keep their button.
- Rules with no action (`SentenceLength`, `We`, `Spacing`, etc.) were already plain comments.

## Verification

- jq parses and runs cleanly.
- Sample Vale JSON confirms a `remove` alert emits no `suggestions` block (the rule message and link are retained) while a `replace` alert still emits its button.
