### PR TITLE
docs: redirect removed Development Tools pages

### DIFF
--- a/.gitbook.yaml
+++ b/.gitbook.yaml
@@ -84,3 +84,10 @@ redirects:
   api-designer/overview/readme: gravitee-cloud/api-designer/guides/api-designer-workspace/README.md
   # deprecated telepresence page — send traffic home
   telepresence/canary-deployments: README.md
+  # blank Development Tools pages removed in PR #1996 (4.11-4.13)
+  apim/4.11/create-and-configure-apis/development-tools: https://documentation.gravitee.io/apim/create-and-configure-apis
+  apim/4.11/create-and-configure-apis/development-tools/enforcing-logging-rules-with-archunit-maven-plugin: https://documentation.gravitee.io/apim/create-and-configure-apis
+  apim/4.12/create-and-configure-apis/development-tools: https://documentation.gravitee.io/apim/create-and-configure-apis
+  apim/4.12/create-and-configure-apis/development-tools/enforcing-logging-rules-with-archunit-maven-plugin: https://documentation.gravitee.io/apim/create-and-configure-apis
+  apim/4.13/create-and-configure-apis/development-tools: https://documentation.gravitee.io/apim/create-and-configure-apis
+  apim/4.13/create-and-configure-apis/development-tools/enforcing-logging-rules-with-archunit-maven-plugin: https://documentation.gravitee.io/apim/create-and-configure-apis


### PR DESCRIPTION
## Summary
- Adds redirects in `.gitbook.yaml` for the blank "Development Tools" pages removed in #1996 (APIM 4.11, 4.12, 4.13)
- Both the section page and the "Enforcing logging rules with ArchUnit Maven plugin" child page now redirect to https://documentation.gravitee.io/apim/create-and-configure-apis instead of 404ing

## Test plan
- [ ] Confirm the six old URLs redirect correctly after Git Sync