### PR TITLE
docs: retarget legacy release-notes and changelog redirects to the section indexes

### DIFF
--- a/.gitbook.yaml
+++ b/.gitbook.yaml
@@ -67,9 +67,9 @@ redirects:
   # legacy alert-engine/* URLs (older prefix, predates the "ae" rename) — mirrored 1:1 into apim/4.12/alert-engine like ae/* above (writer decision 2026-07-22); these URLs belong to a deleted section, so they only fire as GitBook Site redirects (UI) — mirror this block there
   alert-engine: apim/4.12/alert-engine/README.md
   alert-engine/overview/integrations: apim/4.12/alert-engine/overview/integrations.md
-  alert-engine/getting-started/install-and-upgrade-guides/install-via-kubernetes: apim/4.12/alert-engine/getting-started/install-and-upgrade-guides/README.md
-  alert-engine/getting-started/install-and-upgrade-guides/install-via-.zip-file: apim/4.12/alert-engine/getting-started/install-and-upgrade-guides/README.md
-  alert-engine/getting-started/install-and-upgrade-guides/install-via-docker: apim/4.12/alert-engine/getting-started/install-and-upgrade-guides/README.md
+  alert-engine/getting-started/install-and-upgrade-guides/install-via-kubernetes: apim/4.12/alert-engine/getting-started/install-and-upgrade-guides/install-via-kubernetes.md
+  alert-engine/getting-started/install-and-upgrade-guides/install-via-.zip-file: apim/4.12/alert-engine/getting-started/install-and-upgrade-guides/install-via-.zip-file.md
+  alert-engine/getting-started/install-and-upgrade-guides/install-via-docker: apim/4.12/alert-engine/getting-started/install-and-upgrade-guides/install-via-docker.md
   alert-engine/guides/integration-set-up/gravitee-api-management: apim/4.12/alert-engine/guides/integration-set-up/gravitee-api-management/README.md
   alert-engine/changelog/page-6: apim/4.12/alert-engine/releases-and-changelog/page-6.md
   # legacy apim/* URL structure (pre-reorg) — redirect into the current apim/4.12 structure (bump 4.12 at each version cutover)

--- a/.gitbook.yaml
+++ b/.gitbook.yaml
@@ -67,9 +67,9 @@ redirects:
   # legacy alert-engine/* URLs (older prefix, predates the "ae" rename) — mirrored 1:1 into apim/4.12/alert-engine like ae/* above (writer decision 2026-07-22); these URLs belong to a deleted section, so they only fire as GitBook Site redirects (UI) — mirror this block there
   alert-engine: apim/4.12/alert-engine/README.md
   alert-engine/overview/integrations: apim/4.12/alert-engine/overview/integrations.md
-  alert-engine/getting-started/install-and-upgrade-guides/install-via-kubernetes: apim/4.12/alert-engine/getting-started/install-and-upgrade-guides/install-via-kubernetes.md
-  alert-engine/getting-started/install-and-upgrade-guides/install-via-.zip-file: apim/4.12/alert-engine/getting-started/install-and-upgrade-guides/install-via-.zip-file.md
-  alert-engine/getting-started/install-and-upgrade-guides/install-via-docker: apim/4.12/alert-engine/getting-started/install-and-upgrade-guides/install-via-docker.md
+  alert-engine/getting-started/install-and-upgrade-guides/install-via-kubernetes: apim/4.12/alert-engine/getting-started/install-and-upgrade-guides/README.md
+  alert-engine/getting-started/install-and-upgrade-guides/install-via-.zip-file: apim/4.12/alert-engine/getting-started/install-and-upgrade-guides/README.md
+  alert-engine/getting-started/install-and-upgrade-guides/install-via-docker: apim/4.12/alert-engine/getting-started/install-and-upgrade-guides/README.md
   alert-engine/guides/integration-set-up/gravitee-api-management: apim/4.12/alert-engine/guides/integration-set-up/gravitee-api-management/README.md
   alert-engine/changelog/page-6: apim/4.12/alert-engine/releases-and-changelog/page-6.md
   # legacy apim/* URL structure (pre-reorg) — redirect into the current apim/4.12 structure (bump 4.12 at each version cutover)

--- a/.gitbook.yaml
+++ b/.gitbook.yaml
@@ -64,14 +64,14 @@ redirects:
   ae/releases-and-changelog/page-6: apim/4.12/alert-engine/releases-and-changelog/page-6.md
   ae/community-and-support/enterprise-support: apim/4.12/readme/enterprise-edition.md
   ae/community-and-support/community: apim/4.12/readme/community-forum.md
