### PR TITLE
docs (portal-automation): remove terraform mentions. remove default portal mentions.

### DIFF
--- a/docs/apim/4.12/developer-portal/new-developer-portal/customize-the-navigation/portal-automation/README.md
+++ b/docs/apim/4.12/developer-portal/new-developer-portal/customize-the-navigation/portal-automation/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The Next-Gen Developer Portal supports CI/CD-driven setup of portal structure, published APIs, and documentation through the Automation API. You declare portal configuration, navigation hierarchies, API listings, and documentation pages declaratively with Gravitee Kubernetes Operator (GKO) custom resources or the Terraform provider, and APIM reconciles the desired state into the live portal navigation tree.
+The Next-Gen Developer Portal supports CI/CD-driven setup of portal structure, published APIs, and documentation through the Automation API. You declare portal configuration, navigation hierarchies, API listings, and documentation pages declaratively with Gravitee Kubernetes Operator (GKO) custom resources and APIM reconciles the desired state into the live portal navigation tree.
 
 The Automation API supports Gravitee Markdown, OpenAPI, and AsyncAPI documentation types. External link navigation items remain a Console concern.
 
@@ -18,18 +18,16 @@ The Automation API is served at the `/automation` base path on your Management A
 
 For example, the full URL for portal operations is `https://<your-gravitee-mapi-host>/automation/organizations/{orgId}/environments/{envId}/portals`.
 
