### PR TITLE
docs: link, rename, and correct New Developer Portal API docs (DOC-1665)

### DIFF
--- a/docs/apim/4.11/SUMMARY.md
+++ b/docs/apim/4.11/SUMMARY.md
@@ -311,7 +311,7 @@
     * [Enable the New Developer Portal](developer-portal/new-developer-portal/configure-the-new-portal.md)
     * [Layout and Theme](developer-portal/new-developer-portal/layout-and-theme.md)
     * [Customize the Homepage](developer-portal/new-developer-portal/customize-the-homepage.md)
-    * [Customize the Navigation](developer-portal/new-developer-portal/customize-the-navigation/README.md)
+    * [Manage Portal Navigation and APIs](developer-portal/new-developer-portal/customize-the-navigation/README.md)
       * [Structure the navigation with the Management API](developer-portal/new-developer-portal/customize-the-navigation/structure-the-navigation-with-the-management-api.md)
     * [Gravitee Markdown Components](developer-portal/new-developer-portal/gravitee-markdown-components.md)
     * [Application Logs](developer-portal/new-developer-portal/application-logs.md)

--- a/docs/apim/4.11/developer-portal/new-developer-portal/customize-the-navigation/README.md
+++ b/docs/apim/4.11/developer-portal/new-developer-portal/customize-the-navigation/README.md
@@ -1,4 +1,4 @@
-# Customize the Navigation
+# Manage Portal Navigation and APIs
 
 ## Overview
 
@@ -89,7 +89,7 @@ When you add a page that is not in a folder, the page appears as a root level me
 
     <figure><img src="../../../.gitbook/assets/1A5E08E1-648C-4437-81C6-F4C480F04193_1_201_a.jpeg" alt=""><figcaption></figcaption></figure>
 
-8.  In the **Publish page** pop-up window, click **Publish**.<br>
+8.  In the confirmation dialog, click **Publish**.<br>
 
     <figure><img src="../../../.gitbook/assets/C52E694A-6761-45A5-B46B-998AE39FF5E1_1_201_a.jpeg" alt=""><figcaption></figcaption></figure>
 {% endtab %}
@@ -117,7 +117,7 @@ Folders group related pages together. A folder is a section on your New Develope
     *   Navigate to the folder in the navigation bar, click the **ellipses**, and then click **Publish**.<br>
 
         <figure><img src="../../../.gitbook/assets/FAD5D2FB-4EEE-49B7-8081-F790D1AE0EC4_1_201_a.jpeg" alt=""><figcaption></figcaption></figure>
-6.  In the **Publish folder**, pop-up box, click **Publish**.<br>
+6.  In the confirmation dialog, click **Publish**.<br>
 
     <figure><img src="../../../.gitbook/assets/0C92FAF4-F289-4D79-89D2-62448A9E8FE8_1_201_a.jpeg" alt=""><figcaption></figcaption></figure>
 
@@ -129,7 +129,7 @@ Unpublishing now works by cascade: all navigation items within a folder are unpu
 
 When you add a page to a folder, that page becomes a menu item within that section of the New Developer Portal.
 
-1. Navigate to the the folder in the **Navigation items** menu.
+1. Navigate to the folder in the **Navigation items** menu.
 2. Click **the ellipsis**.
 3.  Click **Add page**.<br>
 
@@ -161,7 +161,7 @@ When you add a link, the link appears as a root level menu item. When you publis
     *   Navigate to link in the navigation bar, click the **ellipses**, and then click **Publish**.<br>
 
         <figure><img src="../../../.gitbook/assets/D897DBD4-B160-4F29-ACD8-14E5D0959CF5_1_201_a.jpeg" alt=""><figcaption></figcaption></figure>
-5.  In the **Publish link** pop-up menu, click **Publish**.<br>
+5.  In the confirmation dialog, click **Publish**.<br>
 
     <figure><img src="../../../.gitbook/assets/B33EB73A-836D-4E7F-A297-53C23A7AB324_1_201_a.jpeg" alt=""><figcaption></figcaption></figure>
 {% endtab %}
@@ -175,7 +175,7 @@ Adding APIs to the documentation is **the only way** to make them visible in the
 Unlike in the Classic Portal, the property `published` of an API is not taken into account in the New Developer Portal.
 {% endhint %}
 
-API navigation items act similarly to folders meaning that they can contain other navigation items like Pages, Folders and Links.
+API navigation items act similarly to folders meaning that they can contain other navigation items like Pages, Folders, and Links.
 
 However, there are some limitations of APIs compared to folders:
 
@@ -184,9 +184,15 @@ However, there are some limitations of APIs compared to folders:
 
 **Add an API**
 
