### PR TITLE
docs: move apim redirects into the owning space configs

### DIFF
--- a/.gitbook.yaml
+++ b/.gitbook.yaml
@@ -74,19 +74,12 @@ redirects:
   alert-engine/changelog/page-6: apim/4.12/configure-and-manage-the-platform/gravitee-gateway/alerts.md
   # legacy apim/* URL structure (pre-reorg) — redirect into the current apim/4.12 structure (bump 4.12 at each version cutover)
   apim/guides/federation: apim/4.12/govern-apis/federation/README.md
-  apim/guides/policies: apim/4.12/create-and-configure-apis/apply-policies/README.md
   apim/overview/gravitee-apim-enterprise-edition: apim/4.12/introduction/enterprise-edition.md
   apim/overview/release-notes/apim-4.6: apim/4.12/release-information/release-notes/README.md
   apim/release-information/release-notes/apim-4.9: apim/4.12/release-information/release-notes/README.md
   apim/release-information/release-notes/apim-4.10: apim/4.12/release-information/release-notes/README.md
   apim/release-information/release-notes/apim-4.11: apim/4.12/release-information/release-notes/README.md
   apim/releases-and-changelog/release-notes/apim-4.3: apim/4.12/release-information/release-notes/README.md
-  apim/releases-and-changelog/release-notes/apim-4.5: apim/4.5/overview/release-notes/apim-4.5.md
-  apim/releases-and-changelog/release-notes/gravitee-4.x/apim-4.0: apim/4.0/releases-and-changelog/release-notes/apim-4.0.md
-  apim/4.2/overview/changelog/apim-4.2: apim/4.2/overview/release-notes/apim-4.2.md
-  apim/readme/core-concepts: apim/4.12/introduction/core-concepts.md
-  apim/readme/enterprise-edition: apim/4.12/introduction/enterprise-edition.md
-  apim/readme/enterprise-edition-licensing: apim/4.12/introduction/enterprise-edition-licensing.md
   # legacy api-designer/* prefix (different from apid/* above)
   api-designer/overview/readme: gravitee-cloud/api-designer/guides/api-designer-workspace/README.md
   # deprecated telepresence page — send traffic home

--- a/docs/apim/4.12/.gitbook.yaml
+++ b/docs/apim/4.12/.gitbook.yaml
@@ -504,6 +504,7 @@ redirects:
  guides/gravitee-kubernetes-operator/installation/helm: configure-and-manage-the-platform/gravitee-gateway/deploying-the-hazelcast-rate-limit-repository-with-helm-and-kubernetes-discovery.md
  guides/gravitee-kubernetes-operator/quick-start: govern-apis/README.md
  guides/gravitee-kubernetes-operator/test-gko-after-deployment: govern-apis/README.md
+ guides/policies: create-and-configure-apis/apply-policies/README.md
  guides/policy-design: create-and-configure-apis/apply-policies/v4-api-policy-studio.md
  guides/policy-design/gravitee-api-definitions-compared: create-and-configure-apis/gravitee-api-definitions/execution-engine.md
  guides/policy-design/gravitee-expression-language: gravitee-expression-language.md
@@ -701,6 +702,9 @@ redirects:
  prepare-a-production-environment/sensitive-data-management/apply-secrets-to-apis: prepare-a-production-environment/sensitive-data-management/api-secrets/configuration.md
  prepare-a-production-environment/sensitive-data-management/apply-secrets-to-configurations: prepare-a-production-environment/sensitive-data-management/configure-secrets/reference-secrets-in-configurations.md
  prepare-a-production-environment/sensitive-data-management/configure-secret-provider-plugins: prepare-a-production-environment/sensitive-data-management/api-secrets/configuration.md
+ readme/core-concepts: introduction/core-concepts.md
+ readme/enterprise-edition: introduction/enterprise-edition.md
+ readme/enterprise-edition-licensing: introduction/enterprise-edition-licensing.md
  reference/endpoint-reference: README.md
  reference/endpoint-reference/kafka: create-and-configure-apis/configure-v4-apis/endpoints/kafka.md
  reference/endpoint-reference/mqtt5: create-and-configure-apis/configure-v4-apis/endpoints/mqtt5.md
@@ -787,6 +791,8 @@ redirects:
  releases-and-changelog/release-notes: release-information/release-notes/README.md
  releases-and-changelog/release-notes/apim-4.0: release-information/changelog/apim-4.11.x.md
  releases-and-changelog/release-notes/apim-4.1: release-information/changelog/apim-4.11.x.md
+ releases-and-changelog/release-notes/apim-4.5: release-information/changelog/apim-4.11.x.md
+ releases-and-changelog/release-notes/gravitee-4.x/apim-4.0: release-information/changelog/apim-4.11.x.md
  using-the-product/administration: README.md
  using-the-product/administration/administering-organizations-and-environments: configure-and-manage-the-platform/manage-organizations-and-environments/README.md
  using-the-product/administration/authentication: configure-and-manage-the-platform/manage-organizations-and-environments/authentication/README.md

--- a/docs/apim/4.2/.gitbook.yaml
+++ b/docs/apim/4.2/.gitbook.yaml
@@ -875,6 +875,7 @@ redirects:
  most-common-use-cases/secure-and-expose-grpc-services-with-gravitee: README.md
  new-release: README.md
  overview/architecture: overview/apim-architecture/README.md
+ overview/changelog/apim-4.2: overview/release-notes/apim-4.2.md
  overview/changelog/apim-4.3.x: overview/changelog/apim-4.2.x.md
  overview/changelog/apim-4.4.x: overview/changelog/apim-4.2.x.md
  overview/changelog/apim-4.5.x: overview/changelog/apim-4.2.x.md


### PR DESCRIPTION
## Summary
Follow-up to #1971. That PR added 6 of the 10 requested redirects to the root `.gitbook.yaml`, but they were still 404ing after merge because this repo publishes as multiple GitBook spaces (one per product/version, each with its own `.gitbook.yaml`), and GitBook routes a request to whichever space's URL prefix matches before consulting that space's own redirects. Root-level entries under `apim/*` never fire because a space is already mounted at `/apim` (the 4.12 default variant) and at `/apim/4.2`, etc.

Confirmed via the live 404 pages, which report the residual path *after* the owning space's prefix was stripped (e.g. requesting `apim/guides/policies` produced a 404 for `guides/policies`, proving the request was already routed into the `apim` space and just missing a redirect there).

- Removes the 6 dead entries from root `.gitbook.yaml`
- Adds `guides/policies`, `readme/core-concepts`, `readme/enterprise-edition`, `readme/enterprise-edition-licensing`, `releases-and-changelog/release-notes/apim-4.5`, and `releases-and-changelog/release-notes/gravitee-4.x/apim-4.0` to `docs/apim/4.12/.gitbook.yaml`, matching that file's existing redirect conventions for equivalent legacy paths
- Adds `overview/changelog/apim-4.2` to `docs/apim/4.2/.gitbook.yaml`, matching that file's own changelog→release-notes convention

The other 3 links from the original report (`alert-engine`, `alert-engine/overview/integrations`, `telepresence/canary-deployments`) were already correctly placed in root `.gitbook.yaml` by #1971 — those not resolving yet is most likely GitBook sync propagation lag, not a config issue.

## Test plan
- [ ] After merge and GitBook resync, verify all 10 original URLs resolve (no 404)
- [ ] Spot check that `alert-engine`, `alert-engine/overview/integrations`, and `telepresence/canary-deployments` clear up once sync catches up; if they don't, that points to a real issue in the root space config rather than propagation lag

🤖 Generated with [Claude Code](https://claude.com/claude-code)