### PR TITLE
Replace ASCII architecture diagram with Mermaid on Gamma overview page

### DIFF
--- a/docs/gamma/platform-management/overview.md
+++ b/docs/gamma/platform-management/overview.md
@@ -27,30 +27,25 @@ Gamma addresses the following core challenges:
 
 Gamma unifies four product lines—API Management, Event Stream Management, Agent Management, and Authorization Management—under a shared platform. All four share a common Catalog of assets and a common authorization engine that defines fine-grained policies against those cataloged assets. They also share common enforcement points—the AI Gateway, API Gateway, and Event Gateway—that evaluate the same policies at the wire level.
 
-```
-┌─────────────────────────────────────────────────────────────────────┐
-│                           Gravitee Gamma                            │
-│                                                                     │
-│   Consumers / API Clients / AI Agents                               │
-│          │                   │                   │                  │
-│          ▼                   ▼                   ▼                  │
-│   ┌────────────┐      ┌────────────┐      ┌────────────┐            │
-│   │ API        │      │ AI         │      │ Event      │            │
-│   │ Gateway    │      │ Gateway    │      │ Gateway    │            │
-│   └──────┬─────┘      └──────┬─────┘      └──────┬─────┘            │
-│          │                   │                   │                  │
-│          └───────────────────┴───────────────────┘                  │
-│                              │                                      │
-│                              ▼                                      │
-│   ┌───────────────────────────────────────────────────────────┐     │
-│   │               Gamma Console (Control Plane)               │     │
-│   │  ┌────────────┐  ┌───────────────┐  ┌──────────────────┐  │     │
-│   │  │  Catalog   │  │ Authorization │  │     Platform     │  │     │
-│   │  │ (Registry) │  │  Management   │  │    Management    │  │     │
-│   │  │            │  │  (PDP/GAPL)   │  │ (Apps/Resources) │  │     │
-│   │  └────────────┘  └───────────────┘  └──────────────────┘  │     │
-│   └───────────────────────────────────────────────────────────┘     │
-└─────────────────────────────────────────────────────────────────────┘
+```mermaid
+flowchart TD
+  subgraph gamma["Gravitee Gamma"]
+    consumers["Consumers / API Clients / AI Agents"]
+    API["API Gateway"]
+    AI["AI Gateway"]
+    event["Event Gateway"]
+    subgraph console["Gamma Console (Control Plane)"]
+      catalog["Catalog (Registry)"]
+      authorization["Authorization Management (PDP/GAPL)"]
+      platform["Platform Management (Apps/Resources)"]
+    end
+    consumers --> API
+    consumers --> AI
+    consumers --> event
+    API --> console
+    AI --> console
+    event --> console
+  end
 ```
 
 ### Platform Components


### PR DESCRIPTION
## What

Replaces the ASCII architecture diagram in the **How Gamma Works** section of `docs/gamma/platform-management/overview.md` with a Mermaid flowchart (published at https://documentation.gravitee.io/gravitee-gamma/platform-management/overview).

## Why

PR #1917 fixed the character alignment, but the diagram still renders broken on the live page: GitBook's code-block font leaves vertical gaps between box-drawing characters, so every border looks dashed no matter how the characters line up. Character art can't render cleanly there.

GitBook renders ```mermaid blocks natively as real, theme-aware SVG flowcharts. This repo already uses Mermaid in the APIM plugin reference pages (`docs/apim/4.11` and `4.12`).