-1. Open the context menu of a folder in which you want to add your API by clicking the **ellipses**, and then click **Add API**.
-2. An **API selection dialog** opens up where you can select APIs to be added.
-3. (Optional) Turn on the **Authentication is required to view selected APIs** toggle. This ensures that the user has to sign in to the New Developer Portal to view the APIs.
+1.  Open the context menu of a folder in which you want to add your API by clicking the **ellipses**, and then click **Add API**.<br>
+
+    <!-- TODO: Screenshot of the folder context menu with the Add API option highlighted -->
+    <figure><img src="../../../.gitbook/assets/PLACEHOLDER-devportal-add-api-context-menu.png" alt=""><figcaption><p>Add API in the folder context menu</p></figcaption></figure>
+2.  In the **Add APIs** dialog, select the APIs that you want to add. To find an API by name, use the **Search** field.<br>
+
+    <!-- TODO: Screenshot of the Add APIs dialog with an API selected -->
+    <figure><img src="../../../.gitbook/assets/PLACEHOLDER-devportal-add-apis-dialog.png" alt=""><figcaption><p>Add APIs dialog</p></figcaption></figure>
+3. (Optional) Turn on the **Authentication is required to view selected APIs.** toggle. This ensures that the user has to sign in to the New Developer Portal to view the APIs.
 4. Click **Add**.
 5. Publish the API. To publish the API, complete either of the following steps:
 
@@ -195,13 +201,16 @@ However, there are some limitations of APIs compared to folders:
 * Click **Publish**.
 * Navigate to the folder in the navigation bar, click the **ellipses**, and then click **Publish**.
 
-6. In the **Publish API** pop-up box, click **Publish**.
+6.  In the confirmation dialog, click **Publish**. The dialog title shows the name of your API. For example, **Publish "Payments" API?**<br>
+
+    <!-- TODO: Screenshot of the publish confirmation dialog for an API -->
+    <figure><img src="../../../.gitbook/assets/PLACEHOLDER-devportal-publish-api-dialog.png" alt=""><figcaption><p>Publish confirmation dialog for an API</p></figcaption></figure>
 
 **Add a page to an API**
 
 When you add a page to an API, that page becomes a menu item within that API in the New Developer Portal.
 
-1. Navigate to the the folder in the **Navigation items** menu.
+1. Navigate to the folder in the **Navigation items** menu.
 2. Click **the ellipsis**.
 3. Click **Add page**.
 
@@ -209,7 +218,7 @@ When you add a page to an API, that page becomes a menu item within that API in 
 
 When you add a folder to an API, that folder becomes nested within that API in the New Developer Portal.
 
-1. Navigate to the the folder in the **Navigation items** menu.
+1. Navigate to the folder in the **Navigation items** menu.
 2. Click **the ellipsis**.
 3. Click **Add folder**.
 {% endtab %}

--- a/docs/apim/4.11/getting-started/create-and-publish-your-first-api/publish-your-api.md
+++ b/docs/apim/4.11/getting-started/create-and-publish-your-first-api/publish-your-api.md
@@ -19,6 +19,10 @@ This guide explains how to Publish your API.
 
 ## Publish your API
 
+{% hint style="info" %}
+This page applies to the Classic Portal. The New Developer Portal doesn't use the API's published state. To make an API visible in the New Developer Portal, add the API to the portal navigation and publish it there. For more information, see [Manage Portal Navigation and APIs](../../developer-portal/new-developer-portal/customize-the-navigation/README.md).
+{% endhint %}
+
 1.  From the dashboard, click **APIs**.
 
     <figure><img src="../../.gitbook/assets/A55EF9D7-6D61-4D8F-8BA1-F71122515FAA.jpeg" alt=""><figcaption></figcaption></figure>
@@ -39,7 +43,7 @@ Your API appears on the Developer Portal. To view your API in the Developer Port
 1.  In the console header navigation, click **Developer Portal**.
 
     <figure><img src="../../.gitbook/assets/6B137E7B-B69B-4EFA-9099-B5FA1496B0D7.jpeg" alt=""><figcaption></figcaption></figure>
-2.  In the Developer Portal, click **Explore APIS.**
+2.  In the Developer Portal, click **Explore APIs**.
 
     <figure><img src="../../.gitbook/assets/gs-first-api-publish-your-api-66.png" alt=""><figcaption></figcaption></figure>
 3.  In the **Catalog** page, click **All APIs.**

--- a/docs/apim/4.11/release-information/release-notes/apim-4.11.md
+++ b/docs/apim/4.11/release-information/release-notes/apim-4.11.md
@@ -34,11 +34,11 @@ Existing A2A proxy APIs continue to work but they are no longer supported.
 
 #### **New Developer Portal APIs and documentation pages must be republished**
 
-When you upgrade to APIM 4.11, any APIs and documentation pages previously published to the New Developer Portal are no longer published. After the upgrade, add and publish your APIs and documentation pages again through the **Navigation items** section of the New Developer Portal settings.
+When you upgrade to APIM 4.11, any APIs and documentation pages previously published to the New Developer Portal are no longer published. After the upgrade, add and publish your APIs and documentation pages again through the **Navigation items** section of the New Developer Portal settings. For more information, see [Manage Portal Navigation and APIs](../../developer-portal/new-developer-portal/customize-the-navigation/README.md).
 
 #### **New Developer Portal subscriptions require published API pages**
 
