### PR TITLE
docs(apim): document cluster-scoped distributed sync Redis keys

### DIFF
--- a/docs/apim/4.12/.version-overrides
+++ b/docs/apim/4.12/.version-overrides
@@ -144,6 +144,8 @@ configure-and-manage-the-platform/manage-organizations-and-environments/develope
 govern-apis/federation/federated-apis.md
 release-information/breaking-changes-and-deprecations.md
 configure-and-manage-the-platform/gravitee-gateway/gateway-cluster-sync-with-redis/gateway-cluster-sync-with-redis-using-kubernetes-helm.md
+configure-and-manage-the-platform/gravitee-gateway/gateway-cluster-sync-with-redis/README.md
+configure-and-manage-the-platform/gravitee-gateway/gateway-cluster-sync-with-redis/gateway-cluster-sync-with-redis-using-docker.md
 create-and-configure-apis/apply-policies/configure-cache-policies-to-use-redis-cache-resources.md
 create-and-configure-apis/apply-policies/create-and-configure-redis-cache-resources.md
 create-and-configure-apis/apply-policies/policy-reference/oauth2/README.md

--- a/docs/apim/4.12/configure-and-manage-the-platform/gravitee-gateway/gateway-cluster-sync-with-redis/README.md
+++ b/docs/apim/4.12/configure-and-manage-the-platform/gravitee-gateway/gateway-cluster-sync-with-redis/README.md
@@ -51,6 +51,35 @@ The objects are used to know what needs to be deployed or undeployed across the 
 
 After any business object is deployed, and only if distributed sync is enabled, the primary node stores those objects in the new distributed sync repository.
 
