### PR TITLE
docs(gamma): fix broken internal links and remove AM note

### DIFF
--- a/docs/gamma/agent-management/build/create-an-llm-proxy.md
+++ b/docs/gamma/agent-management/build/create-an-llm-proxy.md
@@ -89,4 +89,4 @@ This is the recommended path for routing Claude Code, Cursor, and other developm
 
 * **Configure routing** — Add models and routing strategies. See [Configure an LLM Proxy](configure-an-llm-proxy.md).
 * **Publish** — Make the LLM Proxy discoverable. See [Publish your LLM Proxy](../publish/publish-your-llm-proxy.md).
-* **Route through Edge Daemon** — For employee device traffic, route through Edge Management. See [Connect Claude Code to the Edge Daemon](../edge-daemon/connect-claude-code-to-daemon.md).
+* **Route through Edge Daemon** — For employee device traffic, route through Edge Management. See [Connect Claude Code to the Edge Daemon](../../edge-management/connect-claude-code-to-daemon.md).

--- a/docs/gamma/agent-management/build/create-an-mcp-studio.md
+++ b/docs/gamma/agent-management/build/create-an-mcp-studio.md
@@ -22,7 +22,7 @@ Studio provides a palette of building blocks drawn from the Catalog:
 | ------------------------ | --------------------------------------------------------------------------------------------------- |
 | **MCP tools**            | From any connected upstream MCP server                                                              |
 | **API tools**            | From REST APIs in API Management (see [Create API tools](../import/create-api-tools.md))               |
-| **Kafka API tools**      | From Kafka APIs in Event Stream Management (see [Create Event tools](../import/create-event-tools.md))        |
+| **Kafka API tools**      | From Kafka APIs in Event Stream Management        |
 | **Skill resources**      | Skill folders exposed via FastMCP (see [Upload skills](../import/upload-skills.md))                    |
 | **Repository resources** | Markdown, JSON, and structured docs from Git (see [Add MCP resources](../import/add-mcp-resources.md)) |
 | **Prompt templates**     | Parameterized prompts registered in the Catalog (see [Import prompts](../import/import-prompts.md))    |

--- a/docs/gamma/agent-management/get-started/create-your-llm-proxy.md
+++ b/docs/gamma/agent-management/get-started/create-your-llm-proxy.md
@@ -87,5 +87,5 @@ A successful response returns the model's reply, confirming that the AI Gateway 
 
 * **Add more models** — Configure additional providers and routing strategies to distribute traffic. See [Configure an LLM Proxy](../build/configure-an-llm-proxy.md).
 * **Secure with an API key plan** — Replace the keyless plan with an API key to track usage and enforce rate limits.
-* **Route Claude Code through the proxy** — Set `ANTHROPIC_BASE_URL` to point at your LLM Proxy for zero-code integration. See [Connect Claude Code to the Edge Daemon](../edge-daemon/connect-claude-code-to-daemon.md).
+* **Route Claude Code through the proxy** — Set `ANTHROPIC_BASE_URL` to point at your LLM Proxy for zero-code integration. See [Connect Claude Code to the Edge Daemon](../../edge-management/connect-claude-code-to-daemon.md).
 * **Publish** — Make the LLM Proxy discoverable. See [Publish your LLM Proxy](../publish/publish-your-llm-proxy.md).

--- a/docs/gamma/agent-management/import/README.md
+++ b/docs/gamma/agent-management/import/README.md
@@ -16,7 +16,6 @@ Populate the Catalog with the assets your agents need — models, MCP servers, t
 * [**Import prompts**](import-prompts.md) — Upload reusable, parameterized prompt templates to the Catalog.
 * [**Add MCP resources**](add-mcp-resources.md) — Catalog server resources from connected MCP servers and repository resources from Git.
 * [**Create API tools**](create-api-tools.md) — Expose REST APIs from API Management as agent-accessible tools in the Catalog.
-* [**Create Event tools**](create-event-tools.md) — Expose Kafka APIs from Event Stream Management as agent-accessible tools in the Catalog.
 * [**Add a knowledge source**](add-knowledge-source.md) — Add external knowledge (documentation, knowledge bases) to the Catalog for agent consumption.
 * [**Upload skills**](upload-skills.md) — Catalog skill folders that agents can consume as MCP resources.
 * [**Import an agent from an integration**](import-an-agent.md) — Import A2A agents and hyperscaler-federated agents from connected integrations.

--- a/docs/gamma/agent-management/observe/monitor-ai-gateway-from-devices.md
+++ b/docs/gamma/agent-management/observe/monitor-ai-gateway-from-devices.md
@@ -44,7 +44,7 @@ Shadow AI detection surfaces AI traffic that bypasses the governance layer — t
 | **Managed/unmanaged ratio** | The percentage of AI traffic under governance vs. shadow traffic.                                 |
 | **Shadow AI detail**        | Per-device breakdown of which tools and providers are being used outside of governance.           |
 
-The shadow AI panel is the starting point for the MDM feedback loop: identify unmanaged traffic → push an MDM configuration to route that traffic through the Edge Daemon → verify the traffic shifts to managed. See [Configure Kandji to deploy the Edge Daemon](../edge-daemon/configure-kandji-daemon.md) for the full loop.
+The shadow AI panel is the starting point for the MDM feedback loop: identify unmanaged traffic → push an MDM configuration to route that traffic through the Edge Daemon → verify the traffic shifts to managed. See [Configure Kandji to deploy the Edge Daemon](../../edge-management/connect/configure-kandji-daemon.md) for the full loop.
 
 ### System health
 
@@ -62,6 +62,6 @@ The shadow AI panel is the starting point for the MDM feedback loop: identify un
 
 ## Next steps
 