-  # legacy alert-engine/* URLs (older prefix, predates the "ae" rename) — consolidated into the single gateway alerts page rather than mirrored 1:1 like ae/* above
-  alert-engine: apim/4.12/configure-and-manage-the-platform/gravitee-gateway/alerts.md
-  alert-engine/overview/integrations: apim/4.12/configure-and-manage-the-platform/gravitee-gateway/alerts.md
-  alert-engine/getting-started/install-and-upgrade-guides/install-via-kubernetes: apim/4.12/configure-and-manage-the-platform/gravitee-gateway/alerts.md
-  alert-engine/getting-started/install-and-upgrade-guides/install-via-.zip-file: apim/4.12/configure-and-manage-the-platform/gravitee-gateway/alerts.md
-  alert-engine/getting-started/install-and-upgrade-guides/install-via-docker: apim/4.12/configure-and-manage-the-platform/gravitee-gateway/alerts.md
-  alert-engine/guides/integration-set-up/gravitee-api-management: apim/4.12/configure-and-manage-the-platform/gravitee-gateway/alerts.md
-  alert-engine/changelog/page-6: apim/4.12/configure-and-manage-the-platform/gravitee-gateway/alerts.md
+  # legacy alert-engine/* URLs (older prefix, predates the "ae" rename) — mirrored 1:1 into apim/4.12/alert-engine like ae/* above (writer decision 2026-07-22); these URLs belong to a deleted section, so they only fire as GitBook Site redirects (UI) — mirror this block there
+  alert-engine: apim/4.12/alert-engine/README.md
+  alert-engine/overview/integrations: apim/4.12/alert-engine/overview/integrations.md
+  alert-engine/getting-started/install-and-upgrade-guides/install-via-kubernetes: apim/4.12/alert-engine/getting-started/install-and-upgrade-guides/install-via-kubernetes.md
+  alert-engine/getting-started/install-and-upgrade-guides/install-via-.zip-file: apim/4.12/alert-engine/getting-started/install-and-upgrade-guides/install-via-.zip-file.md
+  alert-engine/getting-started/install-and-upgrade-guides/install-via-docker: apim/4.12/alert-engine/getting-started/install-and-upgrade-guides/install-via-docker.md
+  alert-engine/guides/integration-set-up/gravitee-api-management: apim/4.12/alert-engine/guides/integration-set-up/gravitee-api-management/README.md
+  alert-engine/changelog/page-6: apim/4.12/alert-engine/releases-and-changelog/page-6.md
   # legacy apim/* URL structure (pre-reorg) — redirect into the current apim/4.12 structure (bump 4.12 at each version cutover)
   apim/guides/federation: apim/4.12/govern-apis/federation/README.md
   apim/overview/gravitee-apim-enterprise-edition: apim/4.12/introduction/enterprise-edition.md

--- a/docs/apim/4.12/.gitbook.yaml
+++ b/docs/apim/4.12/.gitbook.yaml
@@ -635,12 +635,12 @@ redirects:
  overview/apim-architecture/production-deployments-and-capacity-planning: prepare-a-production-environment/production-best-practices/deployments.md
  overview/architecture: README.md
  overview/changelog: release-information/changelog/README.md
- overview/changelog/apim-4.2.x: release-information/changelog/apim-4.11.x.md
- overview/changelog/apim-4.3.x: release-information/changelog/apim-4.11.x.md
- overview/changelog/apim-4.4.x: release-information/changelog/apim-4.11.x.md
- overview/changelog/apim-4.5.x: release-information/changelog/apim-4.11.x.md
- overview/changelog/apim-4.6.x: release-information/changelog/apim-4.11.x.md
- overview/changelog/apim-4.7.x: release-information/changelog/apim-4.11.x.md
+ overview/changelog/apim-4.2.x: release-information/changelog/README.md
+ overview/changelog/apim-4.3.x: release-information/changelog/README.md
+ overview/changelog/apim-4.4.x: release-information/changelog/README.md
+ overview/changelog/apim-4.5.x: release-information/changelog/README.md
+ overview/changelog/apim-4.6.x: release-information/changelog/README.md
+ overview/changelog/apim-4.7.x: release-information/changelog/README.md
  overview/ee-vs-oss: introduction/enterprise-edition.md
  overview/enterprise-edition: introduction/enterprise-edition.md
  overview/execution-engine: create-and-configure-apis/gravitee-api-definitions/execution-engine.md
