### PR TITLE
[sync] apim: 4.11 → 4.12

### DIFF
--- a/docs/apim/4.12/release-information/changelog/apim-4.11.x.md
+++ b/docs/apim/4.12/release-information/changelog/apim-4.11.x.md
@@ -1,9 +1,22 @@
 # APIM 4.11.x
  
+## Gravitee API Management 4.11.13 - June 25, 2026
+<details>
+
+<summary>Bug Fixes</summary>
+
+**Gateway**
+
+* Gateway with LLM proxy API deployed won't start  [#11574](https://github.com/gravitee-io/issues/issues/11574)
+
+</details>
+
+
+ 
 ## Gravitee API Management 4.11.12 - June 24, 2026
 
 {% hint style="warning" %}
-There are known issues with the flows in this version of APIM. Do not upgrade to this version of APIM. Upgrade to the next available version of APIM. We are investigating the issue.
+There is a known issue with LLM Proxy APIs in this version of APIM. If you have at least an LLM Proxy API deployed to your Gateway, do not upgrade to this version of APIM. Upgrade to version 4.11.13+.
 {% endhint %}
 
 <details>
@@ -25,7 +38,7 @@ There are known issues with the flows in this version of APIM. Do not upgrade to
 ## Gravitee API Management 4.11.11 - June 20, 2026
 
 {% hint style="warning" %}
-There are known issues with the flows in this version of APIM. Do not upgrade to this version of APIM. Upgrade to the next available version of APIM. We are investigating the issue.
+There is a known issue with the flows in this version of APIM. Do not upgrade to this version of APIM. Upgrade to version 4.11.13+.
 {% endhint %}
 
 <details>


### PR DESCRIPTION
Auto-synced changes from `docs/apim/4.11/` to `docs/apim/4.12/`.

Triggered by push to `main` (9d76cc29bce931751a75941149acc019782b0185).