### PR TITLE
docs(gamma): index all relevant pages and fix landing page title

### DIFF
--- a/docs/gamma/README.md
+++ b/docs/gamma/README.md
@@ -1,6 +1,5 @@
 ---
-hidden: false
-noIndex: true
+description: Overview of Gravitee Gamma.
 ---
 
 # Gravitee Gamma

--- a/docs/gamma/agent-management/build/README.md
+++ b/docs/gamma/agent-management/build/README.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Build

--- a/docs/gamma/agent-management/build/configure-an-llm-proxy.md
+++ b/docs/gamma/agent-management/build/configure-an-llm-proxy.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Configure an LLM Proxy

--- a/docs/gamma/agent-management/build/configure-your-a2a-proxy/README.md
+++ b/docs/gamma/agent-management/build/configure-your-a2a-proxy/README.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Configure your A2A Proxy

--- a/docs/gamma/agent-management/build/configure-your-a2a-proxy/add-policies-to-a2a-proxy.md
+++ b/docs/gamma/agent-management/build/configure-your-a2a-proxy/add-policies-to-a2a-proxy.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Add policies to your A2A Proxy

--- a/docs/gamma/agent-management/build/configure-your-access-management-instance.md
+++ b/docs/gamma/agent-management/build/configure-your-access-management-instance.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Configure your Access Management instance

--- a/docs/gamma/agent-management/build/configure-your-mcp/README.md
+++ b/docs/gamma/agent-management/build/configure-your-mcp/README.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Configure your MCP proxy

--- a/docs/gamma/agent-management/build/configure-your-mcp/add-policies-to-mcp-server.md
+++ b/docs/gamma/agent-management/build/configure-your-mcp/add-policies-to-mcp-server.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Add policies to your MCP server

--- a/docs/gamma/agent-management/build/configure-your-mcp/apply-policies-to-mcp-methods.md
+++ b/docs/gamma/agent-management/build/configure-your-mcp/apply-policies-to-mcp-methods.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Apply policies to specific MCP methods

--- a/docs/gamma/agent-management/build/configure-your-mcp/apply-policies-to-tool-invocations.md
+++ b/docs/gamma/agent-management/build/configure-your-mcp/apply-policies-to-tool-invocations.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Apply policies to individual tool invocations

--- a/docs/gamma/agent-management/build/create-an-agent-identity.md
+++ b/docs/gamma/agent-management/build/create-an-agent-identity.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Create an agent identity

--- a/docs/gamma/agent-management/build/create-an-llm-proxy.md
+++ b/docs/gamma/agent-management/build/create-an-llm-proxy.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Create an LLM Proxy

--- a/docs/gamma/agent-management/build/create-an-mcp-proxy.md
+++ b/docs/gamma/agent-management/build/create-an-mcp-proxy.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Create an MCP proxy

--- a/docs/gamma/agent-management/build/create-an-mcp-studio.md
+++ b/docs/gamma/agent-management/build/create-an-mcp-studio.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Create an MCP Studio

--- a/docs/gamma/agent-management/build/edit-mcp-studio-composition.md
+++ b/docs/gamma/agent-management/build/edit-mcp-studio-composition.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Edit MCP Studio composition

--- a/docs/gamma/agent-management/build/expose-agent-with-a2a-proxy.md
+++ b/docs/gamma/agent-management/build/expose-agent-with-a2a-proxy.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Expose your agent with the A2A Proxy

--- a/docs/gamma/agent-management/get-started/README.md
+++ b/docs/gamma/agent-management/get-started/README.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Get started

--- a/docs/gamma/agent-management/get-started/ai-management-overview.md
+++ b/docs/gamma/agent-management/get-started/ai-management-overview.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Agent Management overview

--- a/docs/gamma/agent-management/get-started/create-your-first-mcp-server.md
+++ b/docs/gamma/agent-management/get-started/create-your-first-mcp-server.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Create your first MCP server

--- a/docs/gamma/agent-management/get-started/create-your-llm-proxy.md
+++ b/docs/gamma/agent-management/get-started/create-your-llm-proxy.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Create your LLM Proxy

--- a/docs/gamma/agent-management/get-started/roles-and-permissions.md
+++ b/docs/gamma/agent-management/get-started/roles-and-permissions.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Roles and permissions

--- a/docs/gamma/agent-management/import/README.md
+++ b/docs/gamma/agent-management/import/README.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Import

