### PR TITLE
[sync] am: 4.11 → 4.12

### DIFF
--- a/docs/am/4.12/releases-and-changelog/changelog/am-4.11.x.md
+++ b/docs/am/4.12/releases-and-changelog/changelog/am-4.11.x.md
@@ -6,6 +6,25 @@ description: >-
 
 # AM 4.11.x
 
+## Gravitee Access Management 4.11.10 - June 26, 2026
+
+<details>
+
+<summary>Bug fixes</summary>
+
+
+
+
+
+
+
+**Other**
+
+* User search error trying to use equality filters SCIM 2.0 query syntax (filterCriteriaParser) [#11564](https://github.com/gravitee-io/issues/issues/11564)
+
+</details>
+
+
 ## Gravitee Access Management 4.11.9 - June 19, 2026
 
 <details>


### PR DESCRIPTION
Auto-synced changes from `docs/am/4.11/` to `docs/am/4.12/`.

Triggered by push to `main` (308ebc2d43616d45acd976b5e40a51c9fc50124a).