### PR TITLE
docs: document the MCP Tool Server entrypoint on the v4 entrypoints page (DOC-1716)

### DIFF
--- a/docs/apim/4.11/create-and-configure-apis/configure-v4-apis/entrypoints/README.md
+++ b/docs/apim/4.11/create-and-configure-apis/configure-v4-apis/entrypoints/README.md
@@ -48,6 +48,20 @@ You have the option to:
 
 Redeploy the API for your changes to take effect.
 
+### MCP Tool Server
+
+You can also expose a v4 HTTP proxy API as a Model Context Protocol (MCP) Tool Server, so that AI agents call the API's operations as MCP tools. For a v4 proxy API that doesn't use a TCP listener, the Console shows an **MCP Entrypoint** tab alongside the **Entrypoints** tab.
+
+AI agents reach the MCP Tool Server on a path appended to the API's context path. Set that path in the **MCP Path** field. The default is `/mcp`.
+
+{% hint style="warning" %}
+**Enterprise only**
+
+MCP Tool Server is an [Enterprise Edition](../../../readme/enterprise-edition.md) capability.
+{% endhint %}
+
+For the full procedure, including how to generate tools from an OpenAPI specification, see [Convert REST APIs to an MCP Server](../../../ai-agent-management/convert-your-apis-to-mcp-servers.md).
+
 ## Message API entrypoints
 
 {% hint style="warning" %}
@@ -75,7 +89,7 @@ At the top right of the page, you can choose to enable or disable virtual hosts.
 
 <figure><img src="../../../.gitbook/assets/configure v4 message entrypoints.png" alt=""><figcaption><p>v4 message API entrypoint configuration</p></figcaption></figure>
 
-Entrypoint configuration depends on which entrypoint(s) your API utilizes. Click on the tiles below for the configuration details of each specific entrypoint.
+Entrypoint configuration depends on which entrypoints your API uses. Click on the tiles below for the configuration details of each specific entrypoint.
 
 <table data-view="cards"><thead><tr><th></th><th></th><th></th><th data-hidden data-card-target data-type="content-ref"></th></tr></thead><tbody><tr><td></td><td><a href="http-get.md">HTTP GET</a></td><td></td><td><a href="../../../../4.9/create-and-configure-apis/configure-v4-apis/entrypoints/broken-reference/">broken-reference</a></td></tr><tr><td></td><td><a href="http-post.md">HTTP POST</a></td><td></td><td><a href="../../../../4.9/create-and-configure-apis/configure-v4-apis/entrypoints/broken-reference/">broken-reference</a></td></tr><tr><td></td><td><a href="websocket.md">WebSocket</a></td><td></td><td><a href="../../../../4.9/create-and-configure-apis/configure-v4-apis/entrypoints/broken-reference/">broken-reference</a></td></tr><tr><td></td><td><a href="webhook.md">Webhook</a></td><td></td><td><a href="../../../../4.9/create-and-configure-apis/configure-v4-apis/entrypoints/broken-reference/">broken-reference</a></td></tr><tr><td></td><td><a href="server-sent-events.md">Server-sent Events</a></td><td></td><td><a href="../../../../4.9/create-and-configure-apis/configure-v4-apis/entrypoints/broken-reference/">broken-reference</a></td></tr></tbody></table>
 

--- a/docs/apim/4.11/readme/enterprise-edition.md
+++ b/docs/apim/4.11/readme/enterprise-edition.md
@@ -72,7 +72,7 @@ Mediate, expose, and secure asynchronous event streams by connecting to advanced
 | Entrypoint | [WebSocket](../../4.9/create-and-configure-apis/configure-v4-apis/entrypoints/websocket.md)                  | Send and retrieve streamed events and messages in real time using the WebSocket protocol.                          |
 | Endpoint   | [Azure Service Bus](../create-and-configure-apis/configure-v4-apis/endpoints/azure-service-bus.md)           | Publish and subscribe to events in Azure Service Bus via HTTP and WebSocket mediation.                             |
 | Endpoint   | [Kafka](../create-and-configure-apis/configure-v4-apis/endpoints/kafka.md)                                   | Publish and subscribe to Kafka events using HTTP and WebSocket mediation.                                          |