--- a/docs/gamma/agent-management/import/add-an-ai-model.md
+++ b/docs/gamma/agent-management/import/add-an-ai-model.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Add an AI model

--- a/docs/gamma/agent-management/import/add-an-mcp-registry.md
+++ b/docs/gamma/agent-management/import/add-an-mcp-registry.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Add an MCP Registry

--- a/docs/gamma/agent-management/import/add-knowledge-source.md
+++ b/docs/gamma/agent-management/import/add-knowledge-source.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Add a knowledge source

--- a/docs/gamma/agent-management/import/add-mcp-resources.md
+++ b/docs/gamma/agent-management/import/add-mcp-resources.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Add MCP resources

--- a/docs/gamma/agent-management/import/connect-integrations.md
+++ b/docs/gamma/agent-management/import/connect-integrations.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Connect integrations

--- a/docs/gamma/agent-management/import/create-api-tools.md
+++ b/docs/gamma/agent-management/import/create-api-tools.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Create API tools

--- a/docs/gamma/agent-management/import/import-an-agent.md
+++ b/docs/gamma/agent-management/import/import-an-agent.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Register an agent

--- a/docs/gamma/agent-management/import/import-prompts.md
+++ b/docs/gamma/agent-management/import/import-prompts.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Import prompts

--- a/docs/gamma/agent-management/import/register-an-mcp-server.md
+++ b/docs/gamma/agent-management/import/register-an-mcp-server.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Register an MCP server

--- a/docs/gamma/agent-management/import/upload-skills.md
+++ b/docs/gamma/agent-management/import/upload-skills.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Upload skills

--- a/docs/gamma/agent-management/observe/README.md
+++ b/docs/gamma/agent-management/observe/README.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Observe

--- a/docs/gamma/agent-management/observe/inspect-your-agent-log.md
+++ b/docs/gamma/agent-management/observe/inspect-your-agent-log.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Inspect your agent log

--- a/docs/gamma/agent-management/observe/monitor-ai-gateway-from-devices.md
+++ b/docs/gamma/agent-management/observe/monitor-ai-gateway-from-devices.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Monitor AI Gateway usage from employee systems

--- a/docs/gamma/agent-management/observe/monitor-your-mcp-servers.md
+++ b/docs/gamma/agent-management/observe/monitor-your-mcp-servers.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Monitor your MCP servers

--- a/docs/gamma/agent-management/publish/README.md
+++ b/docs/gamma/agent-management/publish/README.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Publish

--- a/docs/gamma/agent-management/publish/expose-an-mcp-registry.md
+++ b/docs/gamma/agent-management/publish/expose-an-mcp-registry.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Expose an MCP Registry

--- a/docs/gamma/agent-management/publish/manage-subscriptions.md
+++ b/docs/gamma/agent-management/publish/manage-subscriptions.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Manage subscriptions

--- a/docs/gamma/agent-management/publish/publish-your-llm-proxy.md
+++ b/docs/gamma/agent-management/publish/publish-your-llm-proxy.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Publish your LLM Proxy

--- a/docs/gamma/api-management/build/README.md
+++ b/docs/gamma/api-management/build/README.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Build

--- a/docs/gamma/api-management/build/api-products.md
+++ b/docs/gamma/api-management/build/api-products.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Create API Products

--- a/docs/gamma/api-management/build/configure-your-api-product/README.md
+++ b/docs/gamma/api-management/build/configure-your-api-product/README.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Configure API products

--- a/docs/gamma/api-management/build/configure-your-api-product/manage-product-apis.md
+++ b/docs/gamma/api-management/build/configure-your-api-product/manage-product-apis.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Manage product APIs

--- a/docs/gamma/api-management/build/configure-your-api-proxy/README.md
+++ b/docs/gamma/api-management/build/configure-your-api-proxy/README.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Configure your API proxy

--- a/docs/gamma/api-management/build/configure-your-api-proxy/apply-security-policies.md
+++ b/docs/gamma/api-management/build/configure-your-api-proxy/apply-security-policies.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Apply security policies

--- a/docs/gamma/api-management/build/configure-your-api-proxy/configure-backend-security.md
+++ b/docs/gamma/api-management/build/configure-your-api-proxy/configure-backend-security.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Configure endpoints

--- a/docs/gamma/api-management/build/configure-your-api-proxy/configure-flow-execution.md
+++ b/docs/gamma/api-management/build/configure-your-api-proxy/configure-flow-execution.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Control how policy flows are matched to requests

