### PR TITLE
docs(gko): unhide the 4.11.x changelog in the 4.12 space

### DIFF
--- a/docs/gko/4.12/.version-overrides
+++ b/docs/gko/4.12/.version-overrides
@@ -3,6 +3,7 @@
 SUMMARY.md
 overview/custom-resource-definitions/subscription.md
 releases-and-changelog/release-notes/gko-4.12.md
+releases-and-changelog/changelog/gko-4.11.x.md
 guides/managing-dictionaries-via-automation-api.md
 overview/custom-resource-definitions/dictionary-management-overview.md
 overview/custom-resource-definitions/dictionary-management-restrictions-and-validation.md

--- a/docs/gko/4.12/releases-and-changelog/changelog/gko-4.11.x.md
+++ b/docs/gko/4.12/releases-and-changelog/changelog/gko-4.11.x.md
@@ -1,7 +1,3 @@
----
-hidden: true
-noIndex: true
----
 # GKO 4.11.x
 
 ## Gravitee Kubernetes Operator 4.11.13 - June 25, 2026


### PR DESCRIPTION
## What

Removes `hidden: true` / `noIndex: true` frontmatter from `docs/gko/4.12/releases-and-changelog/changelog/gko-4.11.x.md`.

## Why

On the live GKO docs, the **latest (4.12) changelog navigation started at GKO 4.10.x** — the **GKO 4.11.x** entry was missing, even though `docs/gko/4.12/SUMMARY.md` lists it first and the page is reachable by URL (returns 200).

Root cause: the page carried `hidden: true`, which tells GitBook to exclude it from the sidebar. That frontmatter was added by the automated 4.12 version-directory bootstrap (commit `5b6f66ffc`, author `Lyd1aCla1r3`), not by an editorial decision. It's inconsistent with:

- the same `gko-4.11.x.md` in the **4.11 and 4.10 spaces**, which have no frontmatter and render in the nav, and
- the 4.12 **release notes** `gko-4.11.md`, which is not hidden and shows correctly.

It was the only `hidden: true` page in the entire 4.12 GKO space.