### PR TITLE
docs: add "subtree" to Vale accept.txt vocabulary

### DIFF
--- a/vale/styles/config/vocabularies/docs/accept.txt
+++ b/vale/styles/config/vocabularies/docs/accept.txt
@@ -742,6 +742,7 @@ datacenter
 trustable
 reallocations
 subnav
+subtree
 subshell
 subprotocol
 subcommand


### PR DESCRIPTION
## What

Adds `subtree` to the Vale spelling vocabulary at `vale/styles/config/vocabularies/docs/accept.txt`.

## Why

The `docs.Spelling` Vale check flagged `subtree` as not in the approved vocabulary on the Portal navigation cascade operations page (`docs/.../portal/new-developer-portal/customize-the-navigation/portal-navigation-cascade-operations.md`), from **APIM-14411 — Portal Navigation Management** (#1799).

`subtree` is a valid technical term for the nested navigation hierarchy (folders and API sections and their nested items), so it's added to the accept list rather than reworded.