--- a/docs/gamma/api-management/build/configure-your-api-proxy/establish-consumer-access.md
+++ b/docs/gamma/api-management/build/configure-your-api-proxy/establish-consumer-access.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Establish consumer access

--- a/docs/gamma/api-management/build/create-an-api-proxy.md
+++ b/docs/gamma/api-management/build/create-an-api-proxy.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Create an API proxy

--- a/docs/gamma/api-management/build/secure-your-api-proxy.md
+++ b/docs/gamma/api-management/build/secure-your-api-proxy.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Secure your API proxy

--- a/docs/gamma/api-management/build/shared-policy-groups.md
+++ b/docs/gamma/api-management/build/shared-policy-groups.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Reuse policies with shared policy groups

--- a/docs/gamma/api-management/get-started/README.md
+++ b/docs/gamma/api-management/get-started/README.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Get started

--- a/docs/gamma/api-management/get-started/api-management-overview.md
+++ b/docs/gamma/api-management/get-started/api-management-overview.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # API Management overview

--- a/docs/gamma/api-management/get-started/create-your-first-api.md
+++ b/docs/gamma/api-management/get-started/create-your-first-api.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Create your first API

--- a/docs/gamma/api-management/observe/README.md
+++ b/docs/gamma/api-management/observe/README.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Observe

--- a/docs/gamma/api-management/observe/api-dashboard.md
+++ b/docs/gamma/api-management/observe/api-dashboard.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Dashboard and metrics

--- a/docs/gamma/api-management/observe/monitor-api-usage.md
+++ b/docs/gamma/api-management/observe/monitor-api-usage.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Monitor API usage

--- a/docs/gamma/api-management/observe/monitor-endpoint-health.md
+++ b/docs/gamma/api-management/observe/monitor-endpoint-health.md
@@ -1,5 +1,5 @@
 ---
-noIndex: true
+noIndex: false
 ---
 
 # Monitor endpoint health

--- a/docs/gamma/api-management/observe/view-api-logs.md
+++ b/docs/gamma/api-management/observe/view-api-logs.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # View API logs

--- a/docs/gamma/authorization-management/authz-gateway-sync.md
+++ b/docs/gamma/authorization-management/authz-gateway-sync.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # AuthZEN PDP synchronization

--- a/docs/gamma/authorization-management/configure/README.md
+++ b/docs/gamma/authorization-management/configure/README.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Configure

--- a/docs/gamma/authorization-management/configure/ai-policy-example.md
+++ b/docs/gamma/authorization-management/configure/ai-policy-example.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # AI policy example

--- a/docs/gamma/authorization-management/configure/api-policy-examples.md
+++ b/docs/gamma/authorization-management/configure/api-policy-examples.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # API policy examples

--- a/docs/gamma/authorization-management/configure/create-update-delete-policies.md
+++ b/docs/gamma/authorization-management/configure/create-update-delete-policies.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Create, update, and delete policies

--- a/docs/gamma/authorization-management/configure/custom-policies/README.md
+++ b/docs/gamma/authorization-management/configure/custom-policies/README.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Custom policies

--- a/docs/gamma/authorization-management/configure/custom-policies/create-a-custom-policy.md
+++ b/docs/gamma/authorization-management/configure/custom-policies/create-a-custom-policy.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Create a custom policy

--- a/docs/gamma/authorization-management/configure/custom-policies/custom-policies-overview.md
+++ b/docs/gamma/authorization-management/configure/custom-policies/custom-policies-overview.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Custom policies overview

--- a/docs/gamma/authorization-management/configure/mcp-policy-examples.md
+++ b/docs/gamma/authorization-management/configure/mcp-policy-examples.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # MCP policy examples

--- a/docs/gamma/authorization-management/evaluate/README.md
+++ b/docs/gamma/authorization-management/evaluate/README.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Evaluate

--- a/docs/gamma/authorization-management/evaluate/configure-gravitee-gateway-as-runtime.md
+++ b/docs/gamma/authorization-management/evaluate/configure-gravitee-gateway-as-runtime.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Configure the Gravitee Gateway as a runtime

--- a/docs/gamma/authorization-management/evaluate/configure-sidecar-as-runtime.md
+++ b/docs/gamma/authorization-management/evaluate/configure-sidecar-as-runtime.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Configure a sidecar as runtime