-After upgrading to APIM 4.11, an API accepts subscriptions through the New Developer Portal only after you publish the API's pages. To enable subscriptions to an API, publish the API's pages through the **Navigation items** section of the New Developer Portal settings.
+After upgrading to APIM 4.11, an API accepts subscriptions through the New Developer Portal only after you publish the API's pages. To enable subscriptions to an API, publish the API's pages through the **Navigation items** section of the New Developer Portal settings. For more information, see [Manage Portal Navigation and APIs](../../developer-portal/new-developer-portal/customize-the-navigation/README.md).
 
 ## New Features
 
@@ -110,9 +110,9 @@ After upgrading to APIM 4.11, an API accepts subscriptions through the New Devel
 
 * Bundle multiple V4 HTTP Proxy APIs into a single subscribable package with unified access control and API Product-level plans (API Key, JWT, or mTLS).
 * Manage subscriptions at the API Product level instead of individual APIs, enabling API Product managers to package and monetize APIs at scale.
-* APIs must have the `allowedInApiProducts` flag enabled to be included in API Products; APIs can belong to multiple API Products while maintaining their own direct subscription plans.
+* APIs must have the `allowedInApiProducts` flag enabled to be included in API Products. APIs can belong to multiple API Products while maintaining their own direct subscription plans.
 * Requires Enterprise Universe tier license and environment-level permissions for API Product management.
-* Plans and subscriptions now support a reference model with `referenceType` (API or API\_PRODUCT) and `referenceId` fields; the legacy `api` field is deprecated as of 4.11.0.
+* Plans and subscriptions now support a reference model with `referenceType` (API or API\_PRODUCT) and `referenceId` fields. The legacy `api` field is deprecated as of 4.11.0.
 
 #### **JMS Endpoint Connector for Message Broker Integration**
 
@@ -120,7 +120,7 @@ After upgrading to APIM 4.11, an API accepts subscriptions through the New Devel
 * Supports multiple connection factory configuration methods: direct broker URL, provider-specific properties (hostname/port/channel), or JNDI lookup with custom properties.
 * Configurable for producer mode (send messages with TEXT or BYTES format), consumer mode (receive messages with durable subscription support), or both capabilities simultaneously on the same endpoint.
 * Requires `event-native` license pack and JMS provider client library placed in `./plugins/jms/ext/` directory.
-* Topic consumers use shared or exclusive connections based on client ID and durability settings; queue consumers always use shared connections.
+* Topic consumers use shared or exclusive connections based on client ID and durability settings. Queue consumers always use shared connections.
 
 #### **Native IP filtering policy for Kafka APIs**
 
@@ -133,7 +133,7 @@ After upgrading to APIM 4.11, an API accepts subscriptions through the New Devel
 #### **Multi-Tenant Endpoint Support for Kafka APIs**
 
 * Enables a single Kafka API definition to route traffic to different backend clusters based on the gateway's configured tenant identifier, eliminating the need to duplicate API definitions across deployment zones.
-* Each endpoint in the first endpoint group can be tagged with one or more tenant identifiers; gateways automatically filter and activate only endpoints matching their configured tenant at startup and during hot-reload.
+* Each endpoint in the first endpoint group can be tagged with one or more tenant identifiers. Gateways automatically filter and activate only endpoints matching their configured tenant at startup and during hot-reload.
 * Endpoints with no tenant tags are treated as shared and always match any gateway, making them useful during gradual rollout or for legacy gateways without tenant configuration.
 * Configure the gateway tenant identifier using the `tenant` property in `gravitee.yml`, environment variable, or system property.
 * If all endpoints in the group are tenant-specific and none match the gateway's tenant, the gateway can't route to the API and connections fail. Include at least one shared (untagged) endpoint to ensure the API remains accessible.
@@ -141,17 +141,17 @@ After upgrading to APIM 4.11, an API accepts subscriptions through the New Devel
 #### **Multiple Endpoints for Native Kafka APIs**
 
 * Native Kafka APIs can now define multiple endpoints within an endpoint group, enabling pre-configured cluster alternatives for disaster recovery, migration, and regional routing scenarios.
-* The gateway routes new connections to the active endpoint based on tenant configuration or list order—publishers control which endpoint is active by reordering endpoints in the group.
-* Endpoint switching is manual and publisher-initiated; the gateway doesn't perform automatic failover or health checks, and Kafka clients must handle reconnection when endpoints change.
-* Tenant-aware routing is supported: if the gateway tenant matches an endpoint's tenant tag, that endpoint is selected; otherwise, the first endpoint in the group is used.
+* The gateway routes new connections to the active endpoint based on tenant configuration or list order. Publishers control which endpoint is active by reordering endpoints in the group.
+* Endpoint switching is manual and publisher-initiated. The gateway doesn't perform automatic failover or health checks, and Kafka clients must handle reconnection when endpoints change.
+* Tenant-aware routing is supported: if the gateway tenant matches an endpoint's tenant tag, that endpoint is selected. Otherwise, the first endpoint in the group is used.
 
 #### **mTLS Plan Support for Kafka Native APIs**
 
 * Kafka native APIs now support mTLS plans for client authentication using X.509 certificates, enabling accurate subscription resolution and metrics attribution.
 * The gateway extracts the client certificate from the TLS session, computes its MD5 hash, and uses it as a security token to look up the subscription and populate connection context with `planId`, `applicationId`, and `subscriptionId`.