@@ -682,12 +682,12 @@ redirects:
  overview/readme/architecture: README.md
  overview/readme/overview: README.md
  overview/release-notes: release-information/release-notes/README.md
- overview/release-notes/apim-4.2: release-information/changelog/apim-4.11.x.md
- overview/release-notes/apim-4.3: release-information/changelog/apim-4.11.x.md
- overview/release-notes/apim-4.4: release-information/changelog/apim-4.11.x.md
- overview/release-notes/apim-4.5: release-information/changelog/apim-4.11.x.md
- overview/release-notes/apim-4.6: release-information/release-notes/apim-4.11.md
- overview/release-notes/apim-4.7: release-information/release-notes/apim-4.11.md
+ overview/release-notes/apim-4.2: release-information/release-notes/README.md
+ overview/release-notes/apim-4.3: release-information/release-notes/README.md
+ overview/release-notes/apim-4.4: release-information/release-notes/README.md
+ overview/release-notes/apim-4.5: release-information/release-notes/README.md
+ overview/release-notes/apim-4.6: release-information/release-notes/README.md
+ overview/release-notes/apim-4.7: release-information/release-notes/README.md
  overview/support: configure-and-manage-the-platform/manage-organizations-and-environments/support.md
  placeholder: README.md
  policies/custom-policies: create-and-configure-apis/apply-policies/policy-reference/README.md
@@ -778,21 +778,21 @@ redirects:
  reference/policy-reference/xml-to-json: create-and-configure-apis/apply-policies/policy-reference/xml-to-json.md
  reference/policy-reference/xml-validation: create-and-configure-apis/apply-policies/policy-reference/xml-validation.md
  reference/policy-reference/xslt: create-and-configure-apis/apply-policies/policy-reference/xslt.md
- release-information/changelog/apim-4.10.x: release-information/changelog/apim-4.11.x.md
- release-information/changelog/apim-4.7.x: release-information/changelog/apim-4.11.x.md
- release-information/changelog/apim-4.8.x: release-information/changelog/apim-4.11.x.md
- release-information/changelog/apim-4.9.x: release-information/changelog/apim-4.11.x.md
- release-information/release-notes/apim-4.10: release-information/release-notes/apim-4.11.md
- release-information/release-notes/apim-4.8: release-information/release-notes/apim-4.11.md
- release-information/release-notes/apim-4.9: release-information/release-notes/apim-4.11.md
+ release-information/changelog/apim-4.10.x: release-information/changelog/README.md
+ release-information/changelog/apim-4.7.x: release-information/changelog/README.md
+ release-information/changelog/apim-4.8.x: release-information/changelog/README.md
+ release-information/changelog/apim-4.9.x: release-information/changelog/README.md
+ release-information/release-notes/apim-4.10: release-information/release-notes/README.md
+ release-information/release-notes/apim-4.8: release-information/release-notes/README.md
+ release-information/release-notes/apim-4.9: release-information/release-notes/README.md
  releases-and-changelog/changelog: release-information/changelog/README.md
- releases-and-changelog/changelog/apim-4.0.x: release-information/changelog/apim-4.11.x.md
- releases-and-changelog/changelog/apim-4.1.x: release-information/changelog/apim-4.11.x.md
+ releases-and-changelog/changelog/apim-4.0.x: release-information/changelog/README.md
+ releases-and-changelog/changelog/apim-4.1.x: release-information/changelog/README.md
  releases-and-changelog/release-notes: release-information/release-notes/README.md
- releases-and-changelog/release-notes/apim-4.0: release-information/changelog/apim-4.11.x.md
- releases-and-changelog/release-notes/apim-4.1: release-information/changelog/apim-4.11.x.md
- releases-and-changelog/release-notes/apim-4.5: release-information/changelog/apim-4.11.x.md
- releases-and-changelog/release-notes/gravitee-4.x/apim-4.0: release-information/changelog/apim-4.11.x.md
+ releases-and-changelog/release-notes/apim-4.0: release-information/release-notes/README.md
+ releases-and-changelog/release-notes/apim-4.1: release-information/release-notes/README.md
+ releases-and-changelog/release-notes/apim-4.5: release-information/release-notes/README.md
+ releases-and-changelog/release-notes/gravitee-4.x/apim-4.0: release-information/release-notes/README.md
  using-the-product/administration: README.md
  using-the-product/administration/administering-organizations-and-environments: configure-and-manage-the-platform/manage-organizations-and-environments/README.md
  using-the-product/administration/authentication: configure-and-manage-the-platform/manage-organizations-and-environments/authentication/README.md

