### PR TITLE
docs: apply SEO checklist edits to homepage README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
+---
+description: Checklists, step-by-step guides, tutorials, and more - all found on Gravitee's Documentation site.
+---
+
 # gravitee-platform-docs
 
-The [Gravitee platform documentation](https://documentation.gravitee.io/platform-overview/) is intended for both business stakeholders and developers as an introduction to the core concepts and technologies comprising Gravitee’s best-in-class API management solution. Gravitee’s standalone and integrated products position customers to easily adopt and maintain complex API architectures and communication in a versatile and innovative ecosystem.
+The [Gravitee platform documentation](https://documentation.gravitee.io/platform-overview/) is intended for both business stakeholders and developers as an introduction to the core concepts and technologies comprising Gravitee’s best-in-class [API management platform](https://www.gravitee.io/platform/api-management). Gravitee’s standalone and integrated products position customers to easily adopt and maintain complex API architectures and communication in a versatile and innovative ecosystem.
 
 The UX of the docs site is structured to promote intuitive navigation and an informative exploration of platform features and capabilities. The fundamental functionality of each Gravitee product is presented in the context of satisfying the business needs of real-world use cases. The complementary relationships between and extensibility of individual platform components demonstrate a centralized, comprehensive approach to API management that is compatible with a wide variety of customer roadmaps and infrastructures. Exhaustive implementation details organized into user guides and reference materials provide clarified guidance with which to harness the potential of Gravitee’s flexible, customizable, and sophisticated feature sets. 
 

--- a/docs/am/4.12/README.md
+++ b/docs/am/4.12/README.md
@@ -1,4 +1,5 @@
 ---
+description: Dive into use case for AM as well as an overview of core components, concepts, and authorization mechanisms with Gravitee.
 metaLinks:
   alternates:
     - https://app.gitbook.com/s/H4VhZJXn1S232OEmh8Wv/overview/readme
@@ -6,9 +7,9 @@ metaLinks:
 
 # Introduction to Gravitee Access Management (AM)
 
-Gravitee Access Management (AM) is a flexible, lightweight, and easy-to-use open source Identity and Access Management (IAM) solution. It offers a centralized authentication and authorization service to deliver secure access to your applications and APIs from any device.
+[Gravitee Access Management (AM)](https://www.gravitee.io/platform/ai-identity-access-management) is a flexible, lightweight, and easy-to-use open source Identity and Access Management (IAM) solution. It offers a centralized authentication and authorization service to deliver secure access to your applications and APIs from any device.
 
-With its intuitive design and seamless integration with our API Management product, Access Management is the natural Identity and Access Management platform choice for our customers.
+With its intuitive design and seamless integration with [our API Management product](https://www.gravitee.io/platform/api-management), Access Management is the natural Identity and Access Management platform choice for our customers.
 
 This article describes the use case for AM and gives a high-level overview of its core components, concepts, and authorization mechanisms.
 

--- a/docs/apim/4.12/configure-and-manage-the-platform/manage-organizations-and-environments/README.md
+++ b/docs/apim/4.12/configure-and-manage-the-platform/manage-organizations-and-environments/README.md
@@ -1,5 +1,5 @@
 ---
-description: An overview about manage organizations & environments.
+description: A tutorial guide about manage organizations & environments in Gravitee's platform.
 metaLinks:
   alternates:
     - ./
@@ -45,7 +45,7 @@ To access your Organization settings:
 2. Select **Organization** from the left nav
 3.  Select **Settings** under **Console**
 
-    <figure><img src="../../.gitbook/assets/organization settings.png" alt=""><figcaption><p>Organization settings</p></figcaption></figure>
+    <figure><img src="../../.gitbook/assets/organization settings.png" alt="Gravitee APIM Console Organization Setting Environment Tutorial"><figcaption><p>Organization settings</p></figcaption></figure>
 4. View or define the settings for your Organization, described below
 
 {% tabs %}
@@ -109,7 +109,7 @@ To learn more about notifications, refer to the [Notifications](../gravitee-gate
 
 ### Platform access
 
-As a part of Organization administration, Gravitee offers multiple ways to manage and control access to the Gravitee platform via identity provider configuration and login/registration settings. See the [Authentication](authentication/README.md) documentation for details.
+As a part of Organization administration, Gravitee offers multiple ways to manage and control access to the [Gravitee platform](https://www.gravitee.io/platform) via identity provider configuration and login/registration settings. See the [Authentication](authentication/README.md) documentation for details.
 
 {% hint style="warning" %}
 This should _not_ be confused with [Gravitee Access Management](https://documentation.gravitee.io/am), which is a full-featured Identity and Access Management solution used to control access to applications and APIs.

--- a/docs/apim/4.12/create-and-configure-apis/configure-v2-apis/service-discovery.md
+++ b/docs/apim/4.12/create-and-configure-apis/configure-v2-apis/service-discovery.md
@@ -1,5 +1,5 @@
 ---
-description: An overview about service discovery.
+description: View Gravitee's complete guide to configure service discovery using the HashiCorp Consul solution.
 metaLinks:
   alternates:
     - service-discovery.md
@@ -27,7 +27,7 @@ Consul agents that run in server mode become the centralized registry for servic
 Refer to the [official Consul documentation](https://www.consul.io/docs/install) to learn how to install a Consul server.
 {% endhint %}
 
-To use `docker-compose` to set up an integration between Gravitee APIM and HashiCorp Consul:
+To use `docker-compose` to set up an integration between [Gravitee APIM](https://www.gravitee.io/platform/api-management) and HashiCorp Consul:
 
 1. Edit the `docker-compose.yml` used to install Gravitee and declare an additional service for the Consul server. The example below declares a read-only volume to mount the directory containing Consul configuration files.
 
@@ -96,7 +96,7 @@ curl -X PUT -d '{ "ID": "whattimeisit_1", "Name": "whattimeisit", "Address": "ap
 
 The Consul web UI should display a new service named `whattimeisit`:
 
-<figure><img src="../../.gitbook/assets/service-discovery-consul-services.png" alt=""><figcaption></figcaption></figure>
+<figure><img src="../../.gitbook/assets/service-discovery-consul-services.png" alt="Consul web UI Environment with whattimeisit photo"><figcaption></figcaption></figure>
 
 You can also verify that your service is successfully registered in Consul by interacting with Consul Agent API.
 

--- a/docs/apim/4.12/gravitee-expression-language.md
+++ b/docs/apim/4.12/gravitee-expression-language.md
@@ -1,3 +1,7 @@
+---
+description: Access our comprehensive guide on Gravitee Expression Language (EL) queries and usage.
+---
+
 # Gravitee Expression Language
 
 ## Overview
@@ -219,7 +223,7 @@ The notifier body is processed by FreeMarker, not the EL template engine. The EL
 
 The Expression Language (EL) Assistant generates EL expressions based on natural language prompts. You describe the condition or logic you need, and the Assistant returns the corresponding EL syntax.
 
-<figure><img src="https://128066588-files.gitbook.io/~/files/v0/b/gitbook-x-prod.appspot.com/o/spaces%2FbGmDEarvnV52XdcOiV8o%2Fuploads%2Fgit-blob-7672c60e0db5e4b1f2a071af3eba3f0b759cb7e3%2Fanim.gif?alt=media" alt=""><figcaption></figcaption></figure>
+<figure><img src="https://128066588-files.gitbook.io/~/files/v0/b/gitbook-x-prod.appspot.com/o/spaces%2FbGmDEarvnV52XdcOiV8o%2Fuploads%2Fgit-blob-7672c60e0db5e4b1f2a071af3eba3f0b759cb7e3%2Fanim.gif?alt=media" alt="Demo of Expression Language (EL) Assistant to generate EL syntax from prompt"><figcaption></figcaption></figure>
 
 ### Prerequisites
 
@@ -281,14 +285,14 @@ The EL Assistant is available in any field that supports Expression Language.
 
 1.  In the field that supports Expression Language, click the **{EL}** icon.
 
-    <figure><img src="https://128066588-files.gitbook.io/~/files/v0/b/gitbook-x-prod.appspot.com/o/spaces%2FbGmDEarvnV52XdcOiV8o%2Fuploads%2Fgit-blob-008c4fc76a06b5570f9af67bb2cfc51457ab629f%2F304A887B-9FD1-4011-961A-7DB7D91D3478_1_201_a.jpeg?alt=media" alt=""><figcaption></figcaption></figure>
+    <figure><img src="https://128066588-files.gitbook.io/~/files/v0/b/gitbook-x-prod.appspot.com/o/spaces%2FbGmDEarvnV52XdcOiV8o%2Fuploads%2Fgit-blob-008c4fc76a06b5570f9af67bb2cfc51457ab629f%2F304A887B-9FD1-4011-961A-7DB7D91D3478_1_201_a.jpeg?alt=media" alt="Image of Gravitee Developer Portal and Create a New Flow with EL Assistant"><figcaption></figcaption></figure>
 2. In the **EL Assistant** pop-up window, enter a natural language prompt describing the Expression Language you need. For example: "Only run this policy if the header equals test."
 3.  Click **Ask Newt AI**. The Assistant generates the corresponding Expression Language.
 
-    <figure><img src="https://128066588-files.gitbook.io/~/files/v0/b/gitbook-x-prod.appspot.com/o/spaces%2FbGmDEarvnV52XdcOiV8o%2Fuploads%2Fgit-blob-7d9c2dbfbfb15a07488aef31b1f2ff476bc84c4c%2FDBE0A0C1-3171-4CA4-A586-A503EBD2B0BD_1_201_a.jpeg?alt=media" alt=""><figcaption></figcaption></figure>
+    <figure><img src="https://128066588-files.gitbook.io/~/files/v0/b/gitbook-x-prod.appspot.com/o/spaces%2FbGmDEarvnV52XdcOiV8o%2Fuploads%2Fgit-blob-7d9c2dbfbfb15a07488aef31b1f2ff476bc84c4c%2FDBE0A0C1-3171-4CA4-A586-A503EBD2B0BD_1_201_a.jpeg?alt=media" alt="Demo image of Gravitee Ask Newt AI to generate Expression Language"><figcaption></figcaption></figure>
 4.  (Optional) Provide feedback by clicking the **thumbs up** or **thumbs down** icon.
 
-    <figure><img src="https://128066588-files.gitbook.io/~/files/v0/b/gitbook-x-prod.appspot.com/o/spaces%2FbGmDEarvnV52XdcOiV8o%2Fuploads%2Fgit-blob-fdfd3541a28f3f38863088cd442a5d75838cbcc3%2F6D6E46F0-AECF-41F9-BE38-53C6EC0EDA38_1_201_a.jpeg?alt=media" alt=""><figcaption></figcaption></figure>
+    <figure><img src="https://128066588-files.gitbook.io/~/files/v0/b/gitbook-x-prod.appspot.com/o/spaces%2FbGmDEarvnV52XdcOiV8o%2Fuploads%2Fgit-blob-fdfd3541a28f3f38863088cd442a5d75838cbcc3%2F6D6E46F0-AECF-41F9-BE38-53C6EC0EDA38_1_201_a.jpeg?alt=media" alt="Photo of feedback option on Gravitee Expression Language (EL) Assistant"><figcaption></figcaption></figure>
 
 ### Use case examples
 

--- a/docs/apim/4.12/management-api-reference.md
+++ b/docs/apim/4.12/management-api-reference.md
@@ -1,5 +1,5 @@
 ---
-description: An overview about management api reference.
+description: An overview guide for Gravitee's management api reference.
 metaLinks:
   alternates:
     - management-api-reference.md
@@ -9,7 +9,7 @@ metaLinks:
 
 ## Overview
 
-The Gravitee Management API is the programmatic interface to the Gravitee APIM backend. The Management API consists of two main subcomponents:
+The Gravitee Management API is the programmatic interface to the [Gravitee APIM](https://www.gravitee.io/platform/api-management) backend. The Management API consists of two main subcomponents:
 
 * The **Management** component. This component exposes the core functionality of APIM. For example, creating APIs, deploying APIs to the gateway, and analytics.
 * The **Portal** component. This component exposes endpoints for listing and managing APIs and applications in Gravitee's Developer Portal UI. Also, you can use the Portal API endpoints to build custom developer portals.

--- a/docs/apim/4.12/release-information/release-notes/README.md
+++ b/docs/apim/4.12/release-information/release-notes/README.md
@@ -1,5 +1,5 @@
 ---
-description: An overview about release notes.
+description: An overview about Gravitee's release notes on news, overviews, and patch releases.
 metaLinks:
   alternates:
     - ./


### PR DESCRIPTION
## Summary
- Add meta description to the homepage README, per the SEO checklist for `documentation.gravitee.io`
- Link "API management platform" text to https://www.gravitee.io/platform/api-management (internal linking item from the checklist)
- Note: the checklist's "alt tag" item isn't applicable — GitBook's auto-generated social preview image has no alt-text field in its API/customization schema

## Test plan
- [ ] Confirm the README front matter renders as the page's meta description in GitBook
- [ ] Confirm the "API management platform" link resolves correctly