-* Kafka native APIs enforce strict plan security mutual exclusion—you can't mix Keyless, mTLS, and authentication plans (OAuth2, JWT, API Key) in published state. Publishing a plan of one type automatically closes all published plans of conflicting types.
+* Kafka native APIs enforce strict plan security mutual exclusion: you can't mix Keyless, mTLS, and authentication plans (OAuth2, JWT, API Key) in published state. Publishing a plan of one type automatically closes all published plans of conflicting types.
 * Requires Gravitee APIM 4.11 or later, `gravitee-policy-mtls` version 2.0.0-alpha.2 or later, and gateway configuration with `kafka.ssl.clientAuth=required` and appropriate truststore/keystore settings.
-* Subscription certificates are loaded dynamically without requiring gateway restarts—when a subscription is created or updated with a new certificate, the gateway's trust store manager refreshes automatically.
+* Subscription certificates are loaded dynamically without requiring gateway restarts. When a subscription is created or updated with a new certificate, the gateway's trust store manager refreshes automatically.
 
 #### **Kafka Governance Rules Policies**
 
@@ -171,7 +171,7 @@ After upgrading to APIM 4.11, an API accepts subscriptions through the New Devel
 
 * Encrypts and decrypts Kafka message payloads at the gateway level using AES-GCM (128, 192, or 256-bit), ensuring data is protected while stored in Kafka topics without requiring changes to producer or consumer applications.
 * Supports three encryption modes: direct encryption with base64 output, direct encryption with JWE format, and DEK-based encryption that generates a unique data encryption key per message.
-* Processes entire message payloads or individual JSON fields identified by JSONPath expressions. Optional compression (GZIP, LZ4, BZIP2, Snappy) mitigates the storage overhead of encrypted data.
+* Processes entire message payloads or individual JSON fields identified by JSONPath expressions. Optional compression (Gzip, LZ4, BZIP2, Snappy) mitigates the storage overhead of encrypted data.
 * Keys are provisioned as base64-encoded values or stored in PKCS12 keystores, with support for Expression Language and the Gravitee secrets mechanism.
 
 #### **Groovy policy support for Native Kafka APIs**
@@ -195,7 +195,7 @@ After upgrading to APIM 4.11, an API accepts subscriptions through the New Devel
 * Subscription forms now support checkbox group fields that allow subscribers to select multiple options from a predefined or dynamically resolved list.
 * Options can be populated at runtime using Expression Language (EL) to reference API or environment metadata, with required fallback values for contexts where metadata is unavailable.
 * Checkbox groups enforce validation constraints including required selection (at least one option) and option list validation (all selected values must exist in allowed options).
-* Subscription forms support up to 25 fields total, with input fields limited to 256 characters and textarea fields limited to 1024 characters.
+* Subscription forms support up to 25 fields total, with input fields limited to 256 characters and text area fields limited to 1024 characters.
 * Form submissions are validated against all constraints before subscription creation, returning field-level error messages when validation fails.
 <!-- /PIPELINE:APIM-13343 -->
 

--- a/docs/apim/4.12/SUMMARY.md
+++ b/docs/apim/4.12/SUMMARY.md
@@ -343,7 +343,7 @@
     * [Enable the New Developer Portal](developer-portal/new-developer-portal/configure-the-new-portal.md)
     * [Layout and Theme](developer-portal/new-developer-portal/layout-and-theme.md)
     * [Customize the Homepage](developer-portal/new-developer-portal/customize-the-homepage.md)
-    * [Customize the Navigation](developer-portal/new-developer-portal/customize-the-navigation.md)
+    * [Manage Portal Navigation and APIs](developer-portal/new-developer-portal/customize-the-navigation.md)
       * [Structure the navigation with the Management API](developer-portal/new-developer-portal/customize-the-navigation/structure-the-navigation-with-the-management-api.md)
       * [Creating OpenAPI Documentation Pages](developer-portal/new-developer-portal/customize-the-navigation/creating-openapi-documentation-pages.md)
       * [Creating AsyncAPI Documentation Pages](developer-portal/new-developer-portal/customize-the-navigation/creating-asyncapi-documentation-pages.md)

--- a/docs/apim/4.12/developer-portal/new-developer-portal/customize-the-navigation.md
+++ b/docs/apim/4.12/developer-portal/new-developer-portal/customize-the-navigation.md
@@ -1,4 +1,4 @@
-# Customize the Navigation
+# Manage Portal Navigation and APIs
 
 ## Overview
 
@@ -100,7 +100,7 @@ When you add a page that is not in a folder, the page appears as a root level me
 *   Navigate to the page in the navigation bar, click the **ellipses** (<i class="fa-ellipsis-vertical">:ellipsis-vertical:</i>), and then click **Publish**.<br>
 
     <figure><img src="../../.gitbook/assets/1A5E08E1-648C-4437-81C6-F4C480F04193_1_201_a.jpeg" alt=""><figcaption></figcaption></figure>
-8.  In the **Publish page** pop-up window, click **Publish**.<br>
+8.  In the confirmation dialog, click **Publish**.<br>
 
     <figure><img src="../../.gitbook/assets/C52E694A-6761-45A5-B46B-998AE39FF5E1_1_201_a.jpeg" alt=""><figcaption></figcaption></figure>
 {% endtab %}
