### PR TITLE
docs: fix redirects for removed Development Tools pages

### DIFF
--- a/.gitbook.yaml
+++ b/.gitbook.yaml
@@ -84,10 +84,3 @@ redirects:
   api-designer/overview/readme: gravitee-cloud/api-designer/guides/api-designer-workspace/README.md
   # deprecated telepresence page — send traffic home
   telepresence/canary-deployments: README.md
-  # blank Development Tools pages removed in PR #1996 (4.11-4.13)
-  apim/4.11/create-and-configure-apis/development-tools: https://documentation.gravitee.io/apim/create-and-configure-apis
-  apim/4.11/create-and-configure-apis/development-tools/enforcing-logging-rules-with-archunit-maven-plugin: https://documentation.gravitee.io/apim/create-and-configure-apis
-  apim/4.12/create-and-configure-apis/development-tools: https://documentation.gravitee.io/apim/create-and-configure-apis
-  apim/4.12/create-and-configure-apis/development-tools/enforcing-logging-rules-with-archunit-maven-plugin: https://documentation.gravitee.io/apim/create-and-configure-apis
-  apim/4.13/create-and-configure-apis/development-tools: https://documentation.gravitee.io/apim/create-and-configure-apis
-  apim/4.13/create-and-configure-apis/development-tools/enforcing-logging-rules-with-archunit-maven-plugin: https://documentation.gravitee.io/apim/create-and-configure-apis

--- a/docs/apim/4.11/.gitbook.yaml
+++ b/docs/apim/4.11/.gitbook.yaml
@@ -1230,3 +1230,5 @@ redirects:
  using-the-product/using-the-gravitee-api-management-components/general-configuration/shared-policy-groups/viewing-version-history-of-the-shared-policy-group: create-and-configure-apis/apply-policies/shared-policy-groups.md
  using-the-product/using-the-gravitee-api-management-components/general-configuration/tenants: configure-and-manage-the-platform/gravitee-gateway/tenants.md
  v2-api-analytics-continuity-after-migration: README.md
+ create-and-configure-apis/development-tools: create-and-configure-apis/README.md
+ create-and-configure-apis/development-tools/enforcing-logging-rules-with-archunit-maven-plugin: create-and-configure-apis/README.md

--- a/docs/apim/4.12/.gitbook.yaml
+++ b/docs/apim/4.12/.gitbook.yaml
@@ -1176,3 +1176,5 @@ redirects:
  using-the-product/using-the-gravitee-api-management-components/general-configuration/shared-policy-groups/shared-policy-groups-overview: create-and-configure-apis/apply-policies/shared-policy-groups.md
  using-the-product/using-the-gravitee-api-management-components/general-configuration/shared-policy-groups/viewing-version-history-of-the-shared-policy-group: create-and-configure-apis/apply-policies/shared-policy-groups.md
  using-the-product/using-the-gravitee-api-management-components/general-configuration/tenants: configure-and-manage-the-platform/gravitee-gateway/tenants.md
+ create-and-configure-apis/development-tools: create-and-configure-apis/README.md
+ create-and-configure-apis/development-tools/enforcing-logging-rules-with-archunit-maven-plugin: create-and-configure-apis/README.md

--- a/docs/apim/4.13/.gitbook.yaml
+++ b/docs/apim/4.13/.gitbook.yaml
@@ -1176,3 +1176,5 @@ redirects:
  using-the-product/using-the-gravitee-api-management-components/general-configuration/shared-policy-groups/shared-policy-groups-overview: create-and-configure-apis/apply-policies/shared-policy-groups.md
  using-the-product/using-the-gravitee-api-management-components/general-configuration/shared-policy-groups/viewing-version-history-of-the-shared-policy-group: create-and-configure-apis/apply-policies/shared-policy-groups.md
  using-the-product/using-the-gravitee-api-management-components/general-configuration/tenants: configure-and-manage-the-platform/gravitee-gateway/tenants.md
+ create-and-configure-apis/development-tools: create-and-configure-apis/README.md
+ create-and-configure-apis/development-tools/enforcing-logging-rules-with-archunit-maven-plugin: create-and-configure-apis/README.md


### PR DESCRIPTION
## Summary
- #1997 added the redirects to the wrong file: the repo-root `.gitbook.yaml` doesn't govern the `apim/4.x` spaces — each version has its own `.gitbook.yaml` (e.g. `docs/apim/4.12/.gitbook.yaml`), and redirect keys there are relative to that version's own space root, not prefixed with `apim/4.x`.
- It also targeted an external URL (`https://documentation.gravitee.io/...`), which `.gitbook.yaml` redirects don't support — only relative paths to files within the same space work. External redirects need to be configured via GitBook's dashboard (Settings → Domain & redirects), not Git Sync.
- This PR removes the ineffective entries from the root `.gitbook.yaml` and adds correct redirects to `docs/apim/4.11/.gitbook.yaml`, `4.12/.gitbook.yaml`, and `4.13/.gitbook.yaml`, pointing the old Development Tools URLs at `create-and-configure-apis/README.md` in each respective version.

## Test plan
- [ ] After Git Sync, confirm the old Development Tools URLs (both the section and the ArchUnit child page) redirect to Create and Configure APIs for 4.11, 4.12, and 4.13