--- a/docs/gamma/authorization-management/evaluate/policy-syncs.md
+++ b/docs/gamma/authorization-management/evaluate/policy-syncs.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Policy syncs

--- a/docs/gamma/authorization-management/get-started/README.md
+++ b/docs/gamma/authorization-management/get-started/README.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Get started

--- a/docs/gamma/authorization-management/get-started/authorization-management-overview.md
+++ b/docs/gamma/authorization-management/get-started/authorization-management-overview.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Authorization Management overview

--- a/docs/gamma/authorization-management/get-started/create-your-first-policy.md
+++ b/docs/gamma/authorization-management/get-started/create-your-first-policy.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Create your first policy

--- a/docs/gamma/authorization-management/get-started/create-your-first-user.md
+++ b/docs/gamma/authorization-management/get-started/create-your-first-user.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Create your first user

--- a/docs/gamma/authorization-management/get-started/import-your-first-resource-from-agent-catalog.md
+++ b/docs/gamma/authorization-management/get-started/import-your-first-resource-from-agent-catalog.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Import your first resource from Agent catalog

--- a/docs/gamma/authorization-management/manage/README.md
+++ b/docs/gamma/authorization-management/manage/README.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Manage

--- a/docs/gamma/authorization-management/manage/actions/README.md
+++ b/docs/gamma/authorization-management/manage/actions/README.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Manage actions

--- a/docs/gamma/authorization-management/manage/actions/action-naming-and-scope.md
+++ b/docs/gamma/authorization-management/manage/actions/action-naming-and-scope.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Action naming and scope

--- a/docs/gamma/authorization-management/manage/actions/create-an-action.md
+++ b/docs/gamma/authorization-management/manage/actions/create-an-action.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Create an action

--- a/docs/gamma/authorization-management/manage/principals/README.md
+++ b/docs/gamma/authorization-management/manage/principals/README.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Manage principals

--- a/docs/gamma/authorization-management/manage/principals/add-attributes-to-principals.md
+++ b/docs/gamma/authorization-management/manage/principals/add-attributes-to-principals.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Add attributes to principals

--- a/docs/gamma/authorization-management/manage/principals/build-principal-relationships.md
+++ b/docs/gamma/authorization-management/manage/principals/build-principal-relationships.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Build principal relationships

--- a/docs/gamma/authorization-management/manage/principals/create-a-local-principal.md
+++ b/docs/gamma/authorization-management/manage/principals/create-a-local-principal.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Create a local principal

--- a/docs/gamma/authorization-management/manage/principals/sync-principals-from-access-management.md
+++ b/docs/gamma/authorization-management/manage/principals/sync-principals-from-access-management.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Sync principals from Access Management

--- a/docs/gamma/authorization-management/manage/resources/README.md
+++ b/docs/gamma/authorization-management/manage/resources/README.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Manage resources

--- a/docs/gamma/authorization-management/manage/resources/add-attributes-to-resources.md
+++ b/docs/gamma/authorization-management/manage/resources/add-attributes-to-resources.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Add attributes to resources

--- a/docs/gamma/authorization-management/manage/resources/build-resource-relationships.md
+++ b/docs/gamma/authorization-management/manage/resources/build-resource-relationships.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Build resource relationships

--- a/docs/gamma/authorization-management/manage/resources/create-a-local-resource.md
+++ b/docs/gamma/authorization-management/manage/resources/create-a-local-resource.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Create a local resource

--- a/docs/gamma/authorization-management/manage/resources/import-resources-from-catalog.md
+++ b/docs/gamma/authorization-management/manage/resources/import-resources-from-catalog.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Import resources from Catalog

--- a/docs/gamma/authorization-management/manage/schemas/README.md
+++ b/docs/gamma/authorization-management/manage/schemas/README.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Manage schemas

--- a/docs/gamma/authorization-management/manage/schemas/schema-generation.md
+++ b/docs/gamma/authorization-management/manage/schemas/schema-generation.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Schema generation

--- a/docs/gamma/edge-management/README.md
+++ b/docs/gamma/edge-management/README.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Edge Daemon

--- a/docs/gamma/edge-management/connect-claude-code-to-daemon.md
+++ b/docs/gamma/edge-management/connect-claude-code-to-daemon.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Connect Claude Code to the Edge Daemon

--- a/docs/gamma/edge-management/connect/README.md
+++ b/docs/gamma/edge-management/connect/README.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Connect

