### PR TITLE
[sync] gko: 4.11 → 4.12

### DIFF
--- a/docs/gko/4.12/releases-and-changelog/changelog/gko-4.11.x.md
+++ b/docs/gko/4.12/releases-and-changelog/changelog/gko-4.11.x.md
@@ -4,6 +4,20 @@ noIndex: true
 ---
 # GKO 4.11.x
 
+## Gravitee Kubernetes Operator 4.11.12 - June 25, 2026
+
+There is nothing new in version 4.11.12.
+
+> This version was generated to keep the kubernetes operator in sync with other gravitee products.
+
+
+## Gravitee Kubernetes Operator 4.11.11 - June 25, 2026
+
+There is nothing new in version 4.11.11.
+
+> This version was generated to keep the kubernetes operator in sync with other gravitee products.
+
+
 ## Gravitee Kubernetes Operator 4.11.10 - June 9, 2026
 
 There is nothing new in version 4.11.10.


### PR DESCRIPTION
Auto-synced changes from `docs/gko/4.11/` to `docs/gko/4.12/`.

Triggered by push to `main` (2f19fa60a7d01abdd302e6bea0340aa9d7caa0e6).