-| Endpoint   | [MQTT5](../create-and-configure-apis/configure-v4-apis/endpoints/mqtt5.md)                                   | Publish and subscribe to messages on an MQTT 5.x broker (e.g., HiveMQ, Mosquitto).                                 |
+| Endpoint   | [MQTT5](../create-and-configure-apis/configure-v4-apis/endpoints/mqtt5.md)                                   | Publish and subscribe to messages on an MQTT 5.x broker (for example, HiveMQ and Mosquitto).                                 |
 | Endpoint   | [RabbitMQ](../create-and-configure-apis/configure-v4-apis/endpoints/rabbitmq.md)                             | Communicate seamlessly with a RabbitMQ resource using the AMQP 0-9-1 protocol.                                     |
 | Endpoint   | [Solace](../create-and-configure-apis/configure-v4-apis/endpoints/solace.md)                                 | Publish and subscribe to messages on a Solace broker using the SMF protocol.                                       |
 | Endpoint   | [JMS](../create-and-configure-apis/configure-v4-apis/endpoints/jms.md)                                       | Publish and subscribe to JMS messages from compliant brokers such as ActiveMQ, IBM MQ, and Solace.                 |
@@ -87,10 +87,11 @@ Govern and manage the communication protocols required for building and securing
 | Reactor    | A2A Proxy      | Dedicated V4 API type that enables agent-to-agent communication through the Gravitee API Management platform.      |
 | Entrypoint | Agent to Agent | Support Google's Agent-to-Agent (A2A) protocol using SSE, HTTP GET, or HTTP POST methods for client consumption.   |
 | Endpoint   | Agent to Agent | Support Google's Agent-to-Agent (A2A) protocol using SSE, HTTP GET, or HTTP POST methods for backend connectivity. |
+| Entrypoint | MCP Tool Server | Expose a v4 HTTP proxy API as a Model Context Protocol (MCP) Tool Server so that AI agents can call its operations as tools. |
 
 ## Alert Engine
 
-Configure and manage proactive alerts across your entire API Management platform. Alert Engine is an enterprise **Plugin Pack** that allows you to monitor API traffic, health checks, and platform events, automatically triggering notifications to your preferred channels (e.g., Email, Slack, Webhooks) whenever specific conditions, anomalies, or thresholds are met.
+Configure and manage proactive alerts across your entire API Management platform. Alert Engine is an enterprise **Plugin Pack** that allows you to monitor API traffic, health checks, and platform events, automatically triggering notifications to your preferred channels (for example, Email, Slack, and Webhooks) whenever specific conditions, anomalies, or thresholds are met.
 
 ## Hosting Options
 

--- a/docs/apim/4.12/create-and-configure-apis/configure-v4-apis/entrypoints/README.md
+++ b/docs/apim/4.12/create-and-configure-apis/configure-v4-apis/entrypoints/README.md
@@ -48,6 +48,20 @@ You have the option to:
 
 Redeploy the API for your changes to take effect.
 
+### MCP Tool Server
+
+You can also expose a v4 HTTP proxy API as a Model Context Protocol (MCP) Tool Server, so that AI agents call the API's operations as MCP tools. For a v4 proxy API that doesn't use a TCP listener, the Console shows an **MCP Entrypoint** tab alongside the **Entrypoints** tab.
+
+AI agents reach the MCP Tool Server on a path appended to the API's context path. Set that path in the **MCP Path** field. The default is `/mcp`.
+
+{% hint style="warning" %}
+**Enterprise only**
+
+MCP Tool Server is an [Enterprise Edition](../../../introduction/enterprise-edition.md) capability.
+{% endhint %}
+
+For the full procedure, including how to generate tools from an OpenAPI specification, see [Convert REST APIs to an MCP Server](../../../ai-agent-management/convert-your-apis-to-mcp-servers.md).
+
 ## Message API entrypoints
 
 {% hint style="warning" %}
@@ -75,7 +89,7 @@ At the top right of the page, you can choose to enable or disable virtual hosts.
 
 <figure><img src="../../../.gitbook/assets/configure v4 message entrypoints.png" alt=""><figcaption><p>v4 message API entrypoint configuration</p></figcaption></figure>
 