+#### Cluster-scoped Redis (multi sharding-tag deployments)
+
+From APIM 4.12, distributed sync events and sync state in Redis are **scoped by cluster ID**. The cluster ID is the Hazelcast `cluster-name` configured on each gateway deployment.
+
+Use this model when several gateway deployments share one Redis instance—for example, separate Helm releases for `external`, `internal`, and `aog` sharding tags:
+
+* Deploy **one gateway Helm release per sharding-tag cluster**.
+* Give each release a **unique Hazelcast `cluster-name`** (runtime cluster ID). With the APIM Helm chart, the default is `<release-name>-<sharding_tags>`; override with `gateway.cluster.hazelcast.clusterName` if needed.
+* All releases may use the **same Redis** host; keys are isolated by cluster ID.
+
+Redis key layout:
+
+| Key pattern | Purpose |
+|:------------|:--------|
+| `distributed_sync_state:<clusterId>` | Last successful sync timeframe for that cluster |
+| `distributed_event:<clusterId>:<type>:<id>` | Deploy/undeploy events for that cluster |
+
+If `sharding_tags` or `cluster-name` change, a **new** cluster ID is used. Delete stale `distributed_event:*` and `distributed_sync_state:*` keys for the old cluster ID in Redis.
+
+{% hint style="warning" %}
+**Deployment constraints:** The primary gateway must populate Redis before secondaries rely on it. On **fresh install**, start with one gateway replica, wait for sync, then scale up one replica at a time. On **upgrade**, use `maxUnavailable: 0` and `maxSurge: 1`. If autoscaling is enabled, throttle scale-up so new pods join one at a time. See the [Helm guide](gateway-cluster-sync-with-redis-using-kubernetes-helm.md#deployment-constraints) for details.
+{% endhint %}
+
+#### Upgrade from pre-cluster-scoped Redis keys
+
+Upgrading to a version with cluster-scoped keys changes the Redis key format. New gateway pods do not read legacy global keys (`distributed_event:API:...`). During rolling upgrade, the primary repopulates Redis from the management repository into the new cluster-scoped format. **Cluster name and sharding tags do not need to change** for a routine version upgrade—only the Redis encoding changes once.
+
+Future version upgrades (for example, 4.12 to 4.13) reuse the same cluster ID and Redis namespace; sync is incremental, not a full reload from the database.
+
 ***
 
 ## Agent Instructions: Querying This Documentation

--- a/docs/apim/4.12/configure-and-manage-the-platform/gravitee-gateway/gateway-cluster-sync-with-redis/gateway-cluster-sync-with-redis-using-docker.md
+++ b/docs/apim/4.12/configure-and-manage-the-platform/gravitee-gateway/gateway-cluster-sync-with-redis/gateway-cluster-sync-with-redis-using-docker.md
@@ -20,6 +20,21 @@ A standard Redis deployment without the Search module appears to connect success
 * Deploy a fully Self-Hosted Installation or a Hybrid Installation of APIM. For more information about self-hosted installation, see [Self-Hosted Installation Guides](/apim/4.10/self-hosted-installation-guides.md) or [Hybrid Installation & Configuration Guides](/apim/4.10/hybrid-installation-and-configuration-guides.md).
 * Deploy at least two API Gateway replicas. Distributed sync works only when `gateway.replicaCount` is greater than or equal to 2, and `gateway.autoscaling.enabled` is `false`, because the Helm chart only honors `replicaCount` when the HPA is disabled.
 
+## Cluster-scoped Redis and Hazelcast cluster naming
+
+From APIM 4.12, distributed sync keys in Redis are scoped by **cluster ID** (the Hazelcast `cluster-name`). When several gateway groups share one Redis instance—for example, `external` and `internal` gateway hosts—each group must use a **different** `<cluster-name>` in `hazelcast-cluster.xml`.
+
+| Gateway group | Example `cluster-name` | Redis key prefix |
+|:--------------|:-----------------------|:-----------------|
+| External gateways | `gio-apim-external` | `distributed_event:gio-apim-external:...` |
+| Internal gateways | `gio-apim-internal` | `distributed_event:gio-apim-internal:...` |
+
+If you change `cluster-name` or sharding tags, delete stale `distributed_event:*` and `distributed_sync_state:*` keys for the old cluster ID in Redis.
+
+{% hint style="warning" %}
+**Deployment constraints:** Start with one gateway instance per group, wait for the primary to sync, then add peers one at a time. During upgrades, replace gateways sequentially so the primary populates Redis before secondaries join.
+{% endhint %}
+
 ## Enable Distributed sync
 
 To configure Distributed sync with Redis, complete the following steps:
@@ -42,7 +57,7 @@ To configure Distributed sync with Redis, complete the following steps:
               xsi:schemaLocation="[http://www.hazelcast.com/schema/config](http://www.hazelcast.com/schema/config)
               [http://www.hazelcast.com/schema/config/hazelcast-config-5.3.xsd](http://www.hazelcast.com/schema/config/hazelcast-config-5.3.xsd)">
 
-       &#x3C;cluster-name>gio-apim-cluster&#x3C;/cluster-name>
+       &#x3C;cluster-name>gio-apim-external&#x3C;/cluster-name>
        &#x3C;network>
            &#x3C;port auto-increment="true" port-count="100">5701&#x3C;/port>
            &#x3C;join>
@@ -63,6 +78,10 @@ To configure Distributed sync with Redis, complete the following steps:
    * `<gateway_client>`. Replace this with the name of your first API Gateway.
    * `<gateway_client_2>`. Replace this with the name of your second API Gateway.
    * `<gateway_server>`. Replace this with the name of your third API Gateway.
+
+   {% hint style="info" %}
+   All gateways in the **same** sharding-tag group must share the **same** `cluster-name`. Gateways in a **different** group (for example, internal vs external) that share Redis must use a **different** `cluster-name`.
+   {% endhint %}
 
 ### Configure your Redis Repository
 
@@ -138,6 +157,14 @@ To enable your distributed sync repository, enable the Search module on your Red
 
    ```bash
    docker compose up -d
+   ```
+
+4. (Optional) Verify cluster-scoped keys in Redis:
+
+   ```bash
+   redis-cli KEYS 'distributed_sync_state:*'
+   redis-cli KEYS 'distributed_event:*' | head
+   # Expect prefixes matching your cluster-name, e.g. distributed_event:gio-apim-external:...
    ```
 
 ## Verification

--- a/docs/apim/4.12/configure-and-manage-the-platform/gravitee-gateway/gateway-cluster-sync-with-redis/gateway-cluster-sync-with-redis-using-docker.md
+++ b/docs/apim/4.12/configure-and-manage-the-platform/gravitee-gateway/gateway-cluster-sync-with-redis/gateway-cluster-sync-with-redis-using-docker.md
@@ -47,31 +47,37 @@ To configure Distributed sync with Redis, complete the following steps:
 
 1. In your `gravitee.yml` file, navigate to the `cluster` section, and then add the following configuration:
 
-   <pre class="language-yaml" data-title="gravitee.yml"><code class="lang-yaml">cluster:
-       type: hazelcast
-   </code></pre>
+   {% code title="gravitee.yml" %}
+   ```yaml
+   cluster:
+          type: hazelcast
+   ```
+   {% endcode %}
 2. In the `${gravitee.home}/config/hazelcast-cluster.xml` file, add the following configuration:
 
-   <pre class="language-xml" data-title="hazelcast-cluster.xml"><code class="lang-xml">&#x3C;hazelcast xmlns="[http://www.hazelcast.com/schema/config](http://www.hazelcast.com/schema/config)"
-              xmlns:xsi="[http://www.w3.org/2001/XMLSchema-instance](http://www.w3.org/2001/XMLSchema-instance)"
-              xsi:schemaLocation="[http://www.hazelcast.com/schema/config](http://www.hazelcast.com/schema/config)
-              [http://www.hazelcast.com/schema/config/hazelcast-config-5.3.xsd](http://www.hazelcast.com/schema/config/hazelcast-config-5.3.xsd)">
-
-       &#x3C;cluster-name>gio-apim-external&#x3C;/cluster-name>
-       &#x3C;network>
-           &#x3C;port auto-increment="true" port-count="100">5701&#x3C;/port>
-           &#x3C;join>
-               &#x3C;auto-detection enabled="true"/>
-               &#x3C;multicast enabled="false"/>
-               &#x3C;tcp-ip enabled="true">
-                   &#x3C;member>&#x3C;gateway_client>&#x3C;/member>
-                   &#x3C;member>&#x3C;gateway_client_2>&#x3C;/member>
-                   &#x3C;member>&#x3C;gateway_server>&#x3C;/member>
-               &#x3C;/tcp-ip>
-           &#x3C;/join>
-       &#x3C;/network>
-   &#x3C;/hazelcast>
-   </code></pre>
+   {% code title="hazelcast-cluster.xml" %}
+   ```xml
+   <hazelcast xmlns="http://www.hazelcast.com/schema/config"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xsi:schemaLocation="http://www.hazelcast.com/schema/config
+                 http://www.hazelcast.com/schema/config/hazelcast-config-5.3.xsd">
+   
+          <cluster-name>gio-apim-external</cluster-name>
+          <network>
+              <port auto-increment="true" port-count="100">5701</port>
+              <join>
+                  <auto-detection enabled="true"/>
+                  <multicast enabled="false"/>
+                  <tcp-ip enabled="true">
+                      <member><gateway_client></member>
+                      <member><gateway_client_2></member>
+                      <member><gateway_server></member>
+                  </tcp-ip>
+              </join>
+          </network>
+      </hazelcast>
+   ```
+   {% endcode %}
 
    Use the following values to replace the variables:
 
@@ -97,62 +103,68 @@ To enable your distributed sync repository, enable the Search module on your Red
 
 1. In your Docker Compose file, navigate to the `distributed-sync` section, and then add the following configuration:
 
-   <pre class="language-yaml" data-title="docker-compose.yml"><code class="lang-yaml">distributed-sync:
-    type: redis
-    redis:
-      # Redis Standalone settings
-      host: localhost
-      port: 6379
-      password:
-      # Redis Sentinel settings
-      sentinel:
-        master: redis-master
-        nodes:
-          - host: sentinel1
-            port: 26379
-          - host: sentinel2
-            port: 26379
-      # SSL settings
-      ssl: false
-      trustAll: true # default value is true to keep backward compatibility but you should set it to false and configure a truststore for security concerns
-      tlsProtocols: # List of TLS protocols to allow comma separated i.e: TLSv1.2, TLSv1.3
-      tlsCiphers: # List of TLS ciphers to allow comma separated i.e: TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384, TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384
-      alpn: false
-      openssl: false # Used to rely on OpenSSL Engine instead of default JDK SSL Engine
-      # Keystore for redis mTLS (client certificate)
-      keystore:
-        type: pem # Supports jks, pem, pkcs12
-        path: ${gravitee.home}/security/redis-keystore.jks # A path is required if certificate's type is jks or pkcs12
-        password: secret
-        keyPassword:
-        alias:
-        certificates: # Certificates are required if keystore's type is pem
-          - cert: ${gravitee.home}/security/redis-mycompany.org.pem
-        key: ${gravitee.home}/security/redis-mycompany.org.key
-          - cert: ${gravitee.home}/security/redis-mycompany.com.pem
-        key: ${gravitee.home}/security/redis-mycompany.com.key
-      truststore:
-        type: pem # Supports jks, pem, pkcs12
-        path: ${gravitee.home}/security/redis-truststore.jks
-        password: secret
-        alias:
-   </code></pre>
+   {% code title="docker-compose.yml" %}
+   ```yaml
+   distributed-sync:
+       type: redis
+       redis:
+         # Redis Standalone settings
+         host: localhost
+         port: 6379
+         password:
+         # Redis Sentinel settings
+         sentinel:
+           master: redis-master
+           nodes:
+             - host: sentinel1
+               port: 26379
+             - host: sentinel2
+               port: 26379
+         # SSL settings
+         ssl: false
+         trustAll: true # default value is true to keep backward compatibility but you should set it to false and configure a truststore for security concerns
+         tlsProtocols: # List of TLS protocols to allow comma separated i.e: TLSv1.2, TLSv1.3
+         tlsCiphers: # List of TLS ciphers to allow comma separated i.e: TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384, TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384
+         alpn: false
+         openssl: false # Used to rely on OpenSSL Engine instead of default JDK SSL Engine
+         # Keystore for redis mTLS (client certificate)
+         keystore:
+           type: pem # Supports jks, pem, pkcs12
+           path: ${gravitee.home}/security/redis-keystore.jks # A path is required if certificate's type is jks or pkcs12
+           password: secret
+           keyPassword:
+           alias:
+           certificates: # Certificates are required if keystore's type is pem
+             - cert: ${gravitee.home}/security/redis-mycompany.org.pem
+           key: ${gravitee.home}/security/redis-mycompany.org.key
+             - cert: ${gravitee.home}/security/redis-mycompany.com.pem
+           key: ${gravitee.home}/security/redis-mycompany.com.key
+         truststore:
+           type: pem # Supports jks, pem, pkcs12
+           path: ${gravitee.home}/security/redis-truststore.jks
+           password: secret
+           alias:
+   ```
+   {% endcode %}
 2. In the `services` section, add the following configuration:
 
-   <pre class="language-yaml" data-title="docker-compose.yml"><code class="lang-yaml">services:
-     # Synchronization daemon used to keep the gateway state in sync with the configuration from the management repository
-     # Be aware that, by disabling it, the gateway will not be sync with the configuration done through management API
-     # and management UI
-     sync:
-       # Synchronization is done each 5 seconds
-       delay: 5000
-       unit: MILLISECONDS
-       repository:
-         enabled : true
-       distributed:
-         enabled : true # By enabling this mode, data synchronization process is distributed over clustered API gateways. You must configure distributed-sync repository.
-       bulk_items: 100 # Defines the number of items to retrieve during synchronization (events, plans, API Keys, ...).
-   </code></pre>
+   {% code title="docker-compose.yml" %}
+   ```yaml
+   services:
+        # Synchronization daemon used to keep the gateway state in sync with the configuration from the management repository
+        # Be aware that, by disabling it, the gateway will not be sync with the configuration done through management API
+        # and management UI
+        sync:
+          # Synchronization is done each 5 seconds
+          delay: 5000
+          unit: MILLISECONDS
+          repository:
+            enabled : true
+          distributed:
+            enabled : true # By enabling this mode, data synchronization process is distributed over clustered API gateways. You must configure distributed-sync repository.
+          bulk_items: 100 # Defines the number of items to retrieve during synchronization (events, plans, API Keys, ...).
+   ```
+   {% endcode %}
 3. Start the API Gateway using the following command:
 
    ```bash

--- a/docs/apim/4.12/configure-and-manage-the-platform/gravitee-gateway/gateway-cluster-sync-with-redis/gateway-cluster-sync-with-redis-using-kubernetes-helm.md
+++ b/docs/apim/4.12/configure-and-manage-the-platform/gravitee-gateway/gateway-cluster-sync-with-redis/gateway-cluster-sync-with-redis-using-kubernetes-helm.md
@@ -46,14 +46,17 @@ Secondary gateways read distributed state from Redis. Initial sync on a secondar
 
 Example rolling strategy:
 
-<pre class="language-yaml" data-title="values.yaml"><code class="lang-yaml">gateway:
+{% code title="values.yaml" %}
+```yaml
+gateway:
   deployment:
     strategy:
       type: RollingUpdate
       rollingUpdate:
         maxUnavailable: 0
         maxSurge: 1
-</code></pre>
+```
+{% endcode %}
 
 ### Upgrade from legacy Redis keys
 
@@ -70,10 +73,13 @@ If `gateway.sharding_tags` or `gateway.cluster.hazelcast.clusterName` change, tr
 
 1. In your `values.yaml` file, navigate to the `gateway.additionalPlugins` section, and then add the `gravitee-node-cluster-plugin-hazelcast` plugin. You must download the Hazelcast plugin at pod startup, and it must match the `gravitee-node` version of your APIM release. For example, for 4.10.x, the `gravitee-node` version is 7.26.x, and the URL of the Hazelcast plugin is `https://repo1.maven.org/maven2/io/gravitee/node/gravitee-node-cluster-plugin-hazelcast/7.26.3/gravitee-node-cluster-plugin-hazelcast-7.26.3.zip`. To confirm the bundled `gravitee-node`, check the `gravitee-api-management` `pom.xml` on the matching branch by using `grep gravitee-node.version`.
 
-   <pre class="language-yaml" data-title="values.yaml"><code class="lang-yaml">gateway:
-     additionalPlugins:
-       - [https://repo1.maven.org/maven2/io/gravitee/node/gravitee-node-cluster-plugin-hazelcast/7.26.3/gravitee-node-cluster-plugin-hazelcast-7.26.3.zip](https://repo1.maven.org/maven2/io/gravitee/node/gravitee-node-cluster-plugin-hazelcast/7.26.3/gravitee-node-cluster-plugin-hazelcast-7.26.3.zip)
-   </code></pre>
+   {% code title="values.yaml" %}
+   ```yaml
+   gateway:
+        additionalPlugins:
+          - https://repo1.maven.org/maven2/io/gravitee/node/gravitee-node-cluster-plugin-hazelcast/7.26.3/gravitee-node-cluster-plugin-hazelcast-7.26.3.zip
+   ```
+   {% endcode %}
 
    <div data-gb-custom-block data-tag="hint" data-style="info" class="hint hint-info"><p>The Helm chart automatically downloads plugins listed in <code>additionalPlugins</code> using an init container at pod startup. Ensure that the pod has outbound access to <code>repo1.maven.org</code>, or mirror the file internally and adjust the URL.</p></div>
 1a. (Optional) Configure Redis Cluster nodes for rate limiting and Redis resource pool settings for cache and AI vector store resources. These settings apply gateway-wide and are sourced from `gravitee.yml` in production deployments.
@@ -95,145 +101,163 @@ If `gateway.sharding_tags` or `gateway.cluster.hazelcast.clusterName` change, tr
    | `gateway.aiVectorStoreRedis.connectTimeout` | AI vector store Redis resource TCP connect timeout (ms) | `2000` |
 
    **Example**:
-   <pre class="language-yaml" data-title="values.yaml"><code class="lang-yaml">gateway:
-     ratelimit:
-       redis:
-         cluster:
-           nodes:
-             - host: redis-node-1.example.com
-               port: 6379
-             - host: redis-node-2.example.com
-               port: 6379
-     cacheRedis:
-       maxPoolSize: 10
-       maxPoolWaiting: 2048
-       poolCleanerInterval: 30000
-       poolRecycleTimeout: 180000
-       maxWaitingHandlers: 1024
-       connectTimeout: 2000
-     aiVectorStoreRedis:
-       maxPoolSize: 10
-       maxPoolWaiting: 2048
-   </code></pre>
+   {% code title="values.yaml" %}
+   ```yaml
+   gateway:
+        ratelimit:
+          redis:
+            cluster:
+              nodes:
+                - host: redis-node-1.example.com
+                  port: 6379
+                - host: redis-node-2.example.com
+                  port: 6379
+        cacheRedis:
+          maxPoolSize: 10
+          maxPoolWaiting: 2048
+          poolCleanerInterval: 30000
+          poolRecycleTimeout: 180000
+          maxWaitingHandlers: 1024
+          connectTimeout: 2000
+        aiVectorStoreRedis:
+          maxPoolSize: 10
+          maxPoolWaiting: 2048
+   ```
+   {% endcode %}
 2. Create the Hazelcast configuration `ConfigMap` using the top-level `extraObjects` value. **Skip this step** if you rely on the chart-rendered `hazelcast.xml` (`gateway.cluster.type: hazelcast` without a custom `configPath`). Hazelcast requires an XML configuration for pods to discover each other. For Kubernetes, use Hazelcast Kubernetes discovery. For more information about Hazelcast Kubernetes discovery, see the [Kubernetes auto discovery documentation](https://docs.hazelcast.com/hazelcast/5.4/kubernetes/kubernetes-auto-discovery).
 
    <div data-gb-custom-block data-tag="hint" data-style="warning" class="hint hint-warning"><p><code>&#x3C;service-port>5701&#x3C;/service-port></code> is mandatory. Without the service port, the pod-label discovery of Hazelcast silently fails. Peer pods are discovered, but the cluster never forms because port <code>5701</code> is not declared as a <code>containerPort</code> on the Gateway deployment. The <code>&#x3C;service-port></code> element tells Hazelcast which port to use against the discovered pods directly. This bypasses the missing <code>containerPort</code> or Service entry.</p></div>
 
-   <pre class="language-yaml" data-title="values.yaml"><code class="lang-yaml">extraObjects:
-     - apiVersion: v1
-       kind: ConfigMap
-       metadata:
-         name: hazelcast-config
-       data:
-         hazelcast.xml: |
-           &#x3C;?xml version="1.0" encoding="UTF-8"?>
-           &#x3C;hazelcast xmlns="[http://www.hazelcast.com/schema/config](http://www.hazelcast.com/schema/config)"
-                      xmlns:xsi="[http://www.w3.org/2001/XMLSchema-instance](http://www.w3.org/2001/XMLSchema-instance)"
-                      xsi:schemaLocation="[http://www.hazelcast.com/schema/config](http://www.hazelcast.com/schema/config)
-                      [http://www.hazelcast.com/schema/config/hazelcast-config-5.3.xsd](http://www.hazelcast.com/schema/config/hazelcast-config-5.3.xsd)">
-
-               &#x3C;cluster-name>gio-apim-cluster&#x3C;/cluster-name>
-
-               &#x3C;properties>
-                   &#x3C;property name="hazelcast.logging.type">slf4j&#x3C;/property>
-                   &#x3C;property name="hazelcast.max.wait.seconds.before.join">20&#x3C;/property>
-                   &#x3C;property name="hazelcast.member.list.publish.interval.seconds">10&#x3C;/property>
-                   &#x3C;property name="hazelcast.socket.client.bind.any">false&#x3C;/property>
-                   &#x3C;property name="hazelcast.max.no.heartbeat.seconds">20&#x3C;/property>
-               &#x3C;/properties>
-
-               &#x3C;network>
-                   &#x3C;port auto-increment="false">5701&#x3C;/port>
-                   &#x3C;join>
-                       &#x3C;multicast enabled="false"/>
-                       &#x3C;tcp-ip enabled="false"/>
-                       &#x3C;kubernetes enabled="true">
-                           &#x3C;namespace>YOUR_NAMESPACE&#x3C;/namespace>
-                           &#x3C;pod-label-name>app.kubernetes.io/component&#x3C;/pod-label-name>
-                           &#x3C;pod-label-value>gateway&#x3C;/pod-label-value>
-                           &#x3C;service-port>5701&#x3C;/service-port>
-                       &#x3C;/kubernetes>
-                   &#x3C;/join>
-               &#x3C;/network>
-           &#x3C;/hazelcast>
-   </code></pre>
+   {% code title="values.yaml" %}
+   ```yaml
+   extraObjects:
+        - apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: hazelcast-config
+          data:
+            hazelcast.xml: |
+              <?xml version="1.0" encoding="UTF-8"?>
+              <hazelcast xmlns="http://www.hazelcast.com/schema/config"
+                         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                         xsi:schemaLocation="http://www.hazelcast.com/schema/config
+                         http://www.hazelcast.com/schema/config/hazelcast-config-5.3.xsd">
+   
+                  <cluster-name>gio-apim-cluster</cluster-name>
+   
+                  <properties>
+                      <property name="hazelcast.logging.type">slf4j</property>
+                      <property name="hazelcast.max.wait.seconds.before.join">20</property>
+                      <property name="hazelcast.member.list.publish.interval.seconds">10</property>
+                      <property name="hazelcast.socket.client.bind.any">false</property>
+                      <property name="hazelcast.max.no.heartbeat.seconds">20</property>
+                  </properties>
+   
+                  <network>
+                      <port auto-increment="false">5701</port>
+                      <join>
+                          <multicast enabled="false"/>
+                          <tcp-ip enabled="false"/>
+                          <kubernetes enabled="true">
+                              <namespace>YOUR_NAMESPACE</namespace>
+                              <pod-label-name>app.kubernetes.io/component</pod-label-name>
+                              <pod-label-value>gateway</pod-label-value>
+                              <service-port>5701</service-port>
+                          </kubernetes>
+                      </join>
+                  </network>
+              </hazelcast>
+   ```
+   {% endcode %}
 
    To complete the configuration, replace `YOUR_NAMESPACE` with the Kubernetes namespace where your gateways are deployed.
 3. Mount the ConfigMap into the API Gateway with `extraVolumes` and `extraVolumeMounts`.
 
-   <pre class="language-yaml" data-title="values.yaml"><code class="lang-yaml">gateway:
-     extraVolumes: |
-       - name: hazelcast-config
-         configMap:
-           name: hazelcast-config
-     extraVolumeMounts: |
-       - name: hazelcast-config
-         mountPath: /opt/graviteeio-gateway/config/hazelcast.xml
-         subPath: hazelcast.xml
-   </code></pre>
+   {% code title="values.yaml" %}
+   ```yaml
+   gateway:
+        extraVolumes: |
+          - name: hazelcast-config
+            configMap:
+              name: hazelcast-config
+        extraVolumeMounts: |
+          - name: hazelcast-config
+            mountPath: /opt/graviteeio-gateway/config/hazelcast.xml
+            subPath: hazelcast.xml
+   ```
+   {% endcode %}
 4. Grant the API Gateway `ServiceAccount` the RBAC permissions it needs to list pods. The Kubernetes discovery plugin for Hazelcast calls the Kubernetes API to list pods. The API Gateway `ServiceAccount` therefore needs `pods`, `endpoints`, `nodes`, and `services` read permissions. The default role of the chart only includes `configmaps` and `secrets`. Append the Hazelcast rules with `apim.roleRules`:
 
-   <pre class="language-yaml" data-title="values.yaml"><code class="lang-yaml">apim:
-     roleRules:
-       # Default chart rules — keep these.
-       - apiGroups: [""]
-         resources: [configmaps, secrets]
-         verbs: [get, list, watch]
-       # Required for Hazelcast Kubernetes auto-discovery.
-       - apiGroups: [""]
-         resources: [pods, endpoints, nodes, services]
-         verbs: [get, list]
-   </code></pre>
+   {% code title="values.yaml" %}
+   ```yaml
+   apim:
+        roleRules:
+          # Default chart rules — keep these.
+          - apiGroups: [""]
+            resources: [configmaps, secrets]
+            verbs: [get, list, watch]
+          # Required for Hazelcast Kubernetes auto-discovery.
+          - apiGroups: [""]
+            resources: [pods, endpoints, nodes, services]
+            verbs: [get, list]
+   ```
+   {% endcode %}
 
    <div data-gb-custom-block data-tag="hint" data-style="warning" class="hint hint-warning"><p>Without these RBAC rules, the Hazelcast plugin starts but fails to discover peers. You see <code>Forbidden: cannot list resource "pods"</code> in the gateway logs, and the second API Gateway never joins the cluster.</p></div>
 5. Enable clustering and distributed sync by setting the following configuration in your `values.yaml` file:
 
    <div data-gb-custom-block data-tag="hint" data-style="warning" class="hint hint-warning"><p>Do not enable <code>services.sync.kubernetes.enabled</code> unless you are running the Gravitee Kubernetes Operator (GKO). That property turns on a parallel sync source that reads API definitions from Kubernetes <code>ConfigMap</code>s, not a "use Kubernetes in distributed-sync mode" switch.</p></div>
 
-   <pre class="language-yaml" data-title="values.yaml"><code class="lang-yaml">gateway:
-     replicaCount: 2
-     sharding_tags: external   # one tag set per Helm release; cluster-name defaults to &lt;release&gt;-external
-     autoscaling:
-       enabled: false
-
-     cluster:
-       type: hazelcast
-       # hazelcast.xml is rendered by the chart; optional override:
-       # hazelcast:
-       #   clusterName: my-release-external
-
-     distributedSync:
-       enabled: true
-       type: redis
-       redis:
-         host: redis
-         port: 6379
-         # password:                  # if Redis requires auth
-         # ssl: false
-         # trustAll: true
-         # tlsProtocols: TLSv1.2
-         # sentinel:                  # uncomment for Sentinel
-         #   master: redis-master
-         #   nodes:
-         #     - host: sentinel1
-         #       port: 26379
-
-     services:
-       sync:
-         repository:
-           enabled: true
-         distributed:
-           enabled: true
-         # Do NOT enable services.sync.kubernetes.enabled unless you are running
-         # the Gravitee Kubernetes Operator (GKO / dbLess mode). It is unrelated to
-         # distributed sync and is a frequent source of failing startup probes
-         # on secondary nodes — see the Troubleshooting section.
-   </code></pre>
+   {% code title="values.yaml" %}
+   ```yaml
+   gateway:
+        replicaCount: 2
+        sharding_tags: external   # one tag set per Helm release; cluster-name defaults to <release>-external
+        autoscaling:
+          enabled: false
+   
+        cluster:
+          type: hazelcast
+          # hazelcast.xml is rendered by the chart; optional override:
+          # hazelcast:
+          #   clusterName: my-release-external
+   
+        distributedSync:
+          enabled: true
+          type: redis
+          redis:
+            host: redis
+            port: 6379
+            # password:                  # if Redis requires auth
+            # ssl: false
+            # trustAll: true
+            # tlsProtocols: TLSv1.2
+            # sentinel:                  # uncomment for Sentinel
+            #   master: redis-master
+            #   nodes:
+            #     - host: sentinel1
+            #       port: 26379
+   
+        services:
+          sync:
+            repository:
+              enabled: true
+            distributed:
+              enabled: true
+            # Do NOT enable services.sync.kubernetes.enabled unless you are running
+            # the Gravitee Kubernetes Operator (GKO / dbLess mode). It is unrelated to
+            # distributed sync and is a frequent source of failing startup probes
+            # on secondary nodes — see the Troubleshooting section.
+   ```
+   {% endcode %}
 6. Mount your Enterprise license, and then create the secret using the following configurations:
 
-   <pre class="language-yaml" data-title="values.yaml"><code class="lang-yaml">license:
-     name: licensekey-apim   # K8s secret name holding key 'licensekey'
-   </code></pre>
+   {% code title="values.yaml" %}
+   ```yaml
+   license:
+        name: licensekey-apim   # K8s secret name holding key 'licensekey'
+   ```
+   {% endcode %}
 
    ```bash
    kubectl -n gravitee-apim create secret generic licensekey-apim \
@@ -242,90 +266,93 @@ If `gateway.sharding_tags` or `gateway.cluster.hazelcast.clusterName` change, tr
 
    Review the following full `values.yaml` example:
 
-   <pre class="language-yaml" data-title="values.yaml"><code class="lang-yaml">extraObjects:
-     - apiVersion: v1
-       kind: ConfigMap
-       metadata:
-         name: hazelcast-config
-       data:
-         hazelcast.xml: |
-           &#x3C;?xml version="1.0" encoding="UTF-8"?>
-           &#x3C;hazelcast xmlns="[http://www.hazelcast.com/schema/config](http://www.hazelcast.com/schema/config)"
-                      xmlns:xsi="[http://www.w3.org/2001/XMLSchema-instance](http://www.w3.org/2001/XMLSchema-instance)"
-                      xsi:schemaLocation="[http://www.hazelcast.com/schema/config](http://www.hazelcast.com/schema/config)
-                      [http://www.hazelcast.com/schema/config/hazelcast-config-5.3.xsd](http://www.hazelcast.com/schema/config/hazelcast-config-5.3.xsd)">
-               &#x3C;cluster-name>gio-apim-cluster&#x3C;/cluster-name>
-               &#x3C;properties>
-                   &#x3C;property name="hazelcast.logging.type">slf4j&#x3C;/property>
-                   &#x3C;property name="hazelcast.max.wait.seconds.before.join">20&#x3C;/property>
-                   &#x3C;property name="hazelcast.member.list.publish.interval.seconds">10&#x3C;/property>
-                   &#x3C;property name="hazelcast.socket.client.bind.any">false&#x3C;/property>
-                   &#x3C;property name="hazelcast.max.no.heartbeat.seconds">20&#x3C;/property>
-               &#x3C;/properties>
-               &#x3C;network>
-                   &#x3C;port auto-increment="false">5701&#x3C;/port>
-                   &#x3C;join>
-                       &#x3C;multicast enabled="false"/>
-                       &#x3C;tcp-ip enabled="false"/>
-                       &#x3C;kubernetes enabled="true">
-                           &#x3C;namespace>gravitee-apim&#x3C;/namespace>
-                           &#x3C;pod-label-name>app.kubernetes.io/component&#x3C;/pod-label-name>
-                           &#x3C;pod-label-value>gateway&#x3C;/pod-label-value>
-                           &#x3C;service-port>5701&#x3C;/service-port>
-                       &#x3C;/kubernetes>
-                   &#x3C;/join>
-               &#x3C;/network>
-           &#x3C;/hazelcast>
-
-   apim:
-     roleRules:
-       - apiGroups: [""]
-         resources: [configmaps, secrets]
-         verbs: [get, list, watch]
-       - apiGroups: [""]
-         resources: [pods, endpoints, nodes, services]
-         verbs: [get, list]
-
-   license:
-     name: licensekey-apim
-
-   gateway:
-     enabled: true
-     replicaCount: 2
-     autoscaling:
-       enabled: false
-
-     additionalPlugins:
-       - [https://repo1.maven.org/maven2/io/gravitee/node/gravitee-node-cluster-plugin-hazelcast/7.26.3/gravitee-node-cluster-plugin-hazelcast-7.26.3.zip](https://repo1.maven.org/maven2/io/gravitee/node/gravitee-node-cluster-plugin-hazelcast/7.26.3/gravitee-node-cluster-plugin-hazelcast-7.26.3.zip)
-
-     cluster:
-       type: hazelcast
-       hazelcast:
-         configPath: /opt/graviteeio-gateway/config/hazelcast.xml
-
-     distributedSync:
-       enabled: true
-       type: redis
-       redis:
-         host: redis-stack
-         port: 6379
-
-     services:
-       sync:
-         repository:
-           enabled: true
-         distributed:
-           enabled: true
-
-     extraVolumes: |
-       - name: hazelcast-config
-         configMap:
-           name: hazelcast-config
-     extraVolumeMounts: |
-       - name: hazelcast-config
-         mountPath: /opt/graviteeio-gateway/config/hazelcast.xml
-         subPath: hazelcast.xml
-   </code></pre>
+   {% code title="values.yaml" %}
+   ```yaml
+   extraObjects:
+        - apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: hazelcast-config
+          data:
+            hazelcast.xml: |
+              <?xml version="1.0" encoding="UTF-8"?>
+              <hazelcast xmlns="http://www.hazelcast.com/schema/config"
+                         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                         xsi:schemaLocation="http://www.hazelcast.com/schema/config
+                         http://www.hazelcast.com/schema/config/hazelcast-config-5.3.xsd">
+                  <cluster-name>gio-apim-cluster</cluster-name>
+                  <properties>
+                      <property name="hazelcast.logging.type">slf4j</property>
+                      <property name="hazelcast.max.wait.seconds.before.join">20</property>
+                      <property name="hazelcast.member.list.publish.interval.seconds">10</property>
+                      <property name="hazelcast.socket.client.bind.any">false</property>
+                      <property name="hazelcast.max.no.heartbeat.seconds">20</property>
+                  </properties>
+                  <network>
+                      <port auto-increment="false">5701</port>
+                      <join>
+                          <multicast enabled="false"/>
+                          <tcp-ip enabled="false"/>
+                          <kubernetes enabled="true">
+                              <namespace>gravitee-apim</namespace>
+                              <pod-label-name>app.kubernetes.io/component</pod-label-name>
+                              <pod-label-value>gateway</pod-label-value>
+                              <service-port>5701</service-port>
+                          </kubernetes>
+                      </join>
+                  </network>
+              </hazelcast>
+   
+      apim:
+        roleRules:
+          - apiGroups: [""]
+            resources: [configmaps, secrets]
+            verbs: [get, list, watch]
+          - apiGroups: [""]
+            resources: [pods, endpoints, nodes, services]
+            verbs: [get, list]
+   
+      license:
+        name: licensekey-apim
+   
+      gateway:
+        enabled: true
+        replicaCount: 2
+        autoscaling:
+          enabled: false
+   
+        additionalPlugins:
+          - https://repo1.maven.org/maven2/io/gravitee/node/gravitee-node-cluster-plugin-hazelcast/7.26.3/gravitee-node-cluster-plugin-hazelcast-7.26.3.zip
+   
+        cluster:
+          type: hazelcast
+          hazelcast:
+            configPath: /opt/graviteeio-gateway/config/hazelcast.xml
+   
+        distributedSync:
+          enabled: true
+          type: redis
+          redis:
+            host: redis-stack
+            port: 6379
+   
+        services:
+          sync:
+            repository:
+              enabled: true
+            distributed:
+              enabled: true
+   
+        extraVolumes: |
+          - name: hazelcast-config
+            configMap:
+              name: hazelcast-config
+        extraVolumeMounts: |
+          - name: hazelcast-config
+            mountPath: /opt/graviteeio-gateway/config/hazelcast.xml
+            subPath: hazelcast.xml
+   ```
+   {% endcode %}
 
 ## Verification&#x20;
 

--- a/docs/apim/4.12/configure-and-manage-the-platform/gravitee-gateway/gateway-cluster-sync-with-redis/gateway-cluster-sync-with-redis-using-kubernetes-helm.md
+++ b/docs/apim/4.12/configure-and-manage-the-platform/gravitee-gateway/gateway-cluster-sync-with-redis/gateway-cluster-sync-with-redis-using-kubernetes-helm.md
@@ -20,6 +20,52 @@ A standard Redis deployment without the Search module appears to connect success
 * Deploy a fully Self-Hosted Installation or a Hybrid Installation of APIM. For more information about self-hosted installation, see [Self-Hosted Installation Guides](../../../self-hosted-installation-guides/README.md) or [Hybrid Installation & Configuration Guides](../../../hybrid-installation-and-configuration-guides/README.md).
 * Deploy at least two API Gateway replicas. Distributed sync works only when `gateway.replicaCount` is greater than or equal to 2, and `gateway.autoscaling.enabled` is `false`, because the Helm chart only honors `replicaCount` when the HPA is disabled.
 
+## Cluster-scoped Redis and Hazelcast cluster naming
+
+When multiple gateway Helm releases share one Redis instance (for example, one release per sharding tag: `external`, `internal`, `aog`), each release must form its **own Hazelcast cluster** with a **unique `cluster-name`**. That name becomes the runtime **cluster ID** and scopes all distributed sync keys in Redis.
+
+| Setting | Description |
+|:--------|:------------|
+| `gateway.sharding_tags` | Comma-separated sharding tags for this release (for example, `external`). Deploy one Helm release per tag set. |
+| `gateway.cluster.type` | Set to `hazelcast` when distributed sync is enabled. The chart renders `hazelcast.xml` and validates this pairing. |
+| `gateway.cluster.hazelcast.clusterName` | Optional override. Default: `<helm-release-name>-<sharding_tags>` (slugged, max 63 characters). Must differ across releases that share Redis. |
+
+{% hint style="info" %}
+From APIM 4.12, the Helm chart can render `config/hazelcast.xml` automatically when `gateway.cluster.type` is `hazelcast`. You do not need a separate `extraObjects` ConfigMap unless you override `gateway.cluster.hazelcast.configPath` with a custom file.
+{% endhint %}
+
+### Deployment constraints
+
+Secondary gateways read distributed state from Redis. Initial sync on a secondary is one-shot; the primary must publish state and events before secondaries can serve APIs.
+
+| Scenario | Requirement |
+|:---------|:--------------|
+| **Fresh install** | Set `gateway.replicaCount: 1` (or `gateway.autoscaling.minReplicas: 1`). Wait until the primary has synchronized. Scale up **one replica at a time**. |
+| **Upgrade** | Set `gateway.deployment.strategy.rollingUpdate.maxUnavailable: 0` and `maxSurge: 1` so pods join the Hazelcast cluster one at a time. |
+| **Autoscaling** | Do not set a high `minReplicas` on first install. Configure HPA `behavior.scaleUp` to add at most one pod per interval when distributed sync is enabled. |
+
+Example rolling strategy:
+
+<pre class="language-yaml" data-title="values.yaml"><code class="lang-yaml">gateway:
+  deployment:
+    strategy:
+      type: RollingUpdate
+      rollingUpdate:
+        maxUnavailable: 0
+        maxSurge: 1
+</code></pre>
+
+### Upgrade from legacy Redis keys
+
+Cluster-scoped keys are introduced in APIM 4.12. After upgrade:
+
+* New pods use keys such as `distributed_event:&lt;clusterId&gt;:...` and RediSearch index `distributed-event-search-idx-v2`.
+* Legacy keys without a cluster ID prefix are not read.
+* The primary repopulates Redis from the management repository during rollout; a second manual restart is not required if MongoDB is reachable.
+* Optionally delete stale `distributed_event:*` and `distributed_sync_state:*` entries and drop the old search index after all gateways are healthy.
+
+If `gateway.sharding_tags` or `gateway.cluster.hazelcast.clusterName` change, treat it as a new cluster: delete Redis keys for the old cluster ID.
+
 ## Configure the distributed sync on the APIM Gateway
 
 1. In your `values.yaml` file, navigate to the `gateway.additionalPlugins` section, and then add the `gravitee-node-cluster-plugin-hazelcast` plugin. You must download the Hazelcast plugin at pod startup, and it must match the `gravitee-node` version of your APIM release. For example, for 4.10.x, the `gravitee-node` version is 7.26.x, and the URL of the Hazelcast plugin is `https://repo1.maven.org/maven2/io/gravitee/node/gravitee-node-cluster-plugin-hazelcast/7.26.3/gravitee-node-cluster-plugin-hazelcast-7.26.3.zip`. To confirm the bundled `gravitee-node`, check the `gravitee-api-management` `pom.xml` on the matching branch by using `grep gravitee-node.version`.
@@ -69,7 +115,7 @@ A standard Redis deployment without the Search module appears to connect success
        maxPoolSize: 10
        maxPoolWaiting: 2048
    </code></pre>
-2. Create the Hazelcast configuration `ConfigMap` using the top-level `extraObjects` value. Hazelcast requires an XML configuration for pods to discover each other. For Kubernetes, use Hazelcast Kubernetes discovery. For more information about Hazelcast Kubernetes discovery, see the [Kubernetes auto discovery documentation](https://docs.hazelcast.com/hazelcast/5.4/kubernetes/kubernetes-auto-discovery).
+2. Create the Hazelcast configuration `ConfigMap` using the top-level `extraObjects` value. **Skip this step** if you rely on the chart-rendered `hazelcast.xml` (`gateway.cluster.type: hazelcast` without a custom `configPath`). Hazelcast requires an XML configuration for pods to discover each other. For Kubernetes, use Hazelcast Kubernetes discovery. For more information about Hazelcast Kubernetes discovery, see the [Kubernetes auto discovery documentation](https://docs.hazelcast.com/hazelcast/5.4/kubernetes/kubernetes-auto-discovery).
 
    <div data-gb-custom-block data-tag="hint" data-style="warning" class="hint hint-warning"><p><code>&#x3C;service-port>5701&#x3C;/service-port></code> is mandatory. Without the service port, the pod-label discovery of Hazelcast silently fails. Peer pods are discovered, but the cluster never forms because port <code>5701</code> is not declared as a <code>containerPort</code> on the Gateway deployment. The <code>&#x3C;service-port></code> element tells Hazelcast which port to use against the discovered pods directly. This bypasses the missing <code>containerPort</code> or Service entry.</p></div>
 
@@ -146,13 +192,15 @@ A standard Redis deployment without the Search module appears to connect success
 
    <pre class="language-yaml" data-title="values.yaml"><code class="lang-yaml">gateway:
      replicaCount: 2
+     sharding_tags: external   # one tag set per Helm release; cluster-name defaults to &lt;release&gt;-external
      autoscaling:
        enabled: false
 
      cluster:
        type: hazelcast
-       hazelcast:
-         configPath: /opt/graviteeio-gateway/config/hazelcast.xml
+       # hazelcast.xml is rendered by the chart; optional override:
+       # hazelcast:
+       #   clusterName: my-release-external
 
      distributedSync:
        enabled: true
@@ -296,12 +344,18 @@ After the `helm upgrade --install ... --wait` command completes, complete the fo
    ```
    INFO  i.g.p.r.i.RepositoryPluginHandler - Repository [DISTRIBUTED_SYNC] loaded by redis
    ```
-4. Ensure that the Distributed sync writes to Redis for the primary node only using the following command:
+4. Ensure that the Distributed sync writes to Redis for the primary node only using the following commands:
 
    ```bash
    kubectl -n gravitee-apim exec deploy/redis-stack -- redis-cli FT._LIST
-   # Expect at least: idx:distributed-sync-state, idx:distributed-sync-events
+   # Expect: distributed-event-search-idx-v2 (cluster-scoped index)
+
+   kubectl -n gravitee-apim exec deploy/redis-stack -- redis-cli KEYS 'distributed_sync_state:*'
+   kubectl -n gravitee-apim exec deploy/redis-stack -- redis-cli KEYS 'distributed_event:*' | head
+   # Expect cluster-scoped prefixes, e.g. distributed_event:my-gw-external:...
    ```
+
+   With multiple sharding-tag releases on shared Redis, you should see **one `distributed_sync_state:<clusterId>` per release**, each with a distinct cluster ID.
 5. Ensure that All probes return `200` with the following command:
 
    ```bash

--- a/vale/styles/config/vocabularies/docs/accept.txt
+++ b/vale/styles/config/vocabularies/docs/accept.txt
@@ -105,7 +105,7 @@ https
 # ============================================
 # Kubernetes & Containers
 # ============================================
-Kubernetes
+[Kk]ubernetes
 kubectl
 Helm
 ConfigMap[s]?
@@ -127,7 +127,7 @@ PostgreSQL
 MySQL
 MariaDB
 Elasticsearch
-Hazelcast
+[Hh]azelcast
 [Rr]edis
 DocumentDB
 R2DBC
@@ -836,3 +836,10 @@ tlsCiphers
 # Search & algorithm terms (2026-06-25)
 # ============================================
 Levenshtein
+
+# ============================================
+# Kubernetes deployment strategy keys (2026-06-26)
+# ============================================
+[Rr]ollingUpdate
+maxUnavailable
+maxSurge


### PR DESCRIPTION
## Summary

Documents cluster-scoped distributed sync introduced in APIM 4.12 (gravitee-api-management#18162):

- Redis keys and sync state scoped by Hazelcast `cluster-name` (cluster ID)
- One Helm release per sharding-tag cluster on shared Redis
- Default cluster naming (`<release>-<sharding_tags>`) and Helm auto-rendered `hazelcast.xml`
- Deployment constraints (primary before secondaries, rolling strategy, autoscaling)
- Upgrade path from legacy global Redis keys and verification commands

## Changes

- `gateway-cluster-sync-with-redis/README.md` — overview, key layout, multi-cluster model
- `gateway-cluster-sync-with-redis-using-kubernetes-helm.md` — Helm settings, constraints, migration, verification
- `gateway-cluster-sync-with-redis-using-docker.md` — distinct `cluster-name` per gateway group on shared Redis