--- a/docs/gamma/edge-management/connect/configure-edge-ingress.md
+++ b/docs/gamma/edge-management/connect/configure-edge-ingress.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Configure Edge Ingress

--- a/docs/gamma/edge-management/connect/configure-edge-management.md
+++ b/docs/gamma/edge-management/connect/configure-edge-management.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 description: How to configure the Edge Management settings, proxy routes, and shadow AI monitoring in the Gamma console.
 ---
 

--- a/docs/gamma/edge-management/connect/configure-kandji-daemon.md
+++ b/docs/gamma/edge-management/connect/configure-kandji-daemon.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 description: How to deploy the Edge Daemon to your macOS device fleet using Kandji MDM.
 ---
 

--- a/docs/gamma/edge-management/connect/proxy-api-reference.md
+++ b/docs/gamma/edge-management/connect/proxy-api-reference.md
@@ -1,7 +1,7 @@
 ---
 description: Reference for the LLM Proxy and HTTP proxy APIs in APIM that handle traffic intercepted by the Edge Daemon.
 hidden: false
-noIndex: true
+noIndex: false
 ---
  
 # Proxy API reference

--- a/docs/gamma/edge-management/get-started/README.md
+++ b/docs/gamma/edge-management/get-started/README.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Get started

--- a/docs/gamma/edge-management/get-started/edge-management-overview.md
+++ b/docs/gamma/edge-management/get-started/edge-management-overview.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Edge Daemon

--- a/docs/gamma/event-stream-management/build/README.md
+++ b/docs/gamma/event-stream-management/build/README.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 <--to be published -->
 # Build

--- a/docs/gamma/event-stream-management/build/create-a-kafka-service-with-a-registered-cluster.md
+++ b/docs/gamma/event-stream-management/build/create-a-kafka-service-with-a-registered-cluster.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 <--- to be published --->
 

--- a/docs/gamma/event-stream-management/build/create-a-kafka-service-with-a-virtual-cluster.md
+++ b/docs/gamma/event-stream-management/build/create-a-kafka-service-with-a-virtual-cluster.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 <--- to be published --->
 

--- a/docs/gamma/event-stream-management/build/establish-a-virtual-cluster.md
+++ b/docs/gamma/event-stream-management/build/establish-a-virtual-cluster.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 <-- to be published-->
 # Establish a Virtual Cluster

--- a/docs/gamma/event-stream-management/build/kafka-virtual-cluster-runtime-behavior-reference.md
+++ b/docs/gamma/event-stream-management/build/kafka-virtual-cluster-runtime-behavior-reference.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 <-- to be published -->
 # Virtual Cluster runtime behavior

--- a/docs/gamma/event-stream-management/build/kafka-virtual-clusters-overview.md
+++ b/docs/gamma/event-stream-management/build/kafka-virtual-clusters-overview.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 <-- to be published -->
 # Virtual Clusters overview

--- a/docs/gamma/event-stream-management/get-started/README.md
+++ b/docs/gamma/event-stream-management/get-started/README.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Get started

--- a/docs/gamma/event-stream-management/get-started/create-your-first-kafka-service.md
+++ b/docs/gamma/event-stream-management/get-started/create-your-first-kafka-service.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 <-- to be published -->
 # Create your first Kafka service

--- a/docs/gamma/event-stream-management/get-started/create-your-first-virtual-cluster.md
+++ b/docs/gamma/event-stream-management/get-started/create-your-first-virtual-cluster.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 # Create your first Virtual Cluster
 

--- a/docs/gamma/event-stream-management/get-started/event-stream-management-overview.md
+++ b/docs/gamma/event-stream-management/get-started/event-stream-management-overview.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 <-- to be published -->
 # Event Stream Management overview

--- a/docs/gamma/event-stream-management/get-started/register-your-first-cluster.md
+++ b/docs/gamma/event-stream-management/get-started/register-your-first-cluster.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 <-- to be published -->
 # Register your first cluster

--- a/docs/gamma/event-stream-management/import/README.md
+++ b/docs/gamma/event-stream-management/import/README.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 <-- to be published -->
 # Import

--- a/docs/gamma/event-stream-management/import/register-your-kafka-clusters.md
+++ b/docs/gamma/event-stream-management/import/register-your-kafka-clusters.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 # Register your Kafka clusters
 

--- a/docs/gamma/platform-management/configure-access-management.md
+++ b/docs/gamma/platform-management/configure-access-management.md
@@ -1,5 +1,5 @@
 ---