@@ -128,7 +128,7 @@ Folders group related pages together. A folder is a section on your New Develope
     *   Navigate to the folder in the navigation bar, click the **ellipses**, and then click **Publish**.<br>
 
         <figure><img src="../../.gitbook/assets/FAD5D2FB-4EEE-49B7-8081-F790D1AE0EC4_1_201_a.jpeg" alt=""><figcaption></figcaption></figure>
-6.  In the **Publish folder**, pop-up box, click **Publish**.<br>
+6.  In the confirmation dialog, click **Publish**.<br>
 
     <figure><img src="../../.gitbook/assets/0C92FAF4-F289-4D79-89D2-62448A9E8FE8_1_201_a.jpeg" alt=""><figcaption></figcaption></figure>
 
@@ -140,7 +140,7 @@ Unpublishing now works by cascade: all navigation items within a folder are unpu
 
 When you add a page to a folder, that page becomes a menu item within that section of the New Developer Portal.
 
-1. Navigate to the the folder in the **Navigation items** menu.
+1. Navigate to the folder in the **Navigation items** menu.
 2. Click **the ellipsis**.
 3.  Click **Add page**.<br>
 
@@ -172,7 +172,7 @@ When you add a link, the link appears as a root level menu item. When you publis
     *   Navigate to link in the navigation bar, click the **ellipses**, and then click **Publish**.<br>
 
         <figure><img src="../../.gitbook/assets/D897DBD4-B160-4F29-ACD8-14E5D0959CF5_1_201_a.jpeg" alt=""><figcaption></figcaption></figure>
-5.  In the **Publish link** pop-up menu, click **Publish**.<br>
+5.  In the confirmation dialog, click **Publish**.<br>
 
     <figure><img src="../../.gitbook/assets/B33EB73A-836D-4E7F-A297-53C23A7AB324_1_201_a.jpeg" alt=""><figcaption></figcaption></figure>
 {% endtab %}
@@ -186,7 +186,7 @@ Adding APIs to the documentation is **the only way** to make them visible in the
 Unlike in the Classic Portal, the property `published` of an API is not taken into account in the New Developer Portal.
 {% endhint %}
 
-API navigation items act similarly to folders meaning that they can contain other navigation items like Pages, Folders and Links.
+API navigation items act similarly to folders meaning that they can contain other navigation items like Pages, Folders, and Links.
 
 However, there are some limitations of APIs compared to folders:
 
@@ -195,9 +195,15 @@ However, there are some limitations of APIs compared to folders:
 
 **Add an API**
 
-1. Open the context menu of a folder in which you want to add your API by clicking the **ellipses**, and then click **Add API**.
-2. An **API selection dialog** opens up where you can select APIs to be added.
-3. (Optional) Turn on the **Authentication is required to view selected APIs** toggle. This ensures that the user has to sign in to the New Developer Portal to view the APIs.
+1.  Open the context menu of a folder in which you want to add your API by clicking the **ellipses**, and then click **Add API**.<br>
+
+    <!-- TODO: Screenshot of the folder context menu with the Add API option highlighted -->
+    <figure><img src="../../.gitbook/assets/PLACEHOLDER-devportal-add-api-context-menu.png" alt=""><figcaption><p>Add API in the folder context menu</p></figcaption></figure>
+2.  In the **Add APIs** dialog, select the APIs that you want to add. To find an API by name, use the **Search** field.<br>
+
+    <!-- TODO: Screenshot of the Add APIs dialog with an API selected -->
+    <figure><img src="../../.gitbook/assets/PLACEHOLDER-devportal-add-apis-dialog.png" alt=""><figcaption><p>Add APIs dialog</p></figcaption></figure>
+3. (Optional) Turn on the **Authentication is required to view selected APIs.** toggle. This ensures that the user has to sign in to the New Developer Portal to view the APIs.
 4. Click **Add**.
 5. Publish the API. To publish the API, complete either of the following steps:
 
@@ -206,7 +212,10 @@ However, there are some limitations of APIs compared to folders:
 * Click **Publish**.
 * Navigate to the folder in the navigation bar, click the **ellipses**, and then click **Publish**.
 
-6. In the **Publish API** pop-up box, click **Publish**.
+6.  In the confirmation dialog, click **Publish**. The dialog title shows the name of your API. For example, **Publish "Payments" API?**<br>
+
+    <!-- TODO: Screenshot of the publish confirmation dialog for an API -->
+    <figure><img src="../../.gitbook/assets/PLACEHOLDER-devportal-publish-api-dialog.png" alt=""><figcaption><p>Publish confirmation dialog for an API</p></figcaption></figure>
 
 **Default Overview page**
 
@@ -223,7 +232,7 @@ Gravitee creates the Overview page only when the API doesn't already have a page
 
 When you add a page to an API, that page becomes a menu item within that API in the New Developer Portal.
 
-1. Navigate to the the folder in the **Navigation items** menu.
+1. Navigate to the folder in the **Navigation items** menu.
 2. Click **the ellipsis**.
 3. Click **Add page**.
 
