### PR TITLE
docs: remove blank Development Tools pages (APIM 4.11-4.13)

### DIFF
--- a/docs/apim/4.11/SUMMARY.md
+++ b/docs/apim/4.11/SUMMARY.md
@@ -276,8 +276,6 @@
       * [XML Validation](create-and-configure-apis/apply-policies/policy-reference/xml-validation.md)
       * [XSLT](create-and-configure-apis/apply-policies/policy-reference/xslt.md)
       * [Webhook Signature Generator](create-and-configure-apis/apply-policies/policy-reference/webhook-signature-generator.md)
-  * [Development Tools](create-and-configure-apis/development-tools/README.md)
-    * [Enforcing logging rules with ArchUnit Maven plugin](create-and-configure-apis/development-tools/enforcing-logging-rules-with-archunit-maven-plugin.md)
 * [Secure & Expose APIs](secure-and-expose-apis/README.md)
   * [Plans](secure-and-expose-apis/plans/README.md)
     * [Keyless](secure-and-expose-apis/plans/keyless.md)

--- a/docs/apim/4.11/create-and-configure-apis/development-tools/README.md
+++ b/docs/apim/4.11/create-and-configure-apis/development-tools/README.md
@@ -1,2 +1,0 @@
-# Development Tools
-

--- a/docs/apim/4.11/create-and-configure-apis/development-tools/enforcing-logging-rules-with-archunit-maven-plugin.md
+++ b/docs/apim/4.11/create-and-configure-apis/development-tools/enforcing-logging-rules-with-archunit-maven-plugin.md
@@ -1,2 +1,0 @@
-# Enforcing logging rules with ArchUnit Maven plugin
-

--- a/docs/apim/4.12/SUMMARY.md
+++ b/docs/apim/4.12/SUMMARY.md
@@ -299,8 +299,6 @@
       * [XML Validation](create-and-configure-apis/apply-policies/policy-reference/xml-validation.md)
       * [XSLT](create-and-configure-apis/apply-policies/policy-reference/xslt.md)
       * [Webhook Signature Generator](create-and-configure-apis/apply-policies/policy-reference/webhook-signature-generator.md)
-  * [Development Tools](create-and-configure-apis/development-tools/README.md)
-    * [Enforcing logging rules with ArchUnit Maven plugin](create-and-configure-apis/development-tools/enforcing-logging-rules-with-archunit-maven-plugin.md)
 * [Secure & Expose APIs](secure-and-expose-apis/README.md)
   * [Plans](secure-and-expose-apis/plans/README.md)
     * [Conditional Updates for Plans](secure-and-expose-apis/plans/conditional-updates-for-plans.md)

--- a/docs/apim/4.12/create-and-configure-apis/development-tools/README.md
+++ b/docs/apim/4.12/create-and-configure-apis/development-tools/README.md
@@ -1,2 +1,0 @@
-# Development Tools
-

--- a/docs/apim/4.12/create-and-configure-apis/development-tools/enforcing-logging-rules-with-archunit-maven-plugin.md
+++ b/docs/apim/4.12/create-and-configure-apis/development-tools/enforcing-logging-rules-with-archunit-maven-plugin.md
@@ -1,2 +1,0 @@
-# Enforcing logging rules with ArchUnit Maven plugin
-

--- a/docs/apim/4.13/SUMMARY.md
+++ b/docs/apim/4.13/SUMMARY.md
@@ -299,8 +299,6 @@
       * [XML Validation](create-and-configure-apis/apply-policies/policy-reference/xml-validation.md)
       * [XSLT](create-and-configure-apis/apply-policies/policy-reference/xslt.md)
       * [Webhook Signature Generator](create-and-configure-apis/apply-policies/policy-reference/webhook-signature-generator.md)
-  * [Development Tools](create-and-configure-apis/development-tools/README.md)
-    * [Enforcing logging rules with ArchUnit Maven plugin](create-and-configure-apis/development-tools/enforcing-logging-rules-with-archunit-maven-plugin.md)
 * [Secure & Expose APIs](secure-and-expose-apis/README.md)
   * [Plans](secure-and-expose-apis/plans/README.md)
     * [Conditional Updates for Plans](secure-and-expose-apis/plans/conditional-updates-for-plans.md)

--- a/docs/apim/4.13/create-and-configure-apis/development-tools/README.md
+++ b/docs/apim/4.13/create-and-configure-apis/development-tools/README.md
@@ -1,2 +1,0 @@
-# Development Tools
-

--- a/docs/apim/4.13/create-and-configure-apis/development-tools/enforcing-logging-rules-with-archunit-maven-plugin.md
+++ b/docs/apim/4.13/create-and-configure-apis/development-tools/enforcing-logging-rules-with-archunit-maven-plugin.md
@@ -1,2 +1,0 @@
-# Enforcing logging rules with ArchUnit Maven plugin
-


### PR DESCRIPTION
## Summary
- Removes the "Development Tools" section (README + "Enforcing logging rules with ArchUnit Maven plugin") from APIM 4.11, 4.12, and 4.13 — these pages contained only a title with no body content
- Updates SUMMARY.md in each affected version to drop the corresponding nav entries

## Test plan
- [ ] Confirm the pages no longer appear in the nav for 4.11/4.12/4.13 after GitBook Git Sync