### PR TITLE
[sync] apim: 4.11 → 4.12

### DIFF
--- a/docs/apim/4.12/release-information/changelog/apim-4.11.x.md
+++ b/docs/apim/4.12/release-information/changelog/apim-4.11.x.md
@@ -1,6 +1,11 @@
 # APIM 4.11.x
  
 ## Gravitee API Management 4.11.12 - June 24, 2026
+
+{% hint style="warning" %}
+There are known issues with the flows in this version of APIM. Do not upgrade to this version of APIM. Upgrade to the next available version of APIM. We are investigating the issue.
+{% endhint %}
+
 <details>
 
 <summary>Bug Fixes</summary>
@@ -18,6 +23,11 @@
 
  
 ## Gravitee API Management 4.11.11 - June 20, 2026
+
+{% hint style="warning" %}
+There are known issues with the flows in this version of APIM. Do not upgrade to this version of APIM. Upgrade to the next available version of APIM. We are investigating the issue.
+{% endhint %}
+
 <details>
 
 <summary>Bug Fixes</summary>


### PR DESCRIPTION
Auto-synced changes from `docs/apim/4.11/` to `docs/apim/4.12/`.

Triggered by push to `main` (f87f4fd401eb7f3b680e94f53f3af0e0fdf231b7).