@@ -231,7 +240,7 @@ When you add a page to an API, that page becomes a menu item within that API in 
 
 When you add a folder to an API, that folder becomes nested within that API in the New Developer Portal.
 
-1. Navigate to the the folder in the **Navigation items** menu.
+1. Navigate to the folder in the **Navigation items** menu.
 2. Click **the ellipsis**.
 3. Click **Add folder**.
 {% endtab %}

--- a/docs/apim/4.12/getting-started/create-and-publish-your-first-api/publish-your-api.md
+++ b/docs/apim/4.12/getting-started/create-and-publish-your-first-api/publish-your-api.md
@@ -19,6 +19,10 @@ This guide explains how to Publish your API.
 
 ## Publish your API
 
+{% hint style="info" %}
+This page applies to the Classic Portal. The New Developer Portal doesn't use the API's published state. To make an API visible in the New Developer Portal, add the API to the portal navigation and publish it there. For more information, see [Manage Portal Navigation and APIs](../../developer-portal/new-developer-portal/customize-the-navigation.md).
+{% endhint %}
+
 1.  From the dashboard, click **APIs**.
 
     <figure><img src="../../.gitbook/assets/A55EF9D7-6D61-4D8F-8BA1-F71122515FAA.jpeg" alt=""><figcaption></figcaption></figure>
@@ -39,7 +43,7 @@ Your API appears on the Developer Portal. To view your API in the Developer Port
 1.  In the console header navigation, click **Developer Portal**.
 
     <figure><img src="../../.gitbook/assets/6B137E7B-B69B-4EFA-9099-B5FA1496B0D7.jpeg" alt=""><figcaption></figcaption></figure>
-2.  In the Developer Portal, click **Explore APIS.**
+2.  In the Developer Portal, click **Explore APIs**.
 
     <figure><img src="../../.gitbook/assets/gs-first-api-publish-your-api-66.png" alt=""><figcaption></figcaption></figure>
 3.  In the **Catalog** page, click **All APIs.**

--- a/docs/apim/4.13/SUMMARY.md
+++ b/docs/apim/4.13/SUMMARY.md
@@ -343,7 +343,7 @@
     * [Enable the New Developer Portal](developer-portal/new-developer-portal/configure-the-new-portal.md)
     * [Layout and Theme](developer-portal/new-developer-portal/layout-and-theme.md)
     * [Customize the Homepage](developer-portal/new-developer-portal/customize-the-homepage.md)
-    * [Customize the Navigation](developer-portal/new-developer-portal/customize-the-navigation.md)
+    * [Manage Portal Navigation and APIs](developer-portal/new-developer-portal/customize-the-navigation.md)
       * [Structure the navigation with the Management API](developer-portal/new-developer-portal/customize-the-navigation/structure-the-navigation-with-the-management-api.md)
       * [Creating OpenAPI Documentation Pages](developer-portal/new-developer-portal/customize-the-navigation/creating-openapi-documentation-pages.md)
       * [Creating AsyncAPI Documentation Pages](developer-portal/new-developer-portal/customize-the-navigation/creating-asyncapi-documentation-pages.md)

--- a/docs/apim/4.13/developer-portal/new-developer-portal/customize-the-navigation.md
+++ b/docs/apim/4.13/developer-portal/new-developer-portal/customize-the-navigation.md
@@ -1,4 +1,4 @@
-# Customize the Navigation
+# Manage Portal Navigation and APIs
 
 ## Overview
 
@@ -100,7 +100,7 @@ When you add a page that is not in a folder, the page appears as a root level me
 *   Navigate to the page in the navigation bar, click the **ellipses** (<i class="fa-ellipsis-vertical">:ellipsis-vertical:</i>), and then click **Publish**.<br>
 
     <figure><img src="../../.gitbook/assets/1A5E08E1-648C-4437-81C6-F4C480F04193_1_201_a.jpeg" alt=""><figcaption></figcaption></figure>
-8.  In the **Publish page** pop-up window, click **Publish**.<br>
+8.  In the confirmation dialog, click **Publish**.<br>
 
     <figure><img src="../../.gitbook/assets/C52E694A-6761-45A5-B46B-998AE39FF5E1_1_201_a.jpeg" alt=""><figcaption></figcaption></figure>
 {% endtab %}
@@ -128,7 +128,7 @@ Folders group related pages together. A folder is a section on your New Develope
     *   Navigate to the folder in the navigation bar, click the **ellipses**, and then click **Publish**.<br>
 
         <figure><img src="../../.gitbook/assets/FAD5D2FB-4EEE-49B7-8081-F790D1AE0EC4_1_201_a.jpeg" alt=""><figcaption></figcaption></figure>
-6.  In the **Publish folder**, pop-up box, click **Publish**.<br>
+6.  In the confirmation dialog, click **Publish**.<br>
 
     <figure><img src="../../.gitbook/assets/0C92FAF4-F289-4D79-89D2-62448A9E8FE8_1_201_a.jpeg" alt=""><figcaption></figcaption></figure>
 
@@ -140,7 +140,7 @@ Unpublishing now works by cascade: all navigation items within a folder are unpu
 
 When you add a page to a folder, that page becomes a menu item within that section of the New Developer Portal.
 