-* [Configure Kandji to deploy the Edge Daemon](../edge-daemon/configure-kandji-daemon.md) — Set up Edge Management and deploy the Edge Daemon to your fleet.
-* [Connect Claude Code to the Edge Daemon](../edge-daemon/connect-claude-code-to-daemon.md) — Route AI tool traffic through the Edge Daemon.
+* [Configure Kandji to deploy the Edge Daemon](../../edge-management/connect/configure-kandji-daemon.md) — Set up Edge Management and deploy the Edge Daemon to your fleet.
+* [Connect Claude Code to the Edge Daemon](../../edge-management/connect-claude-code-to-daemon.md) — Route AI tool traffic through the Edge Daemon.
 * [Inspect your agent log](inspect-your-agent-log.md) — Trace individual invocations at the AI Gateway level.

--- a/docs/gamma/api-management/build/configure-your-api-proxy/apply-security-policies.md
+++ b/docs/gamma/api-management/build/configure-your-api-proxy/apply-security-policies.md
@@ -66,7 +66,7 @@ After creating a policy in Draft status:
 * Select **Deploy to PDP** to activate it. The gateway syncs the policy within 30 seconds — no restart required.
 * Select **Undeploy** on a deployed policy to disable it. The gateway drops it within 30 seconds.
 
-For more details on the full policy language and all service categories, see [Create authorization policies](../../../authorization-management/build/create-authorization-policies.md).
+For more details on the full policy language and all service categories, see [Create authorization policies](../../../authorization-management/configure/create-update-delete-policies.md).
 
 ## Common policy types
 

--- a/docs/gamma/authorization-management/get-started/authorization-management-overview.md
+++ b/docs/gamma/authorization-management/get-started/authorization-management-overview.md
@@ -100,4 +100,4 @@ Authorization Management is not isolated — it integrates with the API Gateway,
 
 ## Next steps
 
-* [Create authorization policies](../build/create-authorization-policies.md) — Learn how to create, edit, and deploy policies for each service category.
+* [Create authorization policies](../configure/create-update-delete-policies.md) — Learn how to create, edit, and deploy policies for each service category.

--- a/docs/gamma/edge-management/connect-claude-code-to-daemon.md
+++ b/docs/gamma/edge-management/connect-claude-code-to-daemon.md
@@ -4,7 +4,7 @@ Once the Edge Daemon is installed on an employee device, you can route Claude Co
 
 ## Prerequisites
 
-* Edge Daemon installed and running on the device (see [Configure Kandji to deploy the Edge Daemon](configure-kandji-daemon.md))
+* Edge Daemon installed and running on the device (see [Configure Kandji to deploy the Edge Daemon](connect/configure-kandji-daemon.md))
 * Claude Code installed on the same device
 * The Edge Daemon is listening on its default local port (`8990`)
 
@@ -20,7 +20,7 @@ The Edge Daemon runs as a local reverse proxy on the employee's device. When you
 {% hint style="warning" %}
 Only LLM traffic is redirected through the Edge Daemon using this method. Claude Code also makes direct calls to `api.anthropic.com` for telemetry, authentication, and other operations — these requests bypass the Edge Daemon and reach Anthropic directly.
 
-An interception mode is in development that will redirect all traffic (including telemetry and auth) using local DNS resolution. This requires additional certificate configuration. See [Edge Daemon](/broken/pages/RC7T5TFQ2SjqcnMJnzfQ) for details.
+An interception mode is in development that will redirect all traffic (including telemetry and auth) using local DNS resolution. This requires additional certificate configuration.
 {% endhint %}
 
 No code changes are required in Claude Code — the base URL override is the only configuration needed.
@@ -55,4 +55,4 @@ Send a test prompt through Claude Code and confirm that traffic is routed throug
 
 ## Next steps
 
-* **Monitor traffic** — View AI usage from this device in the Edge Management dashboard. See [Monitor AI Gateway usage from employee systems](../observe/monitor-ai-gateway-from-devices.md).
+* **Monitor traffic** — View AI usage from this device in the Edge Management dashboard. See [Monitor AI Gateway usage from employee systems](../agent-management/observe/monitor-ai-gateway-from-devices.md).

--- a/docs/gamma/edge-management/connect/README.md
+++ b/docs/gamma/edge-management/connect/README.md
@@ -7,7 +7,7 @@ noIndex: false
 
 Connect your edge environments and tools to the Gamma Edge Daemon.
 
-* [**Create the proxy APIs**](create-proxy-apis.md) — Create the LLM Proxy and HTTP Proxy APIs that capture the traffic forwarded by the daemon.
+* [**Create the proxy APIs**](proxy-api-reference.md) — Create the LLM Proxy and HTTP Proxy APIs that capture the traffic forwarded by the daemon.
 * [**Configure Edge Management**](configure-edge-management.md) — Set the gateway URLs, proxy routes, and shadow AI monitoring from the Gamma console.
 * [**Configure Kandji to deploy the Edge Daemon**](configure-kandji-daemon.md) — Use Kandji MDM to automate Edge Daemon deployment across your device fleet.
-* [**Connect Claude Code to the Edge Daemon**](connect-claude-code-to-daemon.md) — Route Claude Code traffic through the Edge Daemon for governance and observability.
+* [**Connect Claude Code to the Edge Daemon**](../connect-claude-code-to-daemon.md) — Route Claude Code traffic through the Edge Daemon for governance and observability.

--- a/docs/gamma/edge-management/connect/configure-edge-management.md
+++ b/docs/gamma/edge-management/connect/configure-edge-management.md
@@ -15,10 +15,10 @@ The first time you open the page, there is no configuration. Configure the field
 ## Configure Edge Management 
 
 To configure Edge Management, complete the following steps:
