### PR TITLE
docs: fix nav path and wizard step order in MCP server quickstart

### DIFF
--- a/docs/gamma/agent-management/get-started/create-your-first-mcp-server.md
+++ b/docs/gamma/agent-management/get-started/create-your-first-mcp-server.md
@@ -1,4 +1,5 @@
 ---
+description: Create your first MCP Proxy to expose and govern an upstream MCP server through the AI Gateway.
 hidden: false
 noIndex: false
 ---
@@ -6,7 +7,7 @@ noIndex: false
 # Create your first MCP server
 <!-- GAP-STRUCTURAL: Missing procedural content source -->
 
-This quickstart walks you through creating an MCP Proxy in front of an upstream MCP server, so that every tool invocation passes through the AI Gateway with authentication, policy enforcement, and observability. You'll use the simplest configuration — Proxy mode with API key security — to get a governed MCP server running in under five minutes.
+This quickstart walks you through creating an MCP Proxy in front of an upstream MCP server. Every tool invocation then passes through the AI Gateway with authentication, policy enforcement, and observability. You'll use the simplest configuration—Proxy mode with API key security—to get a governed MCP server running in under five minutes.
 
 {% hint style="info" %}
 For a complete reference on all MCP Proxy options, including Studio mode, see [Create an MCP proxy](../build/create-an-mcp-proxy.md).