-noIndex: true
+noIndex: false
 ---
 
 # Configure Access Management

--- a/docs/gamma/platform-management/configure-openapi-viewer.md
+++ b/docs/gamma/platform-management/configure-openapi-viewer.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Configure OpenAPI viewer

--- a/docs/gamma/platform-management/get-started/get-started-for-existing-users/README.md
+++ b/docs/gamma/platform-management/get-started/get-started-for-existing-users/README.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 # Get started for existing users
 

--- a/docs/gamma/platform-management/get-started/get-started-for-existing-users/activate-gamma-with-docker-compose.md
+++ b/docs/gamma/platform-management/get-started/get-started-for-existing-users/activate-gamma-with-docker-compose.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 # Activate Gamma with Docker Compose
 <!-- GAP-STRUCTURAL: Missing procedural content source -->

--- a/docs/gamma/platform-management/get-started/get-started-for-existing-users/activate-gamma-with-kubernetes-helm.md
+++ b/docs/gamma/platform-management/get-started/get-started-for-existing-users/activate-gamma-with-kubernetes-helm.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 # Activate Gamma with Kubernetes (Helm)
 <!-- GAP-STRUCTURAL: Missing procedural content source -->

--- a/docs/gamma/platform-management/get-started/get-started-for-new-users/README.md
+++ b/docs/gamma/platform-management/get-started/get-started-for-new-users/README.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 # Get started for new users
 

--- a/docs/gamma/platform-management/get-started/get-started-for-new-users/fully-self-hosted-with-docker.md
+++ b/docs/gamma/platform-management/get-started/get-started-for-new-users/fully-self-hosted-with-docker.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 # Fully self-hosted installation with Docker
 

--- a/docs/gamma/platform-management/get-started/get-started-for-new-users/fully-self-hosted-with-vanilla-kubernetes.md
+++ b/docs/gamma/platform-management/get-started/get-started-for-new-users/fully-self-hosted-with-vanilla-kubernetes.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 # Fully self-hosted installation with Vanilla Kubernetes
 

--- a/docs/gamma/platform-management/install/hybrid-installation-guides/README.md
+++ b/docs/gamma/platform-management/install/hybrid-installation-guides/README.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 # Hybrid installation guides
 

--- a/docs/gamma/platform-management/install/hybrid-installation-guides/docker/README.md
+++ b/docs/gamma/platform-management/install/hybrid-installation-guides/docker/README.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 # Docker
 

--- a/docs/gamma/platform-management/install/hybrid-installation-guides/docker/docker-cli.md
+++ b/docs/gamma/platform-management/install/hybrid-installation-guides/docker/docker-cli.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 # Run a hybrid Gamma Gateway with Docker CLI
 <!-- GAP-STRUCTURAL: Missing procedural content source -->

--- a/docs/gamma/platform-management/install/hybrid-installation-guides/docker/docker-compose.md
+++ b/docs/gamma/platform-management/install/hybrid-installation-guides/docker/docker-compose.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 # Run a hybrid Gamma Gateway with Docker Compose
 <!-- GAP-STRUCTURAL: Missing procedural content source -->

--- a/docs/gamma/platform-management/install/hybrid-installation-guides/kubernetes/README.md
+++ b/docs/gamma/platform-management/install/hybrid-installation-guides/kubernetes/README.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 # Kubernetes
 

--- a/docs/gamma/platform-management/install/hybrid-installation-guides/kubernetes/aws-eks.md
+++ b/docs/gamma/platform-management/install/hybrid-installation-guides/kubernetes/aws-eks.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 # Install a hybrid Gamma Gateway on AWS EKS
 <!-- GAP-STRUCTURAL: Missing procedural content source -->

--- a/docs/gamma/platform-management/install/hybrid-installation-guides/kubernetes/azure-aks.md
+++ b/docs/gamma/platform-management/install/hybrid-installation-guides/kubernetes/azure-aks.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 # Install a hybrid Gamma Gateway on Azure AKS
 <!-- GAP-STRUCTURAL: Missing procedural content source -->

--- a/docs/gamma/platform-management/install/hybrid-installation-guides/kubernetes/openshift.md
+++ b/docs/gamma/platform-management/install/hybrid-installation-guides/kubernetes/openshift.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 # Install a hybrid Gamma Gateway on OpenShift
 <!-- GAP-STRUCTURAL: Missing procedural content source -->