-For Terraform provider setup, see the [quick start guide](../../../../terraform/quick-start-guide.md). For Kubernetes, see the [GKO quickstart](https://documentation.gravitee.io/gravitee-kubernetes-operator-gko/getting-started/quickstart-guide).
-
 ## Concepts
 
 The following concepts describe how the Automation API models a portal and its content.
 
 ### Portal instance
 
-A portal is a Next-Gen Developer Portal bound to an environment. Each portal has a human-readable ID (HRID) that you provide, a display name, and a top-level navigation hierarchy. In APIM 4.12, only one portal instance can be created per environment. Use the HRID `default-portal` for all portal operations. The portal is created on the first successful `PUT` request.
+A portal is a Next-Gen Developer Portal bound to an environment. Each portal has a human-readable ID (HRID) that you provide, a display name, and a top-level navigation hierarchy. In APIM 4.12, only one portal instance can be created per environment. The portal is created on the first successful `PUT` request.
 
 {% hint style="info" %}
-Multi-portal support (multiple portal instances per environment) is planned for a future release. In 4.12, all portal, listing, and documentation requests must target the HRID `default-portal`. Requests targeting any other HRID are rejected with HTTP 400.
+Multi-portal support (multiple portal instances per environment) is planned for a future release.
 {% endhint %}
 
 The portal's navigation is declared as a flat list of slash-separated paths. Intermediate folders are created implicitly when they are not listed explicitly. The persisted navigation array is returned exactly as written on `GET`.
@@ -84,33 +82,6 @@ The `portalNavigation` field is portal-only metadata. It is not propagated to th
 {% hint style="info" %}
 Resources can reference each other before all dependencies exist. Documentation pages and portal listings tolerate missing navigation paths, API HRIDs, and parent portals. Orphan entries reconnect when the referenced resource is created, so apply order does not matter.
 {% endhint %}
-
-## Multi-portal support
-
-In APIM 4.12, each environment supports a single portal instance. Full multi-portal support (multiple independent portals per environment with separate navigation trees) is planned for a future release.
-
-The `allowMultiplePortalPerEnv` setting controls whether the Automation API accepts portal HRIDs other than `default-portal`. When set to `true`, multiple portal records can be created, but navigation tree materialization (folder sync, listing materialization, and documentation materialization) still runs only for the environment's first-created portal. Setting this flag is primarily useful for forward-compatibility testing.
-
-| Property | Description | Default |
-|:---------|:------------|:--------|
-| `automation.portal.allowMultiplePortalPerEnv` | When `false`, only `default-portal` is accepted as the HRID. Requests targeting a different HRID are rejected with HTTP 400 and the message `{fieldName} does not match the established portal for this environment`. When `true`, multiple portal records are allowed, but navigation tree materialization runs only for the first-created portal. | `false` |
-
-Configure it in `gravitee.yml`:
-
-```yaml
-automation:
-  portal:
-    allowMultiplePortalPerEnv: false
-```
-
-For Kubernetes deployments, set it in the APIM Helm chart values:
-
-```yaml
-api:
-  automation:
-    portal:
-      allowMultiplePortalPerEnv: false
-```
 
 ## Create a portal
 

--- a/docs/apim/4.12/developer-portal/new-developer-portal/customize-the-navigation/portal-automation/portal-documentation.md
+++ b/docs/apim/4.12/developer-portal/new-developer-portal/customize-the-navigation/portal-automation/portal-documentation.md
@@ -19,7 +19,7 @@ When a documentation page references a `location` that does not exist yet in the
 
 {% code overflow="wrap" %}
 ```http
-PUT /organizations/{orgId}/environments/{envId}/portals/default-portal/documentations?dryRun=false
+PUT /organizations/{orgId}/environments/{envId}/portals/{portalHrid}/documentations?dryRun=false
 Content-Type: application/json
 Authorization: Bearer {token}
 

--- a/docs/apim/4.12/developer-portal/new-developer-portal/customize-the-navigation/portal-automation/portal-listings.md
+++ b/docs/apim/4.12/developer-portal/new-developer-portal/customize-the-navigation/portal-automation/portal-listings.md
@@ -12,7 +12,7 @@ Send a `PUT` request to `/organizations/{orgId}/environments/{envId}/portals/{po
 
 {% code overflow="wrap" %}
 ```http
-PUT /organizations/{orgId}/environments/{envId}/portals/default-portal/listings?dryRun=false
+PUT /organizations/{orgId}/environments/{envId}/portals/{portalHrid}/listings?dryRun=false
 Content-Type: application/json
 Authorization: Bearer {token}
 
@@ -72,16 +72,16 @@ spec:
 {% hint style="warning" %}
 **Constraints:**
 
-* The `portalRef` field is immutable after creation. A listing cannot be moved to a different portal.
-* Only v4 APIs are supported. The `kind` field defaults to `ApiV4Definition` when omitted.
-* The GKO admission webhook blocks deletion of portals or APIs that are referenced by active listings.
+- The `portalRef` field is immutable after creation. A listing cannot be moved to a different portal.
+- Only v4 APIs are supported. The `kind` field defaults to `ApiV4Definition` when omitted.
+- The GKO admission webhook blocks deletion of portals or APIs that are referenced by active listings.
 {% endhint %}
 
 ### Automation API vs GKO validation differences
 
 The Automation API and GKO CRDs validate references differently:
 
-* **Automation API:** A listing tolerates references to API HRIDs and portal HRIDs that do not exist yet. No validation errors are raised for missing references. Orphan entries wait for the referenced resource to be created, so apply order does not matter.
-* **GKO admission webhooks:** All referenced APIs must resolve to existing `ApiV4Definition` resources in the cluster and must share the portal's management context. The webhook rejects listings that reference APIs that cannot be found.
+- **Automation API:** A listing tolerates references to API HRIDs and portal HRIDs that do not exist yet. No validation errors are raised for missing references. Orphan entries wait for the referenced resource to be created, so apply order does not matter.
+- **GKO admission webhooks:** All referenced APIs must resolve to existing `ApiV4Definition` resources in the cluster and must share the portal's management context. The webhook rejects listings that reference APIs that cannot be found.
 
 This difference means the Automation API supports order-independent applies across multiple resources, while GKO requires APIs and portals to exist before a listing references them.

--- a/docs/apim/4.12/release-information/release-notes/apim-4.12.md
+++ b/docs/apim/4.12/release-information/release-notes/apim-4.12.md
@@ -216,11 +216,8 @@
 #### **Portal and Documentation Management via Automation API**
 
 * Enables CI/CD-driven configuration of next-generation Developer Portal structure, API listings, and documentation through the Automation API.
-* Supports declarative portal management using Gravitee Kubernetes Operator (GKO) CRDs or the Terraform provider to define navigation hierarchies, publish APIs, and attach documentation pages.
 * Navigation paths use slash-separated strings (`/projects/alpha`) with optional display names and ordering. Portal listings control API placement and sequence within the navigation tree.
 * Documentation pages support Gravitee Markdown, OpenAPI, and AsyncAPI formats and can be scoped to either the portal (platform-level) or specific APIs (appearing under each published API instance).
-* In 4.12, one portal instance per environment is supported (multi-portal is planned for a future release). All requests must target the HRID `default-portal`. Navigation sync is limited to the top navigation bar area.
-
 
 <!-- PIPELINE:APIM-14537 -->
 #### **Custom API Key Reuse**

--- a/docs/apim/4.12/terraform/example-resource-configurations.md
+++ b/docs/apim/4.12/terraform/example-resource-configurations.md
@@ -28,9 +28,8 @@ The Gravitee Terraform provider supports the following Gravitee resource types:
 * Shared Policy Group
 * Application
 * Subscription
-* Portal, Portal Listing, and Documentation (for next-gen Developer Portal automation)
 
-Terraform can create, update, or delete these resources as part of its workflow. The Terraform provider connects to the Automation API at the `/automation` base path. For portal automation resources (portal instances, listings, and documentation pages), see the [Terraform registry documentation](https://registry.terraform.io/providers/gravitee-io/apim/latest/docs) and the [Portal automation](../developer-portal/new-developer-portal/customize-the-navigation/portal-automation/README.md) guide.
+Terraform can create, update, or delete these resources as part of its workflow.
 
 {% hint style="info" %}
 Guides and examples can be found in the [Gravitee "apim" Terraform Registry documentation](https://registry.terraform.io/providers/gravitee-io/apim/latest/docs).

--- a/docs/gko/4.12/overview/custom-resource-definitions/portal.md
+++ b/docs/gko/4.12/overview/custom-resource-definitions/portal.md
@@ -6,7 +6,7 @@ The `Portal` custom resource declares a next-gen Developer Portal instance bound
 
 A Portal resource defines the desired state of a Developer Portal, including its navigation tree. The GKO controller reconciles this resource by calling the Automation API's portal endpoints. Admission webhooks validate the resource before apply using the `dryRun` endpoint.
 
-In APIM 4.12, only one portal instance is supported per environment. All portal operations must target the HRID `default-portal`. Multi-portal support is planned for a future release.
+In APIM 4.12, only one portal instance is supported per environment. Multi-portal support is planned for a future release.
 
 ## Example
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14584

### Description

Portal automation documentation for APIM 4.12 overstated Terraform support and prescribed a fixed `default-portal` HRID for all operations. This change aligns the docs with the current product scope: portal automation is documented through GKO and the Automation API, without Terraform examples or cross-links, and portal HRIDs are described generically rather than hard-coded to `default-portal`.

### Changes

- Overview and concepts now describe GKO-only declarative setup; removed the Terraform quick start link.
- Dropped `default-portal` as the required HRID and removed the multi-portal configuration section (`allowMultiplePortalPerEnv`, gravitee.yml, and Helm examples).
- API examples in portal listings and portal documentation use `{portalHrid}` instead of `default-portal`.
- Trimmed the Portal and Documentation Management via Automation API entry: no Terraform/GKO declarative wording, no `default-portal` or navigation-sync limitations.
- Removed Portal, Portal Listing, and Documentation from the Terraform example resource list and dropped the Automation API portal automation cross-reference.
- GKO Portal CRD page no longer requires the `default-portal` HRID.
