### PR TITLE
docs(apim-4.12): add Kubernetes deployment HA recommendations

### DIFF
--- a/docs/apim/4.12/prepare-a-production-environment/production-best-practices/deployments.md
+++ b/docs/apim/4.12/prepare-a-production-environment/production-best-practices/deployments.md
@@ -155,6 +155,16 @@ The Gravitee Helm chart ships conservative defaults that are safe for a first in
 | `gammaUi` | `gammaUi.replicaCount` | `1` | `2`+ if enabled |
 | `kafkaConsole` | `kafkaConsole.replicaCount` | `1` | `2`+ if enabled |
 
+**Example** (`values-production.yaml`):
+
+```yaml
+api:
+  replicaCount: 2
+
+gateway:
+  replicaCount: 3
+```
+
 ### Pod Disruption Budgets
 
 {% hint style="warning" %}
@@ -169,6 +179,22 @@ Every component ships with `pdb.enabled: false`. Nothing stops a node drain or c
 | `ui` | `ui.pdb.*` | `false` / `""` / `"50%"` | Enable; set `minAvailable: 1` |
 | `gammaUi` | `gammaUi.pdb.*` | `false` / `""` / `"50%"` | Enable if the component is in use |
 | `kafkaConsole` | `kafkaConsole.pdb.*` | `false` / `""` / `"50%"` | Enable if the component is in use |
+
+**Example** (`values-production.yaml`):
+
+```yaml
+api:
+  pdb:
+    enabled: true
+    minAvailable: 1
+    maxUnavailable: ""   # must clear this — Kubernetes rejects a PDB with both set
+
+gateway:
+  pdb:
+    enabled: true
+    minAvailable: 2      # gateway runs 3+ replicas, so keep 2 available during a drain
+    maxUnavailable: ""
+```
 
 ### Pod anti-affinity
 