--- a/docs/apim/4.13/.gitbook.yaml
+++ b/docs/apim/4.13/.gitbook.yaml
@@ -635,12 +635,12 @@ redirects:
  overview/apim-architecture/production-deployments-and-capacity-planning: prepare-a-production-environment/production-best-practices/deployments.md
  overview/architecture: README.md
  overview/changelog: release-information/changelog/README.md
- overview/changelog/apim-4.2.x: release-information/changelog/apim-4.11.x.md
- overview/changelog/apim-4.3.x: release-information/changelog/apim-4.11.x.md
- overview/changelog/apim-4.4.x: release-information/changelog/apim-4.11.x.md
- overview/changelog/apim-4.5.x: release-information/changelog/apim-4.11.x.md
- overview/changelog/apim-4.6.x: release-information/changelog/apim-4.11.x.md
- overview/changelog/apim-4.7.x: release-information/changelog/apim-4.11.x.md
+ overview/changelog/apim-4.2.x: release-information/changelog/README.md
+ overview/changelog/apim-4.3.x: release-information/changelog/README.md
+ overview/changelog/apim-4.4.x: release-information/changelog/README.md
+ overview/changelog/apim-4.5.x: release-information/changelog/README.md
+ overview/changelog/apim-4.6.x: release-information/changelog/README.md
+ overview/changelog/apim-4.7.x: release-information/changelog/README.md
  overview/ee-vs-oss: introduction/enterprise-edition.md
  overview/enterprise-edition: introduction/enterprise-edition.md
  overview/execution-engine: create-and-configure-apis/gravitee-api-definitions/execution-engine.md
@@ -682,12 +682,12 @@ redirects:
  overview/readme/architecture: README.md
  overview/readme/overview: README.md
  overview/release-notes: release-information/release-notes/README.md
- overview/release-notes/apim-4.2: release-information/changelog/apim-4.11.x.md
- overview/release-notes/apim-4.3: release-information/changelog/apim-4.11.x.md
- overview/release-notes/apim-4.4: release-information/changelog/apim-4.11.x.md
- overview/release-notes/apim-4.5: release-information/changelog/apim-4.11.x.md
- overview/release-notes/apim-4.6: release-information/release-notes/apim-4.11.md
- overview/release-notes/apim-4.7: release-information/release-notes/apim-4.11.md
+ overview/release-notes/apim-4.2: release-information/release-notes/README.md
+ overview/release-notes/apim-4.3: release-information/release-notes/README.md
+ overview/release-notes/apim-4.4: release-information/release-notes/README.md
+ overview/release-notes/apim-4.5: release-information/release-notes/README.md
+ overview/release-notes/apim-4.6: release-information/release-notes/README.md
+ overview/release-notes/apim-4.7: release-information/release-notes/README.md
  overview/support: configure-and-manage-the-platform/manage-organizations-and-environments/support.md
  placeholder: README.md
  policies/custom-policies: create-and-configure-apis/apply-policies/policy-reference/README.md
@@ -778,21 +778,21 @@ redirects:
  reference/policy-reference/xml-to-json: create-and-configure-apis/apply-policies/policy-reference/xml-to-json.md
  reference/policy-reference/xml-validation: create-and-configure-apis/apply-policies/policy-reference/xml-validation.md
  reference/policy-reference/xslt: create-and-configure-apis/apply-policies/policy-reference/xslt.md
- release-information/changelog/apim-4.10.x: release-information/changelog/apim-4.11.x.md
- release-information/changelog/apim-4.7.x: release-information/changelog/apim-4.11.x.md
- release-information/changelog/apim-4.8.x: release-information/changelog/apim-4.11.x.md
- release-information/changelog/apim-4.9.x: release-information/changelog/apim-4.11.x.md
- release-information/release-notes/apim-4.10: release-information/release-notes/apim-4.11.md
- release-information/release-notes/apim-4.8: release-information/release-notes/apim-4.11.md
- release-information/release-notes/apim-4.9: release-information/release-notes/apim-4.11.md
+ release-information/changelog/apim-4.10.x: release-information/changelog/README.md
+ release-information/changelog/apim-4.7.x: release-information/changelog/README.md
+ release-information/changelog/apim-4.8.x: release-information/changelog/README.md
+ release-information/changelog/apim-4.9.x: release-information/changelog/README.md
+ release-information/release-notes/apim-4.10: release-information/release-notes/README.md
+ release-information/release-notes/apim-4.8: release-information/release-notes/README.md
+ release-information/release-notes/apim-4.9: release-information/release-notes/README.md
  releases-and-changelog/changelog: release-information/changelog/README.md
