### PR TITLE
docs(gko): fix broken release notes and changelog nav links

### DIFF
--- a/docs/gko/4.10/SUMMARY.md
+++ b/docs/gko/4.10/SUMMARY.md
@@ -71,6 +71,12 @@
 * [Changelog](releases-and-changelog/changelog/README.md)
 * [GKO 4.10.x](releases-and-changelog/changelog/gko-4.10.x.md)
 * [GKO 4.9.x](https://documentation.gravitee.io/gravitee-kubernetes-operator-gko/4.9/releases-and-changelog/changelog/gko-4.9.x)
+* [GKO 4.8.x](https://documentation.gravitee.io/gravitee-kubernetes-operator-gko/4.8/releases-and-changelog/changelog/gko-4.8.x)
+* [GKO 4.7.x](https://documentation.gravitee.io/gravitee-kubernetes-operator-gko/4.7/releases-and-changelog/changelog/gko-4.7.x)
+* [GKO 4.6.x](https://documentation.gravitee.io/gravitee-kubernetes-operator-gko/4.6/releases-and-changelog/changelog/gko-4.6.x)
+* [GKO 4.5.x](https://documentation.gravitee.io/gravitee-kubernetes-operator-gko/4.5/releases-and-changelog/changelog/gko-4.5.x)
+* [GKO 4.4.x](https://documentation.gravitee.io/gravitee-kubernetes-operator-gko/4.4/releases-and-changelog/changelog/gko-4.4.x)
+* [GKO 4.3.x](https://documentation.gravitee.io/gravitee-kubernetes-operator-gko/4.3/releases-and-changelog/changelog/gko-4.3.x)
 
 ## COMMUNITY & SUPPORT
 

--- a/docs/gko/4.11/SUMMARY.md
+++ b/docs/gko/4.11/SUMMARY.md
@@ -61,7 +61,7 @@
 
 * [Release Notes](releases-and-changelog/release-notes/README.md)
   * [GKO 4.11](releases-and-changelog/release-notes/gko-4.11.md)
-  * [GKO 4.10](https://documentation.gravitee.io/gravitee-kubernetes-operator-gko/gko-4.10)
+  * [GKO 4.10](https://documentation.gravitee.io/gravitee-kubernetes-operator-gko/4.10/releases-and-changelog/release-notes/gko-4.10)
   * [GKO 4.9](https://documentation.gravitee.io/gravitee-kubernetes-operator-gko/4.9/releases-and-changelog/release-notes/gko-4.9)
   * [GKO 4.8](https://documentation.gravitee.io/gravitee-kubernetes-operator-gko/4.8/releases-and-changelog/release-notes/gko-4.8)
   * [GKO 4.7](https://documentation.gravitee.io/gravitee-kubernetes-operator-gko/4.7/releases-and-changelog/release-notes/gko-4.7)
@@ -71,8 +71,14 @@
   * [GKO 4.3](https://documentation.gravitee.io/gravitee-kubernetes-operator-gko/4.3/releases-and-changelog/release-notes/gko-4.3)
 * [Changelog](releases-and-changelog/changelog/README.md)
   * [GKO 4.11.x](releases-and-changelog/changelog/gko-4.11.x.md)
-  * [GKO 4.10.x](https://app.gitbook.com/s/mzvj63JEIkcb9VMFMq3W/gko-4.10.x)
+  * [GKO 4.10.x](https://documentation.gravitee.io/gravitee-kubernetes-operator-gko/4.10/releases-and-changelog/changelog/gko-4.10.x)
   * [GKO 4.9.x](https://documentation.gravitee.io/gravitee-kubernetes-operator-gko/4.9/releases-and-changelog/changelog/gko-4.9.x)
+  * [GKO 4.8.x](https://documentation.gravitee.io/gravitee-kubernetes-operator-gko/4.8/releases-and-changelog/changelog/gko-4.8.x)
+  * [GKO 4.7.x](https://documentation.gravitee.io/gravitee-kubernetes-operator-gko/4.7/releases-and-changelog/changelog/gko-4.7.x)
+  * [GKO 4.6.x](https://documentation.gravitee.io/gravitee-kubernetes-operator-gko/4.6/releases-and-changelog/changelog/gko-4.6.x)
+  * [GKO 4.5.x](https://documentation.gravitee.io/gravitee-kubernetes-operator-gko/4.5/releases-and-changelog/changelog/gko-4.5.x)
+  * [GKO 4.4.x](https://documentation.gravitee.io/gravitee-kubernetes-operator-gko/4.4/releases-and-changelog/changelog/gko-4.4.x)
+  * [GKO 4.3.x](https://documentation.gravitee.io/gravitee-kubernetes-operator-gko/4.3/releases-and-changelog/changelog/gko-4.3.x)
 
 ## COMMUNITY & SUPPORT
 

--- a/docs/gko/4.12/SUMMARY.md
+++ b/docs/gko/4.12/SUMMARY.md
@@ -69,7 +69,7 @@
 * [Release Notes](releases-and-changelog/release-notes/README.md)
   * [GKO 4.12](releases-and-changelog/release-notes/gko-4.12.md)
   * [GKO 4.11](releases-and-changelog/release-notes/gko-4.11.md)
-  * [GKO 4.10](https://documentation.gravitee.io/gravitee-kubernetes-operator-gko/gko-4.10)
+  * [GKO 4.10](https://documentation.gravitee.io/gravitee-kubernetes-operator-gko/4.10/releases-and-changelog/release-notes/gko-4.10)
   * [GKO 4.9](https://documentation.gravitee.io/gravitee-kubernetes-operator-gko/4.9/releases-and-changelog/release-notes/gko-4.9)
   * [GKO 4.8](https://documentation.gravitee.io/gravitee-kubernetes-operator-gko/4.8/releases-and-changelog/release-notes/gko-4.8)
   * [GKO 4.7](https://documentation.gravitee.io/gravitee-kubernetes-operator-gko/4.7/releases-and-changelog/release-notes/gko-4.7)
@@ -79,8 +79,14 @@
   * [GKO 4.3](https://documentation.gravitee.io/gravitee-kubernetes-operator-gko/4.3/releases-and-changelog/release-notes/gko-4.3)
 * [Changelog](releases-and-changelog/changelog/README.md)
   * [GKO 4.11.x](releases-and-changelog/changelog/gko-4.11.x.md)
-  * [GKO 4.10.x](https://app.gitbook.com/s/mzvj63JEIkcb9VMFMq3W/gko-4.10.x)
+  * [GKO 4.10.x](https://documentation.gravitee.io/gravitee-kubernetes-operator-gko/4.10/releases-and-changelog/changelog/gko-4.10.x)
   * [GKO 4.9.x](https://documentation.gravitee.io/gravitee-kubernetes-operator-gko/4.9/releases-and-changelog/changelog/gko-4.9.x)
+  * [GKO 4.8.x](https://documentation.gravitee.io/gravitee-kubernetes-operator-gko/4.8/releases-and-changelog/changelog/gko-4.8.x)
+  * [GKO 4.7.x](https://documentation.gravitee.io/gravitee-kubernetes-operator-gko/4.7/releases-and-changelog/changelog/gko-4.7.x)
+  * [GKO 4.6.x](https://documentation.gravitee.io/gravitee-kubernetes-operator-gko/4.6/releases-and-changelog/changelog/gko-4.6.x)
+  * [GKO 4.5.x](https://documentation.gravitee.io/gravitee-kubernetes-operator-gko/4.5/releases-and-changelog/changelog/gko-4.5.x)
+  * [GKO 4.4.x](https://documentation.gravitee.io/gravitee-kubernetes-operator-gko/4.4/releases-and-changelog/changelog/gko-4.4.x)
+  * [GKO 4.3.x](https://documentation.gravitee.io/gravitee-kubernetes-operator-gko/4.3/releases-and-changelog/changelog/gko-4.3.x)
 
 ## COMMUNITY & SUPPORT
 


### PR DESCRIPTION
## What

Fixes broken and incomplete navigation links in the GKO **Release Notes** and **Changelog** sections of the 4.10, 4.11, and 4.12 `SUMMARY.md` files.

## Why

Reported by the writer from the live docs site:

1. **GKO 4.10 release notes link landed on 4.12.** In 4.11 and 4.12, the link was `.../gravitee-kubernetes-operator-gko/gko-4.10` — missing the `/4.10/` version segment, so GitBook redirected it to the latest version (4.12).
2. **GKO 4.10.x changelog link was a private editor URL.** In 4.11 and 4.12, it pointed at `https://app.gitbook.com/s/.../gko-4.10.x`, which readers can't open.
3. **Changelog lists were incomplete.** 4.10, 4.11, and 4.12 only listed changelogs down to 4.9.x, even though changelogs exist and are published all the way back to 4.3.x (this is the convention already followed in the 4.3–4.8 spaces and in the Release Notes section).

## Changes

| File | Change |
|---|---|
| `docs/gko/4.12/SUMMARY.md` | Fix 4.10 release notes URL; fix 4.10.x changelog URL; add changelog 4.8.x → 4.3.x |
| `docs/gko/4.11/SUMMARY.md` | Fix 4.10 release notes URL; fix 4.10.x changelog URL; add changelog 4.8.x → 4.3.x |
| `docs/gko/4.10/SUMMARY.md` | Add changelog 4.8.x → 4.3.x (its 4.10 links were already correct/local) |

## Verification

Every changed and added URL was checked against the live site and returns **HTTP 200**, resolving to the correct version page (no redirect to latest). The previously-broken `.../gko-4.10` URL confirmed to redirect to `.../release-notes/gko-4.12` before the fix.

## Note for reviewer

`docs/gko/4.9/SUMMARY.md` has the same incomplete changelog list (stops at 4.8.x, missing 4.7.x → 4.3.x). It was left out of this PR because it wasn't in the reported scope. Happy to extend the PR to cover 4.9 if wanted.