@@ -14,41 +15,58 @@ For a complete reference on all MCP Proxy options, including Studio mode, see [C
 
 ## Prerequisites
 
-* Access to a running Gamma console instance
-* An upstream MCP server accessible via HTTP (e.g., `https://mcp.example.com/mcp`)
+This quickstart requires the following:
 
-## Step 1: Open the MCP Proxy wizard
+* Access to a running Gamma console instance.
+* An upstream MCP server accessible using HTTP, such as `https://mcp.example.com/mcp`.
+
+## Create the MCP Proxy
+
+To create your MCP Proxy, complete the following steps:
+
+1. [Open the MCP Proxy wizard](#open-the-mcp-proxy-wizard)
+2. [Connect to the upstream server](#connect-to-the-upstream-server)
+3. [Configure upstream authentication](#configure-upstream-authentication)
+4. [Configure security](#configure-security)
+5. [Review and create](#review-and-create)
+
+### Open the MCP Proxy wizard
 
 1. From the Gamma console sidebar, select **Agent Management**.
-2. Navigate to **Build**.
-3. Select **Create MCP Proxy**.
+2. Under **Secure**, select **MCP Proxy**.
+3. Select **+ Create MCP proxy**.
 
-The console opens the MCP Proxy creation wizard. Select **Proxy mode**, enter a name like "My First MCP Server" and a context path, then select **Next**.
+The console opens the MCP Proxy creation wizard. Select **Proxy mode**, enter a name like "My First MCP Server" and a context path, and then select **Next**.
 
-## Step 2: Configure security
+### Connect to the upstream server
+
+Under **Server URL**, enter the URL of your MCP endpoint, such as `https://mcp.example.com/mcp`. The Gateway uses Streamable HTTP transport by default.
+
+Select **Next** to proceed.
+
+### Configure upstream authentication
+
+The next step defines how the Gateway authenticates when calling the upstream MCP server.
+
+For this quickstart, select **No upstream auth** to call the upstream server without injecting credentials, or enter your static credentials if your server requires them.
+
+Select **Next** to proceed.
+
+### Configure security
 
 The next step defines how consumers authenticate when calling tools through this MCP Proxy.
 
-For this quickstart, select **API Key**. API key security lets you track and control which consumers invoke tools through your MCP Proxy without setting up an external identity provider.
+For this quickstart, select **API Key**. API key security lets you track and control which consumers invoke tools through your MCP Proxy without configuring an external identity provider.
 
 Select **Next** to proceed.
 
-## Step 3: Connect to the upstream server
+### Review and create
 
-Provide the connection details for the upstream MCP server:
+Review the MCP Proxy configuration and select **Create MCP Proxy**.
 
-1. Under **Upstream server**, enter the URL of your MCP endpoint (e.g., `https://mcp.example.com/mcp`). The Gateway uses Streamable HTTP transport by default.
-2. Under **Upstream Authentication**, select **No upstream auth** (passthrough) for this quickstart, or enter your static credentials if your server requires them.
+The console creates the MCP Proxy and registers it in the AI Gateway. The MCP Proxy now sits in front of your upstream MCP server, and every tool invocation flows through the AI Gateway, where authentication, policies, and observability are applied.
 
-Select **Next** to proceed.
-
-## Step 4: Review and create
-
-Review the MCP Proxy configuration and select **Create**.
-
-The console creates the MCP Proxy and registers it in the AI Gateway. The MCP Proxy now sits in front of your upstream MCP server — every tool invocation flows through the AI Gateway, where authentication, policies, and observability are applied.
-
-## Step 5: Verify tool invocations
+## Verify tool invocations
 
 Once the MCP Proxy is created, verify that it can receive connections.
 
@@ -66,6 +84,8 @@ curl -X POST https://api.your-gateway.com/mcp/my-first-server \
 
 ## Next steps
 
-* **Add policies** — Apply fine-grained authorization to control which consumers can invoke specific tools. See [Add policies to your MCP server](../build/configure-your-mcp/add-policies-to-mcp-server.md).
-* **Configure mediation** — Set up token exchange and credential mediation for upstream MCP servers that require their own OAuth. See [Configure your MCP proxy](../build/configure-your-mcp/README.md).
-* **Create a Composite MCP Server** — Compose tools from multiple upstream servers, APIs, and events into a single governed MCP server. See [Create an MCP Studio](../build/create-an-mcp-studio.md).
+To extend this MCP Proxy, explore the following options:
+
+* **Add policies.** Apply fine-grained authorization to control which consumers can invoke specific tools. See [Add policies to your MCP server](../build/configure-your-mcp/add-policies-to-mcp-server.md).
+* **Configure mediation.** Configure token exchange and credential mediation for upstream MCP servers that require their own OAuth. See [Configure your MCP proxy](../build/configure-your-mcp/README.md).
+* **Create a Composite MCP Server.** Compose tools from multiple upstream servers, APIs, and events into a single governed MCP server. See [Create an MCP Studio](../build/create-an-mcp-studio.md).


### PR DESCRIPTION
## Summary

Ran the Doc Verification Pipeline on `docs/gamma/agent-management/get-started/create-your-first-mcp-server.md` against the live Gamma console at `http://localhost:8086`, cross-checked against `gravitee-gamma-module-aim`.

## Verdict table

| Claim | Code | Live | Verdict |
|---|---|---|---|
| Sidebar: Agent Management → **Build** → Create MCP Proxy | `navigation.ts`/`routes.ts` have no "Build" group; MCP Proxy is under **Secure** | Confirmed: sidebar groups are Import, Secure, Observability, Edge Management — no Build section exists | **Contradicted** — fixed to Agent Management → Secure → MCP Proxy → **+ Create MCP proxy** |
| 4-step wizard: Define → Security → Connect (URL + upstream auth combined) → Review | RAG-indexed snapshot showed Define → Security → Connect → Review (4 steps) | Live wizard is 5 steps: **Define → Connect → Upstream auth → Security → Review** | **Contradicted** — fixed step count/order; split Connect and Upstream auth into separate steps, moved Security after them |
| Select **Proxy mode**, enter name + context path, select Next | `McpProxyMode = 'PROXY' \| 'STUDIO'` | Confirmed — exact labels match | Confirmed |
| Select **API Key** for consumer security | `AuthMethod` includes `'api-key'` | Confirmed — option exists and works as described (now labeled "Not recommended" in the live UI in favor of "Gravitee as Authorization Server", but doc's own claim isn't contradicted) | Confirmed |
| Server URL field, Gateway uses Streamable HTTP by default | CHANGELOG: "fallback to streamable-http transport" | Confirmed — placeholder `https://mcp.example.com/mcp` matches doc's example exactly | Confirmed |
| **No upstream auth** (passthrough) or static credentials | `upstreamAuthType: 'passthrough' \| 'static'` | Confirmed — exact label match ("No upstream auth") | Confirmed |
| Review and select Create; proxy registered in AI Gateway | `createMcpProxy` service call | Confirmed — created proxy showed status "Running" with an entrypoint URL | Confirmed |
| MCP Proxy URL shown after creation; curl with `X-Gravitee-Api-Key` | — | Confirmed — detail page shows "Entrypoint URL" with copy button; header is Gravitee's standard default (platform docs) | Confirmed |

## What changed

- Fixed the navigation path (no "Build" section exists; MCP Proxy is under **Secure**).
- Fixed wizard step count and order (5 steps, not 4; Connect and Upstream auth are separate steps that come before Security, not after).
- Ran the Docs Editor Pipeline (structure/grammar/terminology) on the file.

## Test plan

- [x] Verified sidebar navigation and wizard step order live against `http://localhost:8086` using `gravitee-browser-agent`
- [x] Created and deleted a test MCP Proxy to confirm the full flow end to end
- [x] Cross-checked against `gravitee-gamma-module-aim` source (navigation.ts, routes.ts, useMcpProxyWizardState.ts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)