-Entrypoint configuration depends on which entrypoint(s) your API utilizes. Click on the tiles below for the configuration details of each specific entrypoint.
+Entrypoint configuration depends on which entrypoints your API uses. Click on the tiles below for the configuration details of each specific entrypoint.
 
 <table data-view="cards"><thead><tr><th></th><th></th><th></th><th data-hidden data-card-target data-type="content-ref"></th></tr></thead><tbody><tr><td></td><td><a href="http-get.md">HTTP GET</a></td><td></td><td><a href="../../../../4.9/create-and-configure-apis/configure-v4-apis/entrypoints/broken-reference/">broken-reference</a></td></tr><tr><td></td><td><a href="http-post.md">HTTP POST</a></td><td></td><td><a href="../../../../4.9/create-and-configure-apis/configure-v4-apis/entrypoints/broken-reference/">broken-reference</a></td></tr><tr><td></td><td><a href="websocket.md">WebSocket</a></td><td></td><td><a href="../../../../4.9/create-and-configure-apis/configure-v4-apis/entrypoints/broken-reference/">broken-reference</a></td></tr><tr><td></td><td><a href="webhook.md">Webhook</a></td><td></td><td><a href="../../../../4.9/create-and-configure-apis/configure-v4-apis/entrypoints/broken-reference/">broken-reference</a></td></tr><tr><td></td><td><a href="server-sent-events.md">Server-sent Events</a></td><td></td><td><a href="../../../../4.9/create-and-configure-apis/configure-v4-apis/entrypoints/broken-reference/">broken-reference</a></td></tr></tbody></table>
 

--- a/docs/apim/4.12/introduction/enterprise-edition.md
+++ b/docs/apim/4.12/introduction/enterprise-edition.md
@@ -9,7 +9,7 @@ metaLinks:
 
 ## Overview
 
