### PR TITLE
docs: update tested db versions for AM 4.13

### DIFF
--- a/docs/am/4.13/.version-overrides
+++ b/docs/am/4.13/.version-overrides
@@ -7,3 +7,4 @@ SUMMARY.md
 .gitbook.yaml
 releases-and-changelog/release-notes/am-4.12.md
 releases-and-changelog/changelog/am-4.12.x.md
+getting-started/configuration/configure-repositories.md

--- a/docs/am/4.13/getting-started/configuration/configure-repositories.md
+++ b/docs/am/4.13/getting-started/configuration/configure-repositories.md
@@ -51,7 +51,7 @@ The following matrix shows the compatibility between scopes and implementations:
 The [MongoDB](https://www.mongodb.org/) repository is included with AM by default.
 
 {% hint style="info" %}
-AM has been tested using Mongo DB in version **4.4** up to **8.0**
+AM has been tested using Mongo DB in version **4.4** up to **8.2**
 {% endhint %}
 
 ### Configuration
@@ -213,7 +213,7 @@ AM uses the JDBC and R2DBC drivers together, since AM uses [Liquibase](https://w
 
 | Database             | Version tested | JDBC Driver                                                                                                                           | R2DBC Driver                                                                                                                     |
 | -------------------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| Postgresql           | 11             | [Download page](https://jdbc.postgresql.org/download/)                                                                                | [Download page](https://repo1.maven.org/maven2/org/postgresql/r2dbc-postgresql/1.0.2.RELEASE/r2dbc-postgresql-1.0.2.RELEASE.jar) |
+| Postgresql           | 18.4           | [Download page](https://jdbc.postgresql.org/download/)                                                                                | [Download page](https://repo1.maven.org/maven2/org/postgresql/r2dbc-postgresql/1.0.2.RELEASE/r2dbc-postgresql-1.0.2.RELEASE.jar) |
 | MySQL                | 8.0            | [Download page](https://dev.mysql.com/downloads/connector/j/)                                                                         | [Download page](https://repo1.maven.org/maven2/io/asyncer/r2dbc-mysql/1.0.2/r2dbc-mysql-1.0.2.jar)                               |
 | MariaDB              | 10.3           | [Download page](https://downloads.mariadb.org/connector-java/)                                                                        | [Download page](https://repo1.maven.org/maven2/org/mariadb/r2dbc-mariadb/1.1.3/r2dbc-mariadb-1.1.3.jar)                          |
 | Microsoft SQL Server | 2017-CU12      | [Download page](https://docs.microsoft.com/en-us/sql/connect/jdbc/download-microsoft-jdbc-driver-for-sql-server?view=sql-server-2017) | [Download page](https://repo1.maven.org/maven2/io/r2dbc/r2dbc-mssql/1.0.0.RELEASE/r2dbc-mssql-1.0.0.RELEASE.jar)                 |


### PR DESCRIPTION
AM is tested on mongo 8.2 and psql 18.4.