--- a/docs/gamma/platform-management/install/hybrid-installation-guides/kubernetes/vanilla-kubernetes.md
+++ b/docs/gamma/platform-management/install/hybrid-installation-guides/kubernetes/vanilla-kubernetes.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 # Install a hybrid Gamma Gateway on Vanilla Kubernetes
 <!-- GAP-STRUCTURAL: Missing procedural content source -->

--- a/docs/gamma/platform-management/install/self-hosted-installation-guides/README.md
+++ b/docs/gamma/platform-management/install/self-hosted-installation-guides/README.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 # Self-hosted installation guides
 

--- a/docs/gamma/platform-management/install/self-hosted-installation-guides/docker/README.md
+++ b/docs/gamma/platform-management/install/self-hosted-installation-guides/docker/README.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 # Docker
 

--- a/docs/gamma/platform-management/install/self-hosted-installation-guides/docker/docker-cli.md
+++ b/docs/gamma/platform-management/install/self-hosted-installation-guides/docker/docker-cli.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 # Run Gamma with Docker CLI
 <!-- GAP-STRUCTURAL: Missing procedural content source -->

--- a/docs/gamma/platform-management/install/self-hosted-installation-guides/docker/docker-compose.md
+++ b/docs/gamma/platform-management/install/self-hosted-installation-guides/docker/docker-compose.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 # Run Gamma with Docker Compose
 <!-- GAP-STRUCTURAL: Missing procedural content source -->

--- a/docs/gamma/platform-management/install/self-hosted-installation-guides/kubernetes/README.md
+++ b/docs/gamma/platform-management/install/self-hosted-installation-guides/kubernetes/README.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 # Kubernetes
 

--- a/docs/gamma/platform-management/install/self-hosted-installation-guides/kubernetes/aws-eks.md
+++ b/docs/gamma/platform-management/install/self-hosted-installation-guides/kubernetes/aws-eks.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 # Install Gamma on AWS EKS
 <!-- GAP-STRUCTURAL: Missing procedural content source -->

--- a/docs/gamma/platform-management/install/self-hosted-installation-guides/kubernetes/azure-aks.md
+++ b/docs/gamma/platform-management/install/self-hosted-installation-guides/kubernetes/azure-aks.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 # Install Gamma on Azure AKS
 <!-- GAP-STRUCTURAL: Missing procedural content source -->

--- a/docs/gamma/platform-management/install/self-hosted-installation-guides/kubernetes/openshift.md
+++ b/docs/gamma/platform-management/install/self-hosted-installation-guides/kubernetes/openshift.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 # Install Gamma on OpenShift
 <!-- GAP-STRUCTURAL: Missing procedural content source -->

--- a/docs/gamma/platform-management/install/self-hosted-installation-guides/kubernetes/vanilla-kubernetes.md
+++ b/docs/gamma/platform-management/install/self-hosted-installation-guides/kubernetes/vanilla-kubernetes.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 # Install Gamma on Vanilla Kubernetes
 <!-- GAP-STRUCTURAL: Missing procedural content source -->

--- a/docs/gamma/platform-management/manage-applications.md
+++ b/docs/gamma/platform-management/manage-applications.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Manage applications

--- a/docs/gamma/platform-management/manage-resources.md
+++ b/docs/gamma/platform-management/manage-resources.md
@@ -1,6 +1,6 @@
 ---
 hidden: false
-noIndex: true
+noIndex: false
 ---
 
 # Manage resources


### PR DESCRIPTION
## What

Two post-migration fixes for the Gamma docs now that the GitBook Gamma space syncs from `docs/gamma`:

1. **Indexing** — 144 Gamma pages had `noIndex: true` (a leftover from when Gamma was pre-GA/private), which de-indexed them from search and showed every page as "not indexed." Flipped them to `noIndex: false` to match the house convention (published spaces are indexed by default). The 6 intentionally hidden pages (`hidden: true`) keep `noIndex: true`.

2. **Landing page title** — `docs/gamma/README.md` used `hidden`/`noIndex` front-matter with no `description`, so GitBook fell back to the filename "README" for the landing page. Switched it to the same convention as APIM/AM/GKO/Cloud (`description` front-matter + H1), so the title resolves to **Gravitee Gamma**.

All changes are front-matter only. No content was touched.

## After merge

Re-sync the Gamma GitBook space (GitHub → GitBook) to pull these in.