-1. Navigate to the the folder in the **Navigation items** menu.
+1. Navigate to the folder in the **Navigation items** menu.
 2. Click **the ellipsis**.
 3.  Click **Add page**.<br>
 
@@ -172,7 +172,7 @@ When you add a link, the link appears as a root level menu item. When you publis
     *   Navigate to link in the navigation bar, click the **ellipses**, and then click **Publish**.<br>
 
         <figure><img src="../../.gitbook/assets/D897DBD4-B160-4F29-ACD8-14E5D0959CF5_1_201_a.jpeg" alt=""><figcaption></figcaption></figure>
-5.  In the **Publish link** pop-up menu, click **Publish**.<br>
+5.  In the confirmation dialog, click **Publish**.<br>
 
     <figure><img src="../../.gitbook/assets/B33EB73A-836D-4E7F-A297-53C23A7AB324_1_201_a.jpeg" alt=""><figcaption></figcaption></figure>
 {% endtab %}
@@ -186,7 +186,7 @@ Adding APIs to the documentation is **the only way** to make them visible in the
 Unlike in the Classic Portal, the property `published` of an API is not taken into account in the New Developer Portal.
 {% endhint %}
 
-API navigation items act similarly to folders meaning that they can contain other navigation items like Pages, Folders and Links.
+API navigation items act similarly to folders meaning that they can contain other navigation items like Pages, Folders, and Links.
 
 However, there are some limitations of APIs compared to folders:
 
@@ -195,9 +195,15 @@ However, there are some limitations of APIs compared to folders:
 
 **Add an API**
 
-1. Open the context menu of a folder in which you want to add your API by clicking the **ellipses**, and then click **Add API**.
-2. An **API selection dialog** opens up where you can select APIs to be added.
-3. (Optional) Turn on the **Authentication is required to view selected APIs** toggle. This ensures that the user has to sign in to the New Developer Portal to view the APIs.
+1.  Open the context menu of a folder in which you want to add your API by clicking the **ellipses**, and then click **Add API**.<br>
+
+    <!-- TODO: Screenshot of the folder context menu with the Add API option highlighted -->
+    <figure><img src="../../.gitbook/assets/PLACEHOLDER-devportal-add-api-context-menu.png" alt=""><figcaption><p>Add API in the folder context menu</p></figcaption></figure>
+2.  In the **Add APIs** dialog, select the APIs that you want to add. To find an API by name, use the **Search** field.<br>
+
+    <!-- TODO: Screenshot of the Add APIs dialog with an API selected -->
+    <figure><img src="../../.gitbook/assets/PLACEHOLDER-devportal-add-apis-dialog.png" alt=""><figcaption><p>Add APIs dialog</p></figcaption></figure>
+3. (Optional) Turn on the **Authentication is required to view selected APIs.** toggle. This ensures that the user has to sign in to the New Developer Portal to view the APIs.
 4. Click **Add**.
 5. Publish the API. To publish the API, complete either of the following steps:
 
@@ -206,7 +212,10 @@ However, there are some limitations of APIs compared to folders:
 * Click **Publish**.
 * Navigate to the folder in the navigation bar, click the **ellipses**, and then click **Publish**.
 
-6. In the **Publish API** pop-up box, click **Publish**.
+6.  In the confirmation dialog, click **Publish**. The dialog title shows the name of your API. For example, **Publish "Payments" API?**<br>
+
+    <!-- TODO: Screenshot of the publish confirmation dialog for an API -->
+    <figure><img src="../../.gitbook/assets/PLACEHOLDER-devportal-publish-api-dialog.png" alt=""><figcaption><p>Publish confirmation dialog for an API</p></figcaption></figure>
 
 **Default Overview page**
 
@@ -223,7 +232,7 @@ Gravitee creates the Overview page only when the API doesn't already have a page
 
 When you add a page to an API, that page becomes a menu item within that API in the New Developer Portal.
 
-1. Navigate to the the folder in the **Navigation items** menu.
+1. Navigate to the folder in the **Navigation items** menu.
 2. Click **the ellipsis**.
 3. Click **Add page**.
 
@@ -231,7 +240,7 @@ When you add a page to an API, that page becomes a menu item within that API in 
 
 When you add a folder to an API, that folder becomes nested within that API in the New Developer Portal.
 
-1. Navigate to the the folder in the **Navigation items** menu.
+1. Navigate to the folder in the **Navigation items** menu.
 2. Click **the ellipsis**.
 3. Click **Add folder**.
 {% endtab %}

--- a/docs/apim/4.13/getting-started/create-and-publish-your-first-api/publish-your-api.md
+++ b/docs/apim/4.13/getting-started/create-and-publish-your-first-api/publish-your-api.md
@@ -19,6 +19,10 @@ This guide explains how to Publish your API.
 
 ## Publish your API
 
+{% hint style="info" %}
+This page applies to the Classic Portal. The New Developer Portal doesn't use the API's published state. To make an API visible in the New Developer Portal, add the API to the portal navigation and publish it there. For more information, see [Manage Portal Navigation and APIs](../../developer-portal/new-developer-portal/customize-the-navigation.md).
+{% endhint %}
+
 1.  From the dashboard, click **APIs**.
 
     <figure><img src="../../.gitbook/assets/A55EF9D7-6D61-4D8F-8BA1-F71122515FAA.jpeg" alt=""><figcaption></figcaption></figure>
