### PR TITLE
[APIM] Add missing changelog for APIM-14665 in 4.11.20 and 4.12.8

### DIFF
--- a/docs/apim/4.11/release-information/changelog/apim-4.11.x.md
+++ b/docs/apim/4.11/release-information/changelog/apim-4.11.x.md
@@ -8,6 +8,7 @@
 **Other**
 
 * APIM -  Traffic Shadowing Policy giving status 0 [#11506](https://github.com/gravitee-io/issues/issues/11506)
+* Support EL in the headers of MCP Proxy endpoint
 
 </details>
 

--- a/docs/apim/4.12/release-information/changelog/apim-4.12.x.md
+++ b/docs/apim/4.12/release-information/changelog/apim-4.12.x.md
@@ -13,6 +13,7 @@ noIndex: false
 **Other**
 
 * APIM -  Traffic Shadowing Policy giving status 0 [#11506](https://github.com/gravitee-io/issues/issues/11506)
+* Support EL in the headers of MCP Proxy endpoint
 
 </details>
 


### PR DESCRIPTION
## Summary
- Add missing changelog entry for [APIM-14665](https://gravitee.atlassian.net/browse/APIM-14665) (*Support EL in the headers of MCP Proxy endpoint*) to the 4.11.20 and 4.12.8 release sections.
- These versions were already documented in #1962 and #1964, but APIM-14665 was omitted from both changelogs.

## Test plan
- [ ] Verify the changelog entry appears under **Bug Fixes > Other** for both 4.11.20 and 4.12.8
- [ ] Confirm the entry title matches the Jira issue summary
- [ ] Review and merge


Made with [Cursor](https://cursor.com)

[APIM-14665]: https://gravitee.atlassian.net/browse/APIM-14665?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