### PR TITLE
[sync] apim: 4.11 → 4.12

### DIFF
--- a/docs/apim/4.12/configure-and-manage-the-platform/manage-organizations-and-environments/authentication/microsoft-entra-id.md
+++ b/docs/apim/4.12/configure-and-manage-the-platform/manage-organizations-and-environments/authentication/microsoft-entra-id.md
@@ -134,9 +134,9 @@ To avoid the use of a previous token or misconfiguration, reset the cache of you
 
 ### **Permissions, groups and roles**
 
-You can manually customize permissions, groups, and roles for new users, or use the automatic Roles and Groups Mapping feature. For more information about Roles and Mappings, see [roles-and-groups-mapping.md](roles-and-groups-mapping.md "mention").
+You can manually customize permissions, groups, and roles for new users, or use the automatic Roles and Groups Mapping feature. For more information about Roles and Mappings, see[roles-and-groups-mapping.md](roles-and-groups-mapping.md "mention").
 
-### :information\_source: **Entra ID and Groups Mapping**
+### **Entra ID and Groups Mapping**
 
 Gravitee APIM can be configured to request the user's groups from an UserInfo endpoint of the OAuth2 server, but Entra ID cannot be configured to provide this information through their UserInfo endpoint.
 

--- a/docs/apim/4.12/release-information/breaking-changes-and-deprecations.md
+++ b/docs/apim/4.12/release-information/breaking-changes-and-deprecations.md
@@ -15,22 +15,6 @@ Here are the breaking changes for versions 4.X of Gravitee and versions 3.X of G
 
 Here are the breaking changes from versions 4.X of Gravitee.
 
-#### 4.12.0
-
-**`gravitee-resource-cache-redis` requires version 5.0.0**
-
-If you use the `gravitee-resource-cache-redis` plugin, you must upgrade it to version 5.0.0 when upgrading to APIM 4.12. This plugin is not included in the default APIM bundle and must be managed independently. Running an older version of `gravitee-resource-cache-redis` with APIM 4.12 is not supported.
-
-**Redis cache resource now uses a shared connection pool**
-
-The Redis cache resource now uses a shared Redis client factory with gateway-wide connection pool and timeout settings. Previously, each API using a Redis cache resource maintained its own dedicated connection to Redis, so 100 APIs with a Redis cache resource resulted in 100 active Redis connections to the server.
-
-If you use the `gravitee-resource-cache-redis` or `aiVectorStoreRedis` resource, review and adjust the following settings to suit your workload:
-
-* `resources.aiVectorStoreRedis.maxPoolSize`
-* `gateway.cacheRedis.maxPoolSize`
-* Timeout settings for both resources
-
 #### 4.11.0
 
 **A2A Proxy APIs architecture**

--- a/docs/apim/4.12/release-information/changelog/apim-4.11.x.md
+++ b/docs/apim/4.12/release-information/changelog/apim-4.11.x.md
@@ -1,5 +1,22 @@
 # APIM 4.11.x
  
+## Gravitee API Management 4.11.12 - June 24, 2026
+<details>
+
+<summary>Bug Fixes</summary>
+
+**Console**
+
+* Debug mode selects SaaS gateway instead of hybrid gateway when API has a sharding tag [#11533](https://github.com/gravitee-io/issues/issues/11533)
+
+**Other**
+
+* Dynamic Routing redirect rules broken  [#11571](https://github.com/gravitee-io/issues/issues/11571)
+
+</details>
+
+
+ 
 ## Gravitee API Management 4.11.11 - June 20, 2026
 <details>
 


### PR DESCRIPTION
Auto-synced changes from `docs/apim/4.11/` to `docs/apim/4.12/`.

Triggered by push to `main` (3b516d584d0cd007af4acc871a976740927aeb2a).