-* [Configure the Gateway](/docs/gamma/edge-management/connect/configure-edge-management.md#configure-the-gateway)
-* [Configure the Proxy](/docs/gamma/edge-management/connect/configure-edge-management.md#configure-the-proxy)
-* [Configure Shadow AI monitoring](/docs/gamma/edge-management/connect/configure-edge-management.md#configure-shadow-ai-monitoring)
-* [Save the configuration](/docs/gamma/edge-management/connect/configure-edge-management.md#save-the-configuration)
+* [Configure the Gateway](configure-edge-management.md#configure-the-gateway)
+* [Configure the Proxy](configure-edge-management.md#configure-the-proxy)
+* [Configure Shadow AI monitoring](configure-edge-management.md#configure-shadow-ai-monitoring)
+* [Save the configuration](configure-edge-management.md#save-the-configuration)
 
 ## Configure the Gateway
 
@@ -82,4 +82,4 @@ Configure the following settings:
 ## Next steps
 
 * **Deploy the Edge Daemon.** See [Configure Kandji to deploy the Edge Daemon](configure-kandji-daemon.md).
-* **Connect AI tools.** See [Connect Claude Code to the Edge Daemon](connect-claude-code-to-daemon.md).
+* **Connect AI tools.** See [Connect Claude Code to the Edge Daemon](../connect-claude-code-to-daemon.md).

--- a/docs/gamma/edge-management/connect/configure-kandji-daemon.md
+++ b/docs/gamma/edge-management/connect/configure-kandji-daemon.md
@@ -94,4 +94,4 @@ Once devices are reporting, the Gamma console provides the following dashboards:
 
 ## Next steps
 
-* **Connect AI tools.** Route Claude Code through the Edge Daemon. See [Connect Claude Code to the Edge Daemon](connect-claude-code-to-daemon.md).
+* **Connect AI tools.** Route Claude Code through the Edge Daemon. See [Connect Claude Code to the Edge Daemon](../connect-claude-code-to-daemon.md).

--- a/docs/gamma/edge-management/get-started/edge-management-overview.md
+++ b/docs/gamma/edge-management/get-started/edge-management-overview.md
@@ -55,7 +55,7 @@ The traffic forwarded by the Edge Daemon is captured by standard APIM APIs that 
 | **HTTP Proxy API** | Handles classic HTTP traffic (telemetry, authentication). Enables HTTP-specific policies.                |
 
 {% hint style="info" %}
-For the API types, context paths, and required keyless plan, see [Create the proxy APIs](../connect/create-proxy-apis.md). Routing of proxied traffic to these APIs is then configured from the Gamma console — see [Configure Edge Management](../connect/configure-edge-management.md).
+For the API types, context paths, and required keyless plan, see [Create the proxy APIs](../connect/proxy-api-reference.md). Routing of proxied traffic to these APIs is then configured from the Gamma console — see [Configure Edge Management](../connect/configure-edge-management.md).
 {% endhint %}
 
 ## Gateway-side requirements
@@ -77,5 +77,5 @@ The traffic the daemon forwards is captured by the proxy APIs deployed on the AI
 
 ## Next steps
 
-* **Deploy the Edge Daemon** — Use an MDM solution to distribute the Edge Daemon to your device fleet. See [Configure Kandji to deploy the Edge Daemon](configure-kandji-daemon.md).
-* **Connect AI tools** — Route Claude Code through the Edge Daemon. See [Connect Claude Code to the Edge Daemon](connect-claude-code-to-daemon.md).
+* **Deploy the Edge Daemon** — Use an MDM solution to distribute the Edge Daemon to your device fleet. See [Configure Kandji to deploy the Edge Daemon](../connect/configure-kandji-daemon.md).
+* **Connect AI tools** — Route Claude Code through the Edge Daemon. See [Connect Claude Code to the Edge Daemon](../connect-claude-code-to-daemon.md).

--- a/docs/gamma/event-stream-management/build/create-a-kafka-service-with-a-registered-cluster.md
+++ b/docs/gamma/event-stream-management/build/create-a-kafka-service-with-a-registered-cluster.md
@@ -82,9 +82,7 @@ Once a plan is established, you can apply **Policies** to enforce quotas, messag
 
 Once a Kafka Service is running, you can expose its topics as **Kafka API Tools** in the Catalog, bridging your event infrastructure to the AI agent layer. Kafka API Tools become available as building blocks in MCP Studio alongside other tools, resources, and prompts.
 
-For details, see [Create Event tools](../../agent-management/import/create-event-tools.md).
-
 ## Next steps
 
 * **Provision a Virtual Cluster** — Add multi-tenant isolation on top of your Kafka Service. See [Establish a virtual cluster](establish-a-virtual-cluster.md).
-* **Create topics** — Set up Kafka topics for producing and consuming messages. See [Create Kafka topics](../explorer/create-kafka-topics.md).
+* **Create topics** — Set up Kafka topics for producing and consuming messages.

--- a/docs/gamma/event-stream-management/build/create-a-kafka-service-with-a-virtual-cluster.md
+++ b/docs/gamma/event-stream-management/build/create-a-kafka-service-with-a-virtual-cluster.md
@@ -64,9 +64,7 @@ After creation, configure a security plan and, optionally, policies on the servi
 
 Once the Kafka Service is running, you can expose its topics as **Kafka API Tools** in the Catalog, bridging your event infrastructure to the AI agent layer. Kafka API Tools become available as building blocks in MCP Studio alongside other tools, resources, and prompts.
 
-For details, see [Create Event tools](../../agent-management/import/create-event-tools.md).
-
 ## Next steps
 
-* **Create topics** — Set up Kafka topics across the Virtual Cluster's backends. See [Create Kafka topics](../explorer/create-kafka-topics.md).
-* **Monitor your service** — View the service in Explorer. See [Manage connections](../explorer/manage-connections.md).
+* **Create topics** — Set up Kafka topics across the Virtual Cluster's backends.
+* **Monitor your service** — View the service in Explorer.

--- a/docs/gamma/event-stream-management/build/establish-a-virtual-cluster.md
+++ b/docs/gamma/event-stream-management/build/establish-a-virtual-cluster.md
@@ -82,5 +82,5 @@ Removing a backend from a deployed Virtual Cluster affects any clients consuming
 
 ## Next steps
 
-* **Create topics** — Set up Kafka topics inside your Virtual Cluster. See [Create Kafka topics](../explorer/create-kafka-topics.md).
+* **Create topics** — Set up Kafka topics inside your Virtual Cluster.
 * **Create a Kafka Service** — Add governance, security plans, and policies on top of the Virtual Cluster. See [Create a Kafka service with a virtual cluster](create-a-kafka-service-with-a-virtual-cluster.md).

--- a/docs/gamma/event-stream-management/get-started/create-your-first-kafka-service.md
+++ b/docs/gamma/event-stream-management/get-started/create-your-first-kafka-service.md
@@ -86,5 +86,5 @@ Once the plan is created and published, your Kafka Service is active. You can no
 ## Next steps
 
 * **Create a Virtual Cluster** — Provision a logically isolated Kafka environment on top of your service. See [Establish a virtual cluster](../build/establish-a-virtual-cluster.md).
-* **Create a topic** — Start producing and consuming messages. See [Create Kafka topics](../explorer/create-kafka-topics.md).
+* **Create a topic** — Start producing and consuming messages.
 * **Explore all configuration options** — Security plans, policies, and advanced settings. See [Create a Kafka service with a registered cluster](../build/create-a-kafka-service-with-a-registered-cluster.md).

--- a/docs/gamma/event-stream-management/get-started/event-stream-management-overview.md
+++ b/docs/gamma/event-stream-management/get-started/event-stream-management-overview.md
@@ -30,7 +30,7 @@ Gamma unifies four product lines — API Management, Event Stream Management, Ag
 2. **A common authorization engine** that defines fine-grained policies against those cataloged assets
 3. **Common enforcement points** (AI Gateway, API Gateway, Event Gateway) that evaluate the same policies at the wire level
 
-Event Stream Management contributes Kafka APIs and event streams to the Catalog. Those Kafka APIs can be exposed as **Kafka API Tools** in Agent Management, making existing event infrastructure accessible to AI agents without redevelopment. For details on bridging event streams to the agent layer, see [Create Event tools](../../agent-management/import/create-event-tools.md).
+Event Stream Management contributes Kafka APIs and event streams to the Catalog. Those Kafka APIs can be exposed as **Kafka API Tools** in Agent Management, making existing event infrastructure accessible to AI agents without redevelopment.
 
 ## Get started
 

--- a/docs/gamma/event-stream-management/import/register-your-kafka-clusters.md
+++ b/docs/gamma/event-stream-management/import/register-your-kafka-clusters.md
@@ -59,4 +59,4 @@ Removing a cluster registration does not affect the cluster itself — it only r
 ## Next steps
 
 * **Create a Kafka Service** — Build a governed Kafka Service on top of your Registered Cluster. See [Create a Kafka service with a registered cluster](../build/create-a-kafka-service-with-a-registered-cluster.md).
-* **Browse topics in Explorer** — Connect to the cluster and inspect its topics and messages. See [Manage connections](../explorer/manage-connections.md).
+* **Browse topics in Explorer** — Connect to the cluster and inspect its topics and messages.

--- a/docs/gamma/platform-management/get-started/get-started-for-existing-users/activate-gamma-with-docker-compose.md
+++ b/docs/gamma/platform-management/get-started/get-started-for-existing-users/activate-gamma-with-docker-compose.md
@@ -13,7 +13,7 @@ Gamma ships in 4.12 (`4.12.0`). Activating Gamma moves your stack to that build.
 
 ## Overview
 
-If you already run Gravitee API Management with Docker Compose, you turn Gamma on by moving to the Gamma build, enabling Gamma on the Management API, and adding the Gamma console. This page covers only those changes. For the full stack from scratch, see [Run Gamma with Docker Compose](../self-hosted-installation-guides/docker/docker-compose.md).
+If you already run Gravitee API Management with Docker Compose, you turn Gamma on by moving to the Gamma build, enabling Gamma on the Management API, and adding the Gamma console. This page covers only those changes. For the full stack from scratch, see [Run Gamma with Docker Compose](../../install/self-hosted-installation-guides/docker/docker-compose.md).
 
 ## Activate Gamma
 
@@ -47,7 +47,7 @@ If you already run Gravitee API Management with Docker Compose, you turn Gamma o
    docker compose up -d
    ```
 
-For the full single-host layout, the complete CORS and cookie reasoning, and the enterprise license step for Agent Management, see [Run Gamma with Docker Compose](../self-hosted-installation-guides/docker/docker-compose.md).
+For the full single-host layout, the complete CORS and cookie reasoning, and the enterprise license step for Agent Management, see [Run Gamma with Docker Compose](../../install/self-hosted-installation-guides/docker/docker-compose.md).
 
 ## Verification
 
@@ -62,4 +62,4 @@ For the full single-host layout, the complete CORS and cookie reasoning, and the
 
 ## Next steps
 
-* Create your first MCP server. For more information, see [Create your first MCP server](../../agent-management/get-started/create-your-first-mcp-server.md).
+* Create your first MCP server. For more information, see [Create your first MCP server](../../../agent-management/get-started/create-your-first-mcp-server.md).

--- a/docs/gamma/platform-management/get-started/get-started-for-existing-users/activate-gamma-with-kubernetes-helm.md
+++ b/docs/gamma/platform-management/get-started/get-started-for-existing-users/activate-gamma-with-kubernetes-helm.md
@@ -13,7 +13,7 @@ Gamma ships in 4.12 (`4.12.0`). Activating Gamma moves your deployment to that b
 
 ## Overview
 
-If you already run Gravitee API Management with the Helm chart, you turn Gamma on by moving to the Gamma build, enabling Gamma, and adding the Gamma console to your `values.yaml`. This page covers only those changes. For a full install, follow the Helm guide for your cluster: [Vanilla Kubernetes](../self-hosted-installation-guides/kubernetes/vanilla-kubernetes.md), [AWS EKS](../self-hosted-installation-guides/kubernetes/aws-eks.md), [Azure AKS](../self-hosted-installation-guides/kubernetes/azure-aks.md), or [OpenShift](../self-hosted-installation-guides/kubernetes/openshift.md).
+If you already run Gravitee API Management with the Helm chart, you turn Gamma on by moving to the Gamma build, enabling Gamma, and adding the Gamma console to your `values.yaml`. This page covers only those changes. For a full install, follow the Helm guide for your cluster: [Vanilla Kubernetes](../../install/self-hosted-installation-guides/kubernetes/vanilla-kubernetes.md), [AWS EKS](../../install/self-hosted-installation-guides/kubernetes/aws-eks.md), [Azure AKS](../../install/self-hosted-installation-guides/kubernetes/azure-aks.md), or [OpenShift](../../install/self-hosted-installation-guides/kubernetes/openshift.md).
 
 ## Activate Gamma
 
@@ -83,4 +83,4 @@ For the complete `values.yaml`, the ingress and single-host layout, and the ente
 
 ## Next steps
 
-* Create your first MCP server. For more information, see [Create your first MCP server](../../agent-management/get-started/create-your-first-mcp-server.md).
+* Create your first MCP server. For more information, see [Create your first MCP server](../../../agent-management/get-started/create-your-first-mcp-server.md).

--- a/docs/gamma/platform-management/get-started/get-started-for-new-users/fully-self-hosted-with-docker.md
+++ b/docs/gamma/platform-management/get-started/get-started-for-new-users/fully-self-hosted-with-docker.md
@@ -10,9 +10,9 @@ To run a full Gamma platform yourself with Docker, use one of the Docker install
 
 ## Choose a Docker guide
 
-* [Run Gamma with Docker Compose](../self-hosted-installation-guides/docker/docker-compose.md): one Compose file that brings up every component together. Use this for the simplest path.
-* [Run Gamma with Docker CLI](../self-hosted-installation-guides/docker/docker-cli.md): start each container yourself with `docker run`. Use this when you want to see each component or fit Gamma into an existing setup.
-* **Hybrid with Docker:** run a self-hosted Docker Gateway against a Gravitee Cloud (Next-Gen Cloud) control plane. See [Run a hybrid Gateway with Docker Compose](../hybrid-installation-guides/docker/docker-compose.md) or [with the Docker CLI](../hybrid-installation-guides/docker/docker-cli.md).
+* [Run Gamma with Docker Compose](../../install/self-hosted-installation-guides/docker/docker-compose.md): one Compose file that brings up every component together. Use this for the simplest path.
+* [Run Gamma with Docker CLI](../../install/self-hosted-installation-guides/docker/docker-cli.md): start each container yourself with `docker run`. Use this when you want to see each component or fit Gamma into an existing setup.
+* **Hybrid with Docker:** run a self-hosted Docker Gateway against a Gravitee Cloud (Next-Gen Cloud) control plane. See [Run a hybrid Gateway with Docker Compose](../../install/hybrid-installation-guides/docker/docker-compose.md) or [with the Docker CLI](../../install/hybrid-installation-guides/docker/docker-cli.md).
 
 ## What to expect
 
@@ -20,4 +20,4 @@ Both guides serve every console and the Management API on one host so the Gamma 
 
 ## Next steps
 
-* Once Gamma is running, create your first MCP server. For more information, see [Create your first MCP server](../../agent-management/get-started/create-your-first-mcp-server.md).
+* Once Gamma is running, create your first MCP server. For more information, see [Create your first MCP server](../../../agent-management/get-started/create-your-first-mcp-server.md).

--- a/docs/gamma/platform-management/get-started/get-started-for-new-users/fully-self-hosted-with-vanilla-kubernetes.md
+++ b/docs/gamma/platform-management/get-started/get-started-for-new-users/fully-self-hosted-with-vanilla-kubernetes.md
@@ -10,11 +10,11 @@ To run a full Gamma platform yourself on Kubernetes, install the Helm chart with
 
 ## Choose a Kubernetes guide
 
-* [Install Gamma on Vanilla Kubernetes](../self-hosted-installation-guides/kubernetes/vanilla-kubernetes.md): the standard Helm install for Docker Desktop, minikube, or any vanilla cluster.
-* [Install Gamma on AWS EKS](../self-hosted-installation-guides/kubernetes/aws-eks.md): a managed cluster on Amazon, fronted by an AWS load balancer.
-* [Install Gamma on Azure AKS](../self-hosted-installation-guides/kubernetes/azure-aks.md): a managed cluster on Azure, fronted by an NGINX ingress.
-* [Install Gamma on OpenShift](../self-hosted-installation-guides/kubernetes/openshift.md): an OpenShift cluster, served through edge-terminated Routes.
-* **Hybrid on Kubernetes:** run a self-hosted Helm Gateway against a Gravitee Cloud (Next-Gen Cloud) control plane. See the hybrid Kubernetes guides for [Vanilla Kubernetes](../hybrid-installation-guides/kubernetes/vanilla-kubernetes.md), [AWS EKS](../hybrid-installation-guides/kubernetes/aws-eks.md), [Azure AKS](../hybrid-installation-guides/kubernetes/azure-aks.md), or [OpenShift](../hybrid-installation-guides/kubernetes/openshift.md).
+* [Install Gamma on Vanilla Kubernetes](../../install/self-hosted-installation-guides/kubernetes/vanilla-kubernetes.md): the standard Helm install for Docker Desktop, minikube, or any vanilla cluster.
+* [Install Gamma on AWS EKS](../../install/self-hosted-installation-guides/kubernetes/aws-eks.md): a managed cluster on Amazon, fronted by an AWS load balancer.
+* [Install Gamma on Azure AKS](../../install/self-hosted-installation-guides/kubernetes/azure-aks.md): a managed cluster on Azure, fronted by an NGINX ingress.
+* [Install Gamma on OpenShift](../../install/self-hosted-installation-guides/kubernetes/openshift.md): an OpenShift cluster, served through edge-terminated Routes.
+* **Hybrid on Kubernetes:** run a self-hosted Helm Gateway against a Gravitee Cloud (Next-Gen Cloud) control plane. See the hybrid Kubernetes guides for [Vanilla Kubernetes](../../install/hybrid-installation-guides/kubernetes/vanilla-kubernetes.md), [AWS EKS](../../install/hybrid-installation-guides/kubernetes/aws-eks.md), [Azure AKS](../../install/hybrid-installation-guides/kubernetes/azure-aks.md), or [OpenShift](../../install/hybrid-installation-guides/kubernetes/openshift.md).
 
 ## What to expect
 
@@ -22,4 +22,4 @@ Every guide serves the Gamma console and the Management API on a single host so 
 
 ## Next steps
 
-* Once Gamma is running, create your first MCP server. For more information, see [Create your first MCP server](../../agent-management/get-started/create-your-first-mcp-server.md).
+* Once Gamma is running, create your first MCP server. For more information, see [Create your first MCP server](../../../agent-management/get-started/create-your-first-mcp-server.md).

--- a/docs/gamma/platform-management/install/hybrid-installation-guides/docker/docker-cli.md
+++ b/docs/gamma/platform-management/install/hybrid-installation-guides/docker/docker-cli.md
@@ -184,5 +184,5 @@ gravitee_system_proxy_https_port=<proxy-port>
 
 ## Next steps
 
-* Create your first MCP server. For more information, see [Create your first MCP server](../../../agent-management/get-started/create-your-first-mcp-server.md).
-* Create your first API. For more information, see [Create your first API](../../../api-management/get-started/create-your-first-api.md).
+* Create your first MCP server. For more information, see [Create your first MCP server](../../../../agent-management/get-started/create-your-first-mcp-server.md).
+* Create your first API. For more information, see [Create your first API](../../../../api-management/get-started/create-your-first-api.md).

--- a/docs/gamma/platform-management/install/hybrid-installation-guides/docker/docker-compose.md
+++ b/docs/gamma/platform-management/install/hybrid-installation-guides/docker/docker-compose.md
@@ -215,5 +215,5 @@ gravitee_system_proxy_https_port=<proxy-port>
 
 ## Next steps
 
-* Create your first MCP server. For more information, see [Create your first MCP server](../../../agent-management/get-started/create-your-first-mcp-server.md).
-* Create your first API. For more information, see [Create your first API](../../../api-management/get-started/create-your-first-api.md).
+* Create your first MCP server. For more information, see [Create your first MCP server](../../../../agent-management/get-started/create-your-first-mcp-server.md).
+* Create your first API. For more information, see [Create your first API](../../../../api-management/get-started/create-your-first-api.md).

--- a/docs/gamma/platform-management/install/hybrid-installation-guides/kubernetes/aws-eks.md
+++ b/docs/gamma/platform-management/install/hybrid-installation-guides/kubernetes/aws-eks.md
@@ -366,5 +366,5 @@ gateway:
 
 ## Next steps
 
-* Create your first MCP server. For more information, see [Create your first MCP server](../../../agent-management/get-started/create-your-first-mcp-server.md).
-* Create your first API. For more information, see [Create your first API](../../../api-management/get-started/create-your-first-api.md).
+* Create your first MCP server. For more information, see [Create your first MCP server](../../../../agent-management/get-started/create-your-first-mcp-server.md).
+* Create your first API. For more information, see [Create your first API](../../../../api-management/get-started/create-your-first-api.md).

--- a/docs/gamma/platform-management/install/hybrid-installation-guides/kubernetes/azure-aks.md
+++ b/docs/gamma/platform-management/install/hybrid-installation-guides/kubernetes/azure-aks.md
@@ -296,5 +296,5 @@ gateway:
 
 ## Next steps
 
-* Create your first MCP server. For more information, see [Create your first MCP server](../../../agent-management/get-started/create-your-first-mcp-server.md).
-* Create your first API. For more information, see [Create your first API](../../../api-management/get-started/create-your-first-api.md).
+* Create your first MCP server. For more information, see [Create your first MCP server](../../../../agent-management/get-started/create-your-first-mcp-server.md).
+* Create your first API. For more information, see [Create your first API](../../../../api-management/get-started/create-your-first-api.md).

--- a/docs/gamma/platform-management/install/hybrid-installation-guides/kubernetes/openshift.md
+++ b/docs/gamma/platform-management/install/hybrid-installation-guides/kubernetes/openshift.md
@@ -274,5 +274,5 @@ gateway:
 
 ## Next steps
 
-* Create your first MCP server. For more information, see [Create your first MCP server](../../../agent-management/get-started/create-your-first-mcp-server.md).
-* Create your first API. For more information, see [Create your first API](../../../api-management/get-started/create-your-first-api.md).
+* Create your first MCP server. For more information, see [Create your first MCP server](../../../../agent-management/get-started/create-your-first-mcp-server.md).
+* Create your first API. For more information, see [Create your first API](../../../../api-management/get-started/create-your-first-api.md).

--- a/docs/gamma/platform-management/install/hybrid-installation-guides/kubernetes/vanilla-kubernetes.md
+++ b/docs/gamma/platform-management/install/hybrid-installation-guides/kubernetes/vanilla-kubernetes.md
@@ -301,8 +301,8 @@ gateway:
 
 ## Next steps
 
-* Create your first MCP server. For more information, see [Create your first MCP server](../../../agent-management/get-started/create-your-first-mcp-server.md).
-* Create your first API. For more information, see [Create your first API](../../../api-management/get-started/create-your-first-api.md).
+* Create your first MCP server. For more information, see [Create your first MCP server](../../../../agent-management/get-started/create-your-first-mcp-server.md).
+* Create your first API. For more information, see [Create your first API](../../../../api-management/get-started/create-your-first-api.md).
 
 {% hint style="warning" %}
 To access your Gateway from outside of your Kubernetes cluster, you must implement a load balancer or ingress.

--- a/docs/gamma/platform-management/install/self-hosted-installation-guides/docker/docker-cli.md
+++ b/docs/gamma/platform-management/install/self-hosted-installation-guides/docker/docker-cli.md
@@ -196,4 +196,4 @@ The cross-origin cookie problem that breaks Gamma login on separate hostnames do
 
 ## Next steps
 
-* Create your first MCP server. For more information, see [Create your first MCP server](../../../agent-management/get-started/create-your-first-mcp-server.md).
+* Create your first MCP server. For more information, see [Create your first MCP server](../../../../agent-management/get-started/create-your-first-mcp-server.md).

--- a/docs/gamma/platform-management/install/self-hosted-installation-guides/docker/docker-compose.md
+++ b/docs/gamma/platform-management/install/self-hosted-installation-guides/docker/docker-compose.md
@@ -257,4 +257,4 @@ The cross-origin cookie problem that breaks Gamma login on separate hostnames do
 
 ## Next steps
 
-* Create your first MCP server. For more information, see [Create your first MCP server](../../../agent-management/get-started/create-your-first-mcp-server.md).
+* Create your first MCP server. For more information, see [Create your first MCP server](../../../../agent-management/get-started/create-your-first-mcp-server.md).

--- a/docs/gamma/platform-management/install/self-hosted-installation-guides/kubernetes/aws-eks.md
+++ b/docs/gamma/platform-management/install/self-hosted-installation-guides/kubernetes/aws-eks.md
@@ -522,4 +522,4 @@ The Gamma console (`/`) and the API (`/gamma`, `/management`) are on the same ho
 
 ## Next steps
 
-* Create your first MCP server. For more information, see [Create your first MCP server](../../../agent-management/get-started/create-your-first-mcp-server.md).
+* Create your first MCP server. For more information, see [Create your first MCP server](../../../../agent-management/get-started/create-your-first-mcp-server.md).

--- a/docs/gamma/platform-management/install/self-hosted-installation-guides/kubernetes/azure-aks.md
+++ b/docs/gamma/platform-management/install/self-hosted-installation-guides/kubernetes/azure-aks.md
@@ -387,4 +387,4 @@ To serve the single host over HTTPS, add a `tls` block to the `extraObjects` ing
 
 ## Next steps
 
-* Create your first MCP server. For more information, see [Create your first MCP server](../../../agent-management/get-started/create-your-first-mcp-server.md).
+* Create your first MCP server. For more information, see [Create your first MCP server](../../../../agent-management/get-started/create-your-first-mcp-server.md).

--- a/docs/gamma/platform-management/install/self-hosted-installation-guides/kubernetes/openshift.md
+++ b/docs/gamma/platform-management/install/self-hosted-installation-guides/kubernetes/openshift.md
@@ -409,4 +409,4 @@ The Gamma console (`/`) and the API (`/gamma`, `/management`) are on the same ho
 
 ## Next steps
 
-* Create your first MCP server. For more information, see [Create your first MCP server](../../../agent-management/get-started/create-your-first-mcp-server.md).
+* Create your first MCP server. For more information, see [Create your first MCP server](../../../../agent-management/get-started/create-your-first-mcp-server.md).

--- a/docs/gamma/platform-management/install/self-hosted-installation-guides/kubernetes/vanilla-kubernetes.md
+++ b/docs/gamma/platform-management/install/self-hosted-installation-guides/kubernetes/vanilla-kubernetes.md
@@ -39,10 +39,6 @@ The platform also requires two datastores:
 * MongoDB: stores API definitions, configurations, and rate-limiting data.
 * Elasticsearch: provides analytics, logging, and search.
 
-{% hint style="info" %}
-This guide doesn't deploy Access Management (AM). You don't need AM to run Gamma or to sign in. AM is required only for Gamma's agent-identity features in Agent Management. To add those features, deploy AM separately and wire it to Gamma after the platform is up.
-{% endhint %}
-
 ## Install Gamma
 
 To install Gamma, complete the following steps:
@@ -752,5 +748,5 @@ If you need the consoles on separate subdomains (for example, `console.example.c
 
 ## Next steps
 
-* Create your first MCP server. For more information, see [Create your first MCP server](../../../agent-management/get-started/create-your-first-mcp-server.md).
-* Add Gamma's agent-identity features. Deploy Access Management and wire it to Gamma. For more information, see [Configure your Access Management instance](../../../agent-management/build/configure-your-access-management-instance.md).
+* Create your first MCP server. For more information, see [Create your first MCP server](../../../../agent-management/get-started/create-your-first-mcp-server.md).
+* Add Gamma's agent-identity features. Deploy Access Management and wire it to Gamma. For more information, see [Configure your Access Management instance](../../../../agent-management/build/configure-your-access-management-instance.md).

--- a/docs/gamma/platform-management/overview.md
+++ b/docs/gamma/platform-management/overview.md
@@ -72,37 +72,37 @@ Gamma includes the following components:
 
 API Management governs REST, GraphQL, and gRPC traffic through API proxies—the core artifact that mediates between consumers and backend services. The API Gateway enforces runtime policy on every request while the Gamma console provides the Control Plane to design, secure, publish, and observe APIs. Creation wizards offer both a from-scratch four-step flow—API Details, Configure Proxy, Secure, and Review & Deploy—and quick-start templates for common patterns.
 
-See [API Management overview](api-management/get-started/api-management-overview.md).
+See [API Management overview](../api-management/get-started/api-management-overview.md).
 
 ### Security & Authentication
 
 Every API proxy accepts one or more security plans that define how consumers authenticate. Supported plan types include Keyless, API Key, JWT, OAuth2, and mTLS. Plans move through a defined lifecycle—Staging, Published, Deprecated, and Closed—and support rate limiting, quotas, and resource filtering at the plan level. For AI traffic, the AI Gateway supports OAuth authorization discovery and credential mediation for MCP servers, and token-based rate limiting for LLM Proxies.
 
-See [Secure your API proxy](api-management/build/secure-your-api-proxy.md).
+See [Secure your API proxy](../api-management/build/secure-your-api-proxy.md).
 
 ### Event Stream Management
 
 Event Stream Management governs Kafka clusters, event-driven data flows, and streaming infrastructure. Key capabilities include Kafka cluster registration, Kafka Service creation—the event-stream equivalent of an API proxy—and Virtual Clusters for multi-tenant isolation on shared infrastructure. An integrated Explorer lets you create topics, inspect messages, and manage connections. Kafka APIs contributed to the Catalog can be exposed as Kafka API Tools in Agent Management, bridging event streams to the AI agent layer without redevelopment.
 
-See [Event Stream Management overview](event-stream-management/get-started/event-stream-management-overview.md).
+See [Event Stream Management overview](../event-stream-management/get-started/event-stream-management-overview.md).
 
 ### Agent Management & AI Governance
 
 Agent Management governs every protocol in the agentic stack. The **LLM Proxy** handles traffic to LLM providers—Anthropic, OpenAI, AWS Bedrock, Vertex AI, and Azure—with routing strategies (`COST`, `LATENCY`, `RANDOM`), guardrails, PII filtering, and token-based rate limiting. The **MCP Proxy** governs tool invocations in two modes: Proxy mode for transparent governance of upstream MCP servers, and Studio mode for composing Composite MCP Servers. The **A2A Proxy** governs agent-to-agent delegations with skill discovery, per-skill authorization, and agent identity verification. Every interaction emits an OpenTelemetry span with agent identity, tool name, inputs, outputs, latency, policy decision, cost, and timestamp.
 
-See [Agent Management overview](agent-management/get-started/ai-management-overview.md).
+See [Agent Management overview](../agent-management/get-started/ai-management-overview.md).
 
 ### Authorization Management
 
 Authorization Management provides fine-grained, catalog-aware access control across all Gamma traffic types through policies written in Gravitee Authorization Policy Language (GAPL), a subset of the Cedar policy language. Policies declare an effect (`permit` or `forbid`), a principal, an action, a resource, and optional conditions for time-of-day restrictions, IP range checks, token budgets, and custom attribute matching. Policy categories cover MCP Policies, AI Model Policies, API Policies, and Custom Policies. Principals can be synchronized from identity providers using SCIM or from Gravitee Access Management.
 
-See [Authorization Management overview](authorization-management/get-started/authorization-management-overview.md).
+See [Authorization Management overview](../authorization-management/get-started/authorization-management-overview.md).
 
 ### Edge Management
 
 Edge Management provides visibility and control over AI traffic on employee devices. The Edge Daemon, distributed using MDM solutions—Kandji, Jamf, and Intune—supports two routing modes. Interception mode is the default and provides transparent DNS-level redirect of AI provider traffic. Proxy mode requires explicit per-tool base URL configuration. The daemon detects shadow AI usage regardless of whether traffic is routed through it. It enforces local pre-egress policies and forwards requests to the AI Gateway for enterprise-wide policy enforcement. The Edge Management dashboard surfaces fleet status, metrics filterable by device and model, and shadow AI usage reports.
 
-See [Edge Management overview](edge-management/get-started/edge-management-overview.md).
+See [Edge Management overview](../edge-management/get-started/edge-management-overview.md).
 
 ***
 
@@ -126,12 +126,12 @@ Gamma supports the following protocols and standards:
 
 If you are new to Gravitee Gamma, complete the following steps:
 
-1. [**Create your first API**](api-management/get-started/create-your-first-api.md) — Create an API proxy and enforce a security plan in under five minutes.
-2. [**Create your first MCP server**](agent-management/get-started/create-your-first-mcp-server.md) — Set up an MCP proxy in front of an upstream MCP server and verify tool invocations.
-3. [**Create your first Kafka service**](event-stream-management/get-started/create-your-first-kafka-service.md) — Register a Kafka cluster and create a governed Kafka service.
+1. [**Create your first API**](../api-management/get-started/create-your-first-api.md) — Create an API proxy and enforce a security plan in under five minutes.
+2. [**Create your first MCP server**](../agent-management/get-started/create-your-first-mcp-server.md) — Set up an MCP proxy in front of an upstream MCP server and verify tool invocations.
+3. [**Create your first Kafka service**](../event-stream-management/get-started/create-your-first-kafka-service.md) — Register a Kafka cluster and create a governed Kafka service.
 
 If you are evaluating Gravitee Gamma for your organization, consult the following resources:
 
-* [**Authorization Management overview**](authorization-management/get-started/authorization-management-overview.md)**.** Understand GAPL policies and how the shared policy engine governs all traffic types.
-* [**Agent Management overview**](agent-management/get-started/ai-management-overview.md)**.** Understand how the AI Gateway, Catalog, and Agent Identity work together to govern AI agent traffic.
-* [**Event Stream Management overview**](event-stream-management/get-started/event-stream-management-overview.md)**.** Understand how Kafka infrastructure is governed and exposed to agents through the Catalog.
+* [**Authorization Management overview**](../authorization-management/get-started/authorization-management-overview.md)**.** Understand GAPL policies and how the shared policy engine governs all traffic types.
+* [**Agent Management overview**](../agent-management/get-started/ai-management-overview.md)**.** Understand how the AI Gateway, Catalog, and Agent Identity work together to govern AI agent traffic.
+* [**Event Stream Management overview**](../event-stream-management/get-started/event-stream-management-overview.md)**.** Understand how Kafka infrastructure is governed and exposed to agents through the Catalog.


### PR DESCRIPTION
## What

The Gamma IA restructure left **85 broken relative links** in `docs/gamma`. GitBook can't resolve a broken relative link, so it renders it as a dead GitHub blob URL (for example, the "Run Gamma with Docker Compose" link pointed at `github.com/.../get-started/self-hosted-installation-guides/docker/docker-compose.md`, a path that no longer exists).

### Links (85 fixed → 0 broken)
- **Repointed** links whose target pages moved during the restructure (install guides `get-started/` → `install/`, `edge-daemon/` → `edge-management/`, `overview.md` depth fixes, install-guide `../` depth fixes).
- **Repointed** links whose target pages were renamed:
  - "Create the proxy APIs" → `proxy-api-reference.md` (verified it documents the LLM/HTTP proxy APIs)
  - "Create authorization policies" → `configure/create-update-delete-policies.md`
- **Removed** dead cross-references to pages removed in the restructure with no equivalent: Create Event tools (`create-api-tools.md` is REST-only), Explorer / Create Kafka topics, Manage connections.

Every fix was verified against the files that actually exist. A full scan confirms **0 broken relative links** remain (522 internal links checked).

### Content
- Removed the "This guide doesn't deploy Access Management (AM)…" info hint from the vanilla Kubernetes self-hosted install guide.

## After merge
Re-sync the Gamma GitBook space (GitHub → GitBook). Once the new IA is published, I can run an HTTP 200 sweep against the live URLs to confirm.