@@ -185,6 +211,42 @@ No component configures anti-affinity out of the box (`deployment.affinity: {}` 
 | `gammaUi` | `gammaUi.deployment.affinity` | `{}` (none) | Add if the component is in use |
 | `kafkaConsole` | `kafkaConsole.deployment.affinity` | `{}` (none) | Add if the component is in use |
 
+**Example** (`values-production.yaml`):
+
+The chart injects this value as literal YAML (no templating), so reference the real pod labels directly. Each component is labeled with `app.kubernetes.io/name: apim` and `app.kubernetes.io/component: <api|gateway|portal|ui|gamma|kafkaConsole>` (note: `gammaUi`'s component label value is `gamma`, not `gammaUi`). Add `app.kubernetes.io/instance: <your-release-name>` too if more than one `apim` release runs in the same namespace.
+
+```yaml
+api:
+  deployment:
+    affinity:
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: apim
+                  app.kubernetes.io/component: api
+
+gateway:
+  deployment:
+    affinity:
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: apim
+                  app.kubernetes.io/component: gateway
+```
+
+{% hint style="info" %}
+`preferredDuringSchedulingIgnoredDuringExecution` (soft anti-affinity) is used here rather than `requiredDuringSchedulingIgnoredDuringExecution` (hard). Hard anti-affinity blocks scheduling entirely if there aren't enough nodes to spread every replica, which is usually worse than accepting occasional co-location.
+{% endhint %}
+
 ### Controlled HPA scaling behavior
 
 | Component | Helm value | Chart default | Recommendation |
@@ -198,4 +260,54 @@ No component configures anti-affinity out of the box (`deployment.affinity: {}` 
 
 {% hint style="info" %}
 `autoscaling.enabled` defaults to `true` for every component, so a `HorizontalPodAutoscaler` is created out of the box. The chart leaves `behavior` commented out, so Kubernetes' own default scaling behavior applies (near-instant scale-up, a 300-second scale-down stabilization window) until you set it explicitly.
+{% endhint %}
+
+**Example** (`values-production.yaml`):
+
+```yaml
+api:
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 6
+    targetAverageUtilization: 50
+    targetMemoryAverageUtilization: 80
+    behavior:
+      scaleDown:
+        stabilizationWindowSeconds: 300
+        policies:
+          - type: Pods
+            value: 1
+            periodSeconds: 60
+      scaleUp:
+        stabilizationWindowSeconds: 0
+        policies:
+          - type: Pods
+            value: 2
+            periodSeconds: 60
+
+gateway:
+  autoscaling:
+    enabled: true
+    minReplicas: 3
+    maxReplicas: 10
+    targetAverageUtilization: 50
+    targetMemoryAverageUtilization: 80
+    behavior:
+      scaleDown:
+        stabilizationWindowSeconds: 600   # gateway sees bursty traffic — hold off scaling down longer
+        policies:
+          - type: Pods
+            value: 1
+            periodSeconds: 60
+      scaleUp:
+        stabilizationWindowSeconds: 0
+        policies:
+          - type: Pods
+            value: 2
+            periodSeconds: 60
+```
+
+{% hint style="info" %}
+Scale-up is intentionally fast (`stabilizationWindowSeconds: 0`) and scale-down is intentionally slow — this asymmetry avoids dropping capacity too early during a temporary traffic dip.
 {% endhint %}

--- a/docs/apim/4.12/prepare-a-production-environment/production-best-practices/deployments.md
+++ b/docs/apim/4.12/prepare-a-production-environment/production-best-practices/deployments.md
@@ -135,3 +135,67 @@ reporters:
 {% hint style="warning" %}
 If LogGuard is triggered, both the request body and response body are unavailable to the UI. They are replaced with the message `BODY NOT CAPTURED`. The request body and response body are also unavailable to external monitoring systems, such as Datadog.
 {% endhint %}
+
+## Kubernetes deployments
+
+The Gravitee Helm chart ships conservative defaults that are safe for a first install but are not sufficient for high availability on their own. Review the following settings for each component you deploy (`api`, `gateway`, `portal`, `ui`, and, if enabled, `gammaUi` and `kafkaConsole`) before going to production.
+
+{% hint style="info" %}
+`gammaUi` and `kafkaConsole` are disabled by default (`enabled: false`) and only apply if you've enabled those features.
+{% endhint %}
+
+### Minimum HA replicas
+
+| Component | Helm value | Chart default | Recommendation |
+|---|---|---|---|
+| `api` (Management API) | `api.replicaCount` | `1` | `2`+ |
+| `gateway` | `gateway.replicaCount` | `1` | `3`+ |
+| `portal` | `portal.replicaCount` | `1` | `2`+ |
+| `ui` (Console webui) | `ui.replicaCount` | `1` | `2`+ |
+| `gammaUi` | `gammaUi.replicaCount` | `1` | `2`+ if enabled |
+| `kafkaConsole` | `kafkaConsole.replicaCount` | `1` | `2`+ if enabled |
+
+### Pod Disruption Budgets
+
+{% hint style="warning" %}
+Every component ships with `pdb.enabled: false`. Nothing stops a node drain or cluster upgrade from evicting every replica of a component at once unless you enable this explicitly.
+{% endhint %}
+
+| Component | Helm value | Chart default | Recommendation |
+|---|---|---|---|
+| `api` | `api.pdb.enabled` / `minAvailable` / `maxUnavailable` | `false` / `""` / `"50%"` | Enable; set `minAvailable: 1` (or `replicas - 1`) |
+| `gateway` | `gateway.pdb.*` | `false` / `""` / `"50%"` | Enable; set `minAvailable: 1` |
+| `portal` | `portal.pdb.*` | `false` / `""` / `"50%"` | Enable; set `minAvailable: 1` |
+| `ui` | `ui.pdb.*` | `false` / `""` / `"50%"` | Enable; set `minAvailable: 1` |
+| `gammaUi` | `gammaUi.pdb.*` | `false` / `""` / `"50%"` | Enable if the component is in use |
+| `kafkaConsole` | `kafkaConsole.pdb.*` | `false` / `""` / `"50%"` | Enable if the component is in use |
+
+### Pod anti-affinity
+
+{% hint style="warning" %}
+No component configures anti-affinity out of the box (`deployment.affinity: {}` for all of them). Replicas can land on the same node with no anti-affinity rule in place.
+{% endhint %}
+
+| Component | Helm value | Chart default | Recommendation |
+|---|---|---|---|
+| `api` | `api.deployment.affinity` | `{}` (none) | Add a `podAntiAffinity` rule keyed on the `api` pod label |
+| `gateway` | `gateway.deployment.affinity` | `{}` (none) | Add a `podAntiAffinity` rule keyed on the `gateway` pod label |
+| `portal` | `portal.deployment.affinity` | `{}` (none) | Add a `podAntiAffinity` rule keyed on the `portal` pod label |
+| `ui` | `ui.deployment.affinity` | `{}` (none) | Add a `podAntiAffinity` rule keyed on the `ui` pod label |
+| `gammaUi` | `gammaUi.deployment.affinity` | `{}` (none) | Add if the component is in use |
+| `kafkaConsole` | `kafkaConsole.deployment.affinity` | `{}` (none) | Add if the component is in use |
+
+### Controlled HPA scaling behavior
+
+| Component | Helm value | Chart default | Recommendation |
+|---|---|---|---|
+| `api` | `api.autoscaling.*` | `enabled: true`, `minReplicas: 1` / `maxReplicas: 3`, CPU `50%` / memory `80%`, `behavior` unset | Set `behavior.scaleDown.stabilizationWindowSeconds` (300-600) and a bounded `scaleUp` policy |
+| `gateway` | `gateway.autoscaling.*` | Same defaults | Same tuning; the gateway is the component most exposed to traffic bursts |
+| `portal` | `portal.autoscaling.*` | Same defaults | Same tuning |
+| `ui` | `ui.autoscaling.*` | Same defaults | Same tuning |
+| `gammaUi` | `gammaUi.autoscaling.*` | Same defaults | Same tuning, if enabled |
+| `kafkaConsole` | `kafkaConsole.autoscaling.*` | Same defaults | Same tuning, if enabled |
+
+{% hint style="info" %}
+`autoscaling.enabled` defaults to `true` for every component, so a `HorizontalPodAutoscaler` is created out of the box. The chart leaves `behavior` commented out, so Kubernetes' own default scaling behavior applies (near-instant scale-up, a 300-second scale-down stabilization window) until you set it explicitly.
+{% endhint %}


### PR DESCRIPTION
## Summary
- Adds a "Kubernetes deployments" section to `docs/apim/4.12/prepare-a-production-environment/production-best-practices/deployments.md`
- Covers minimum HA replica counts, Pod Disruption Budgets, pod anti-affinity, and controlled HPA scaling behavior, broken out per Helm chart component (`api`, `gateway`, `portal`, `ui`, `gammaUi`, `kafkaConsole`)
- Values are grounded in the actual chart defaults in `gravitee-api-management/helm/values.yaml` (e.g. `pdb.enabled: false` and empty `deployment.affinity` by default on every component), not assumed

## Test plan
- [x] Vale lint passes on the added section (0 errors)
- [ ] Docs review: confirm recommended values (min replicas, PDB `minAvailable`, HPA stabilization window) match current guidance/support recommendations
- [ ] Confirm placement (this production-best-practices page) is the right home vs. a Kubernetes-specific install guide

🤖 Generated with [Claude Code](https://claude.com/claude-code)