### PR TITLE
docs: accept Vale vocabulary terms surfaced across open PRs

### DIFF
--- a/vale/styles/config/vocabularies/docs/accept.txt
+++ b/vale/styles/config/vocabularies/docs/accept.txt
@@ -435,7 +435,7 @@ external-dns
 cert-manager
 controllerName
 parametersRef
-[Oo]penssl
+(?i)openssl
 [Gg]ravitee\.io
 [Mm]inikube
 balancer's
@@ -813,3 +813,15 @@ Norasi
 Kalimati
 Luxi
 Bitstream
+
+# ============================================
+# Spell-check sweep additions (2026-06-24)
+# Terms surfaced by Vale across PRs #1770, #1800, #1805, #1806, #1807, #1810.
+# ============================================
+asc
+cacheRedis
+connectTimeout
+prefetch
+resync
+[Ss]harded
+tlsCiphers


### PR DESCRIPTION
## What

Adds/adjusts entries in `vale/styles/config/vocabularies/docs/accept.txt` to resolve `docs.Spelling` and `Vale.Terms` findings surfaced by a local Vale sweep of several open PRs.

## Changes

| Term | Action | Why |
|------|--------|-----|
| `[Oo]penssl` → `(?i)openssl` | broadened | Accept `OpenSSL` (the correct brand casing) and any other casing. Matches the existing `(?i)metadata` idiom. |
| `asc` | added | Sort-order term flagged in #1810. |
| `cacheRedis` | added | Config key flagged in #1800. |
| `connectTimeout` | added | Config key flagged in #1800. |
| `prefetch` | added | Flagged in #1770. |
| `resync` | added | Flagged in #1807. |
| `[Ss]harded` | added | Covers `sharded` and `Sharded`, flagged in #1800. |
| `tlsCiphers` | added | Config key flagged in #1800. |

## Not changed

`metadata` needs no change. `(?i)metadata` is already present on `main` and accepts `METADATA`/`Metadata`/`metadata`. The `METADATA` finding in #1770 only appears because that branch was cut from an older `main` (entry was `[Mm]etadata`); it clears once #1770 rebases.

## Verification

Ran `vale --output=JSON` locally against a prose test file containing every term above. None of the target terms were flagged after these edits (the only finding was an unrelated `Microsoft.We` on the test sentence itself).

🤖 Generated with [Claude Code](https://claude.com/claude-code)