### PR TITLE
docs(apim): add 4.12 to classic cloud Bridge/Gateway compatibility tables

### DIFF
--- a/docs/apim/4.12/.version-overrides
+++ b/docs/apim/4.12/.version-overrides
@@ -194,3 +194,4 @@ developer-portal/new-developer-portal/customize-the-navigation/portal-automation
 developer-portal/new-developer-portal/customize-the-navigation/portal-automation/portal-documentation.md
 developer-portal/new-developer-portal/customize-the-navigation/portal-automation/api-documentation.md
 terraform/example-resource-configurations.md
+hybrid-installation-and-configuration-guides/classic-cloud/README.md

--- a/docs/apim/4.12/hybrid-installation-and-configuration-guides/classic-cloud/README.md
+++ b/docs/apim/4.12/hybrid-installation-and-configuration-guides/classic-cloud/README.md
@@ -48,6 +48,7 @@ The following table lists the Gateway versions supported by each Bridge version.
 | 4.9.x          | 4.6.x to 4.9.x             |
 | 4.10.x         | 4.7.x to 4.10.x            |
 | 4.11.x         | 4.8.x to 4.11.x            |
+| 4.12.x         | 4.9.x to 4.12.x            |
 
 The following table lists the Bridge versions supported by each Gateway version.
 
@@ -57,9 +58,10 @@ The following table lists the Bridge versions supported by each Gateway version.
 | 4.6.x           | 4.6.x to 4.9.x            |
 | 4.7.x           | 4.7.x to 4.10.x           |
 | 4.8.x           | 4.8.x to 4.11.x           |
-| 4.9.x           | 4.9.x to 4.11.x           |
-| 4.10.x          | 4.10.x to 4.11.x          |
-| 4.11.x          | 4.11.x                    |
+| 4.9.x           | 4.9.x to 4.12.x           |
+| 4.10.x          | 4.10.x to 4.12.x          |
+| 4.11.x          | 4.11.x to 4.12.x          |
+| 4.12.x          | 4.12.x                    |
 
 ## Architecture
 


### PR DESCRIPTION
## What
Release-checklist item: update the **compatibility table** on the [classic cloud page](https://documentation.gravitee.io/apim/hybrid-installation-and-configuration-guides/classic-cloud) for the 4.12 release.

File: `docs/apim/4.12/hybrid-installation-and-configuration-guides/classic-cloud/README.md`

## Changes
**Bridge → Supported Gateway versions:** added `4.12.x → 4.9.x to 4.12.x`.

**Gateway → Supported Bridge versions:** added `4.12.x → 4.12.x`, and bumped the rows that were capped at the previous latest release from `4.11.x` to `4.12.x`:
- `4.9.x`: 4.9.x to 4.11.x → **4.9.x to 4.12.x**
- `4.10.x`: 4.10.x to 4.11.x → **4.10.x to 4.12.x**
- `4.11.x`: 4.11.x → **4.11.x to 4.12.x**

## Note for reviewer
These values follow the **3-minor-version compatibility window** that's consistent across all existing rows (Bridge N supports Gateway N-3→N; Gateway N supports Bridge N→N+3, capped at the latest release). Please confirm 4.12 keeps the same window before merging.