- releases-and-changelog/changelog/apim-4.0.x: release-information/changelog/apim-4.11.x.md
- releases-and-changelog/changelog/apim-4.1.x: release-information/changelog/apim-4.11.x.md
+ releases-and-changelog/changelog/apim-4.0.x: release-information/changelog/README.md
+ releases-and-changelog/changelog/apim-4.1.x: release-information/changelog/README.md
  releases-and-changelog/release-notes: release-information/release-notes/README.md
- releases-and-changelog/release-notes/apim-4.0: release-information/changelog/apim-4.11.x.md
- releases-and-changelog/release-notes/apim-4.1: release-information/changelog/apim-4.11.x.md
- releases-and-changelog/release-notes/apim-4.5: release-information/changelog/apim-4.11.x.md
- releases-and-changelog/release-notes/gravitee-4.x/apim-4.0: release-information/changelog/apim-4.11.x.md
+ releases-and-changelog/release-notes/apim-4.0: release-information/release-notes/README.md
+ releases-and-changelog/release-notes/apim-4.1: release-information/release-notes/README.md
+ releases-and-changelog/release-notes/apim-4.5: release-information/release-notes/README.md
+ releases-and-changelog/release-notes/gravitee-4.x/apim-4.0: release-information/release-notes/README.md
  using-the-product/administration: README.md
  using-the-product/administration/administering-organizations-and-environments: configure-and-manage-the-platform/manage-organizations-and-environments/README.md
  using-the-product/administration/authentication: configure-and-manage-the-platform/manage-organizations-and-environments/authentication/README.md


### PR DESCRIPTION
## What

Two redirect fixes from the July SEO 4XX report:

1. **Retargets 25 legacy redirect keys** in `docs/apim/4.12/.gitbook.yaml` and its identical `docs/apim/4.13/.gitbook.yaml` mirror. Every old-version release-notes URL now lands on the Release Notes index (`release-information/release-notes/README.md`), and every old-version changelog URL lands on the Changelog index (`release-information/changelog/README.md`), instead of silently landing on APIM 4.11 content.
2. **Repoints the legacy `alert-engine/*` registry block** in the repo-root `.gitbook.yaml` at the Alert Engine section that now lives inside the APIM docs (`apim/4.12/alert-engine/...`, live at `/apim/alert-engine`), mirroring 1:1 like the `ae/*` block, instead of collapsing every URL onto the gateway alerts page.

## Why

PR #1974 moved the legacy `apim/*` redirects from the repo-root `.gitbook.yaml` (which GitBook doesn't read) into the owning space configs, fixing the 404s from the July SEO report. Space configs can't target another space's files, so that move downgraded the release-notes targets to `release-information/changelog/apim-4.11.x.md`: a reader asking for the APIM 4.5 release notes landed on the 4.11.x changelog. The Release Notes index nav lists every version 4.0 and later, so it gives readers a one-click path to the version they asked for.

The `alert-engine/*` URLs belong to a deleted section, so the root-file entries document intent only: they must be mirrored as **GitBook Site redirects in the admin UI** to take effect. Every new target file exists in the repo, and every corresponding live destination URL was verified (`/apim/alert-engine`, `/apim/alert-engine/integrations`, `/apim/alert-engine/architecture` all 200).

## Verification

- All three files parse as YAML (checked with Ruby's YAML loader); every redirect target file exists.
- The 4.12 and 4.13 space configs remain identical, so the fix survives the 4.13 cutover whichever folder feeds the live default space (`/apim/4.12` currently 307s to bare `/apim`, so 4.12 is the live default variant).
- Live checks (2026-07-22): `/apim/releases-and-changelog/release-notes/apim-4.5` and `/apim/releases-and-changelog/release-notes/gravitee-4.x/apim-4.0` resolve 200 today but land on `/apim/release-information/changelog/apim-4.11.x`.