@@ -39,7 +43,7 @@ Your API appears on the Developer Portal. To view your API in the Developer Port
 1.  In the console header navigation, click **Developer Portal**.
 
     <figure><img src="../../.gitbook/assets/6B137E7B-B69B-4EFA-9099-B5FA1496B0D7.jpeg" alt=""><figcaption></figcaption></figure>
-2.  In the Developer Portal, click **Explore APIS.**
+2.  In the Developer Portal, click **Explore APIs**.
 
     <figure><img src="../../.gitbook/assets/gs-first-api-publish-your-api-66.png" alt=""><figcaption></figcaption></figure>
 3.  In the **Catalog** page, click **All APIs.**

--- a/vale/styles/config/vocabularies/docs/accept.txt
+++ b/vale/styles/config/vocabularies/docs/accept.txt
@@ -778,7 +778,7 @@ dockerize
 downscoping
 anonymization
 reauthentication
-unpublishing
+[Uu]npublishing
 multifactor
 strikethrough
 fullscreen


### PR DESCRIPTION
## Summary

[DOC-1665](https://gravitee.atlassian.net/browse/DOC-1665) — backlog ticket (no release deliverables for the ticket itself). "Manage Portal APIs" documentation update, applied to `docs/apim/4.11`, `4.12`, and `4.13`. SME: Varun Goel.

- **Release notes link**: both APIM 4.11 breaking-changes entries about the New Developer Portal now link to the navigation page. Edited in `docs/apim/4.11/release-information/release-notes/apim-4.11.md` only — the 4.12/4.13 copies are external-URL stubs per the cutover convention.
- **Rename**: "Customize the Navigation" → **"Manage Portal Navigation and APIs"** (H1 + `SUMMARY.md` in all three versions). File paths unchanged, so existing URLs keep resolving. Wording is open to SME preference — a two-line change per version.
- **Add API screenshots**: three TODO placeholders added to the "Add an API" steps in each version (folder context menu, Add APIs dialog, publish confirmation dialog). Labels are identical from 4.11.x through master, so the same captures can be reused.
- **Publish your API note**: hint added at the top of the "Publish your API" section in all three versions — the page applies to the Classic Portal, the New Developer Portal doesn't use the API's published state, APIs get into the New Developer Portal via portal navigation (with link).
- **Label corrections verified from source** while touching these sections: "API selection dialog" → **Add APIs** dialog + **Search** field, toggle text trailing period, the nonexistent "Publish API/page/folder/link pop-up" titles → the real dynamic confirmation dialog, "Explore APIS." → **Explore APIs**.
- **Lint fixes on touched pages** (Vale hook): semicolons and em dashes split in the 4.11 release notes, "the the" typos, Gzip casing, "textarea" → "text area", Oxford comma, and `accept.txt` now accepts `[Uu]npublishing` (established casing-regex idiom).

## Claims table

| # | Claim | Verdict |
|---|---|---|
| 1 | The New Developer Portal doesn't use the API's published state | Verified — visibility resolved solely from published API navigation items plus visibility/membership (`gravitee-apim-rest-api-service/.../portal_page/domain_service/PortalNavigationApiVisibilityDomainService.java:43-112`); absence sweep of the portal-navigation flow (core use cases, domain services, infra query service, repository criteria) found zero `lifecycleState` references |
| 2 | Publishing an API applies to the Classic Portal | Verified — classic catalog filters on `ApiLifecycleState.PUBLISHED` (`ApiAuthorizationServiceImpl.java:145`); Console Danger Zone publish sets that field (`api-general-info-danger-zone.component.ts:202,225`) |
| 3 | New Developer Portal subscriptions need a published API navigation item | Verified — `GetSubscriptionFormForApiPortalUseCase.java:49-52` (backs the release-notes entries the links were added to) |
| 4 | **Add API** lives in the folder context (ellipsis) menu | Verified — `gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.html:150` on master and on `origin/4.11.x` |
| 5 | Dialog titled **Add APIs**, **Search** field, toggle "Authentication is required to view selected APIs.", **Add**/**Cancel** buttons | Verified — `api-section-editor-dialog.component.html:27,103,109-110`, `.ts:106`; identical on `origin/4.11.x` |
| 6 | Publish confirmation dialog title is dynamic (for example, `Publish "Payments" API?`), confirm button **Publish** | Verified — 4.11.x `portal-navigation-items.component.ts` (`getPublishDialogData`), master `publish-navigation-item-dialog.component.ts:55-86` |
| 7 | **Explore APIs** label in the Classic Portal | Verified — `gravitee-apim-portal-webui/src/assets/i18n/en.json:1001` |
| 8 | Feature/mechanism is 4.11+ (justifies targeting 4.11-4.13) | Verified — first commit of the visibility flow contained in tag `4.11.0` |

[DOC-1665]: https://gravitee.atlassian.net/browse/DOC-1665?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