### PR TITLE
docs(vale): accept auto-* terms, all-caps METADATA, and lowercase gravitee/am

### DIFF
--- a/vale/styles/config/vocabularies/docs/accept.txt
+++ b/vale/styles/config/vocabularies/docs/accept.txt
@@ -1,10 +1,10 @@
 # ============================================
 # Gravitee Product & Platform Terms
 # ============================================
-Gravitee
+[Gg]ravitee
 [Aa][Pp][Ii][Mm]
 APID
-AM
+[Aa][Mm]
 GKO
 GC
 Cockpit
@@ -296,6 +296,9 @@ ISO
 # ============================================
 # Compound / Technical Words
 # ============================================
+auto-fetch
+auto-validate
+auto-validation
 [Bb]ackend
 [Ff]rontend
 [Cc]odebase
@@ -307,7 +310,7 @@ ISO
 [Hh]otfixes
 [Kk]eystore
 [Ll]ifecycle
-[Mm]etadata
+(?i)metadata
 [Mm]icroservices
 [Mm]onorepo
 [Oo]nboarding


### PR DESCRIPTION
## What

Vale vocabulary (`accept.txt`) changes only — **no contributor doc content is touched**. This reduces false-positive Vale findings reported across several 4.12 pages.

| Change | Clears |
|---|---|
| Add `auto-fetch`, `auto-validate`, `auto-validation` | `Microsoft.Auto` "don't hyphenate" errors (federated-apis ×3, apim-4.12, manage-subscriptions) |
| `[Mm]etadata` → `(?i)metadata` | `Vale.Terms` flag on the `METADATA` permission constant (user-management) |
| `Gravitee` → `[Gg]ravitee` | accepts lowercase `gravitee` |
| `AM` → `[Aa][Mm]` | accepts lowercase `am` |

## Verified

- Ran Vale 3.13.1 locally: the targeted `Microsoft.Auto` and `Vale.Terms` findings are gone; vocabulary recompiles with no errors.
- `OAuth2` (`OAuth2?`), `MongoDB`, `EMAIL` (`[Ee]mail[s]?|EMAIL`), and `api` (`[Aa][Pp][Ii]`) were **already** in `accept.txt`, so they're intentionally left unchanged.

## Out of scope

- The `role(s)` / `HTTP(S)` findings are `Microsoft.Plurals`, which matches the bare `(s)` token, not the word — `accept.txt` cannot silence it. Those are content fixes owned by the respective pages' authors.
