### PR TITLE
Accept 'beta' in Vale vocabulary

### DIFF
--- a/vale/styles/config/vocabularies/docs/accept.txt
+++ b/vale/styles/config/vocabularies/docs/accept.txt
@@ -825,3 +825,9 @@ prefetch
 resync
 [Ss]harded
 tlsCiphers
+
+# ============================================
+# Release-stage terms (2026-06-25)
+# ============================================
+[Aa]lpha
+[Bb]eta


### PR DESCRIPTION
Adds `[Bb]eta` to `vale/styles/config/vocabularies/docs/accept.txt` so both **beta** and **Beta** pass the Vale spell-check, using the repo's existing case-insensitive regex idiom (like `[Bb]ackend`, `[Bb]oolean`).

Also adds `[Aa]lpha` as the obvious paired release-stage sibling.