-The Enterprise Edition (EE) version of API Management (APIM) distribution can include API Management, Event Management, and AI Agent Management features andcapabilities.
+The Enterprise Edition (EE) version of API Management (APIM) distribution can include API Management, Event Management, and AI Agent Management features and capabilities.
 
 The Gravitee APIM Enterprise Edition requires a [license](https://documentation.gravitee.io/platform-overview/gravitee-platform/gravitee-offerings-ce-vs-ee/enterprise-edition-licensing). Licenses are available as different packages, each offering a different level of access to enterprise features and capabilities. For more information, go to the [pricing page](https://www.gravitee.io/pricing).
 
@@ -58,7 +58,7 @@ Mediate, expose, and secure asynchronous event streams by connecting to advanced
 | Entrypoint | [WebSocket](../../4.9/create-and-configure-apis/configure-v4-apis/entrypoints/websocket.md)                  | Send and retrieve streamed events and messages in real time using the WebSocket protocol.                          |
 | Endpoint   | [Azure Service Bus](../create-and-configure-apis/configure-v4-apis/endpoints/azure-service-bus.md)           | Publish and subscribe to events in Azure Service Bus via HTTP and WebSocket mediation.                             |
 | Endpoint   | [Kafka](../create-and-configure-apis/configure-v4-apis/endpoints/kafka.md)                                   | Publish and subscribe to Kafka events using HTTP and WebSocket mediation.                                          |
-| Endpoint   | [MQTT5](../create-and-configure-apis/configure-v4-apis/endpoints/mqtt5.md)                                   | Publish and subscribe to messages on an MQTT 5.x broker (e.g., HiveMQ, Mosquitto).                                 |
+| Endpoint   | [MQTT5](../create-and-configure-apis/configure-v4-apis/endpoints/mqtt5.md)                                   | Publish and subscribe to messages on an MQTT 5.x broker (for example, HiveMQ and Mosquitto).                                 |
 | Endpoint   | [RabbitMQ](../create-and-configure-apis/configure-v4-apis/endpoints/rabbitmq.md)                             | Communicate seamlessly with a RabbitMQ resource using the AMQP 0-9-1 protocol.                                     |
 | Endpoint   | [Solace](../create-and-configure-apis/configure-v4-apis/endpoints/solace.md)                                 | Publish and subscribe to messages on a Solace broker using the SMF protocol.                                       |
 | Endpoint   | [JMS](../create-and-configure-apis/configure-v4-apis/endpoints/jms.md)                                       | Publish and subscribe to JMS messages from compliant brokers such as ActiveMQ, IBM MQ, and Solace.                 |
@@ -73,10 +73,11 @@ Govern and manage the communication protocols required for building and securing
 | Reactor    | A2A Proxy      | Dedicated V4 API type that enables agent-to-agent communication through the Gravitee API Management platform.      |
 | Entrypoint | Agent to Agent | Support Google's Agent-to-Agent (A2A) protocol using SSE, HTTP GET, or HTTP POST methods for client consumption.   |
 | Endpoint   | Agent to Agent | Support Google's Agent-to-Agent (A2A) protocol using SSE, HTTP GET, or HTTP POST methods for backend connectivity. |
+| Entrypoint | MCP Tool Server | Expose a v4 HTTP proxy API as a Model Context Protocol (MCP) Tool Server so that AI agents can call its operations as tools. |
 
 ## Alert Engine
 
-Configure and manage proactive alerts across your entire API Management platform. Alert Engine is an enterprise **Plugin Pack** that allows you to monitor API traffic, health checks, and platform events, automatically triggering notifications to your preferred channels (e.g., Email, Slack, Webhooks) whenever specific conditions, anomalies, or thresholds are met.
+Configure and manage proactive alerts across your entire API Management platform. Alert Engine is an enterprise **Plugin Pack** that allows you to monitor API traffic, health checks, and platform events, automatically triggering notifications to your preferred channels (for example, Email, Slack, and Webhooks) whenever specific conditions, anomalies, or thresholds are met.
 
 ## Hosting Options
 

--- a/docs/apim/4.13/create-and-configure-apis/configure-v4-apis/entrypoints/README.md
+++ b/docs/apim/4.13/create-and-configure-apis/configure-v4-apis/entrypoints/README.md
@@ -48,6 +48,20 @@ You have the option to:
 
 Redeploy the API for your changes to take effect.
 
+### MCP Tool Server
+
+You can also expose a v4 HTTP proxy API as a Model Context Protocol (MCP) Tool Server, so that AI agents call the API's operations as MCP tools. For a v4 proxy API that doesn't use a TCP listener, the Console shows an **MCP Entrypoint** tab alongside the **Entrypoints** tab.
+
+AI agents reach the MCP Tool Server on a path appended to the API's context path. Set that path in the **MCP Path** field. The default is `/mcp`.
+
+{% hint style="warning" %}
+**Enterprise only**
+
+MCP Tool Server is an [Enterprise Edition](../../../introduction/enterprise-edition.md) capability.
+{% endhint %}
+
+For the full procedure, including how to generate tools from an OpenAPI specification, see [Convert REST APIs to an MCP Server](../../../ai-agent-management/convert-your-apis-to-mcp-servers.md).
+
 ## Message API entrypoints
 
 {% hint style="warning" %}
@@ -75,7 +89,7 @@ At the top right of the page, you can choose to enable or disable virtual hosts.
 
 <figure><img src="../../../.gitbook/assets/configure v4 message entrypoints.png" alt=""><figcaption><p>v4 message API entrypoint configuration</p></figcaption></figure>
 
-Entrypoint configuration depends on which entrypoint(s) your API utilizes. Click on the tiles below for the configuration details of each specific entrypoint.
+Entrypoint configuration depends on which entrypoints your API uses. Click on the tiles below for the configuration details of each specific entrypoint.
 
 <table data-view="cards"><thead><tr><th></th><th></th><th></th><th data-hidden data-card-target data-type="content-ref"></th></tr></thead><tbody><tr><td></td><td><a href="http-get.md">HTTP GET</a></td><td></td><td><a href="../../../../4.9/create-and-configure-apis/configure-v4-apis/entrypoints/broken-reference/">broken-reference</a></td></tr><tr><td></td><td><a href="http-post.md">HTTP POST</a></td><td></td><td><a href="../../../../4.9/create-and-configure-apis/configure-v4-apis/entrypoints/broken-reference/">broken-reference</a></td></tr><tr><td></td><td><a href="websocket.md">WebSocket</a></td><td></td><td><a href="../../../../4.9/create-and-configure-apis/configure-v4-apis/entrypoints/broken-reference/">broken-reference</a></td></tr><tr><td></td><td><a href="webhook.md">Webhook</a></td><td></td><td><a href="../../../../4.9/create-and-configure-apis/configure-v4-apis/entrypoints/broken-reference/">broken-reference</a></td></tr><tr><td></td><td><a href="server-sent-events.md">Server-sent Events</a></td><td></td><td><a href="../../../../4.9/create-and-configure-apis/configure-v4-apis/entrypoints/broken-reference/">broken-reference</a></td></tr></tbody></table>
 

--- a/docs/apim/4.13/introduction/enterprise-edition.md
+++ b/docs/apim/4.13/introduction/enterprise-edition.md
@@ -9,7 +9,7 @@ metaLinks:
 
 ## Overview
 
-The Enterprise Edition (EE) version of API Management (APIM) distribution can include API Management, Event Management, and AI Agent Management features andcapabilities.
+The Enterprise Edition (EE) version of API Management (APIM) distribution can include API Management, Event Management, and AI Agent Management features and capabilities.
 
 The Gravitee APIM Enterprise Edition requires a [license](https://documentation.gravitee.io/platform-overview/gravitee-platform/gravitee-offerings-ce-vs-ee/enterprise-edition-licensing). Licenses are available as different packages, each offering a different level of access to enterprise features and capabilities. For more information, go to the [pricing page](https://www.gravitee.io/pricing).
 
@@ -58,7 +58,7 @@ Mediate, expose, and secure asynchronous event streams by connecting to advanced
 | Entrypoint | [WebSocket](../../4.9/create-and-configure-apis/configure-v4-apis/entrypoints/websocket.md)                  | Send and retrieve streamed events and messages in real time using the WebSocket protocol.                          |
 | Endpoint   | [Azure Service Bus](../create-and-configure-apis/configure-v4-apis/endpoints/azure-service-bus.md)           | Publish and subscribe to events in Azure Service Bus via HTTP and WebSocket mediation.                             |
 | Endpoint   | [Kafka](../create-and-configure-apis/configure-v4-apis/endpoints/kafka.md)                                   | Publish and subscribe to Kafka events using HTTP and WebSocket mediation.                                          |
-| Endpoint   | [MQTT5](../create-and-configure-apis/configure-v4-apis/endpoints/mqtt5.md)                                   | Publish and subscribe to messages on an MQTT 5.x broker (e.g., HiveMQ, Mosquitto).                                 |
+| Endpoint   | [MQTT5](../create-and-configure-apis/configure-v4-apis/endpoints/mqtt5.md)                                   | Publish and subscribe to messages on an MQTT 5.x broker (for example, HiveMQ and Mosquitto).                                 |
 | Endpoint   | [RabbitMQ](../create-and-configure-apis/configure-v4-apis/endpoints/rabbitmq.md)                             | Communicate seamlessly with a RabbitMQ resource using the AMQP 0-9-1 protocol.                                     |
 | Endpoint   | [Solace](../create-and-configure-apis/configure-v4-apis/endpoints/solace.md)                                 | Publish and subscribe to messages on a Solace broker using the SMF protocol.                                       |
 | Endpoint   | [JMS](../create-and-configure-apis/configure-v4-apis/endpoints/jms.md)                                       | Publish and subscribe to JMS messages from compliant brokers such as ActiveMQ, IBM MQ, and Solace.                 |
@@ -73,10 +73,11 @@ Govern and manage the communication protocols required for building and securing
 | Reactor    | A2A Proxy      | Dedicated V4 API type that enables agent-to-agent communication through the Gravitee API Management platform.      |
 | Entrypoint | Agent to Agent | Support Google's Agent-to-Agent (A2A) protocol using SSE, HTTP GET, or HTTP POST methods for client consumption.   |
 | Endpoint   | Agent to Agent | Support Google's Agent-to-Agent (A2A) protocol using SSE, HTTP GET, or HTTP POST methods for backend connectivity. |
+| Entrypoint | MCP Tool Server | Expose a v4 HTTP proxy API as a Model Context Protocol (MCP) Tool Server so that AI agents can call its operations as tools. |
 
 ## Alert Engine
 
-Configure and manage proactive alerts across your entire API Management platform. Alert Engine is an enterprise **Plugin Pack** that allows you to monitor API traffic, health checks, and platform events, automatically triggering notifications to your preferred channels (e.g., Email, Slack, Webhooks) whenever specific conditions, anomalies, or thresholds are met.
+Configure and manage proactive alerts across your entire API Management platform. Alert Engine is an enterprise **Plugin Pack** that allows you to monitor API traffic, health checks, and platform events, automatically triggering notifications to your preferred channels (for example, Email, Slack, and Webhooks) whenever specific conditions, anomalies, or thresholds are met.
 
 ## Hosting Options
 

--- a/vale/styles/config/vocabularies/docs/accept.txt
+++ b/vale/styles/config/vocabularies/docs/accept.txt
@@ -876,3 +876,4 @@ llmtest
 # GitBook page frontmatter key
 noIndex
 [Ww]alkthroughs?
+dashboarding


### PR DESCRIPTION
## Summary

[DOC-1716](https://gravitee.atlassian.net/browse/DOC-1716) — backlog ticket (reporter Brent Hunter, SME Jonathan Michaux). Applied to APIM 4.11, 4.12, and 4.13.

**The ticket's premise needed adjusting.** It says there's no documentation for enabling MCP on an existing API, but the full procedure already exists at `ai-agent-management/convert-your-apis-to-mcp-servers.md` in all three versions, and it's accurate against the current Console. The real gap is discoverability: the v4 entrypoints page (where the reporter looked, and where the Console actually puts MCP) never mentions MCP. So this PR adds a short section there that cross-references the existing procedure rather than duplicating it, per rule 25.

- **`create-and-configure-apis/configure-v4-apis/entrypoints/README.md`** — new `### MCP Tool Server` section under **Proxy API entrypoints**: what it does, that the Console shows an **MCP Entrypoint** tab beside **Entrypoints** for v4 proxy APIs without a TCP listener, the **MCP Path** field and its `/mcp` default, an Enterprise-only hint, and a link to the full procedure.
- **`enterprise-edition.md`** — adds the missing **MCP Tool Server** entrypoint row to the AI Agent Management table (it was absent in every version, while A2A was listed).

Pre-existing lint fixed on the touched pages: `entrypoint(s)` → `entrypoints`, two banned `e.g.` instances, and an `andcapabilities` typo. `dashboarding` added to `accept.txt`.

## Claims table

| # | Claim | Verdict |
|---|---|---|
| 1 | MCP Tool Server is a v4 entrypoint connector plugin | Verified — `gravitee-entrypoint-mcp-tool-server/src/main/resources/plugin.properties`: `id=mcp`, `name=MCP Server`, `type=entrypoint-connector`, `class=…MCPEntrypointConnectorFactory` |
| 2 | It applies to v4 HTTP proxy APIs only | Verified — `MCPEntrypointConnector.java:26-27` (`ListenerType.HTTP`, `REQUEST_RESPONSE`); `supportedApi()` inherited as `ApiType.PROXY` from `gravitee-gateway-api/.../HttpEntrypointSyncConnectorFactory.java:32-35` |
| 3 | The Console shows an **MCP Entrypoint** tab beside **Entrypoints**, for proxy APIs without a TCP listener | Verified — `api-v4-menu.service.ts:152-181`: `addEntrypointsMenuEntry()` builds the **Entrypoints** menu whose tabs are `Entrypoints` and, when `api.type === 'PROXY' && !hasTcpListeners`, `MCP Entrypoint` |
| 4 | Field label **MCP Path**, default `/mcp`, appended to the API context path | Verified — `configure-mcp-entrypoint.component.html:20`; `schema-form.json` `mcpPath` (`"default": "/mcp"`, "This path is appended to the API contextPath"), and `mcpPath` is the schema's only required property |
| 5 | Enterprise Edition capability | Verified — `plugin.properties` `feature=apim-mcp-tool-server`, mapped in `gravitee-node/.../license-model.yml` to the `agent-mesh` pack (line 160) and the Gamma `agent-management` pack (line 249) |
| 6 | Available in 4.11, 4.12, and 4.13 | Verified — `gravitee-entrypoint-mcp-tool-server.version` is `2.0.2` in `pom.xml` on `origin/4.11.x`, `origin/4.12.x`, and `master` (`<revision>4.13.0</revision>`); plugin `README.adoc:16-19` maps 2.x → APIM 4.11.x |
| 7 | The linked procedure page is still accurate | Verified — its steps match the Console: `Entrypoints` menu, `MCP Entrypoint` tab, **Enable MCP** button (`no-mcp-entrypoint.component.html`), **Generate Tools from OpenAPI** (`configure-mcp-entrypoint.component.html:33`) |

[DOC-1716]: https://gravitee.atlassian.net/browse/DOC-1716?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