### PR TITLE
docs(gamma): pin install guides to floating 4.12 image tags

### DIFF
--- a/docs/gamma/4.12/platform-management/get-started/get-started-for-existing-users/README.md
+++ b/docs/gamma/4.12/platform-management/get-started/get-started-for-existing-users/README.md
@@ -6,7 +6,7 @@ noIndex: false
 
 Gravitee Gamma is Gravitee's next-generation unified control plane. It brings API Management, Event Management, Agent Management, Authorization Management, and Platform Management together in a single console, so you manage your APIs, Kafka streams, AI agents and MCP servers, and authorization policies from one place.
 
-If you already run Gravitee, you turn Gamma on rather than installing from scratch. Activating Gamma means moving to the Gamma build (the `4.12.0` images), enabling Gamma on the Management API, and adding the Gamma console. Choose the page for how you run Gravitee today.
+If you already run Gravitee, you turn Gamma on rather than installing from scratch. Activating Gamma means moving to the Gamma build (the `4.12` images), enabling Gamma on the Management API, and adding the Gamma console. Choose the page for how you run Gravitee today.
 
 ## Choose your path
 

--- a/docs/gamma/4.12/platform-management/get-started/get-started-for-existing-users/activate-gamma-with-docker-compose.md
+++ b/docs/gamma/4.12/platform-management/get-started/get-started-for-existing-users/activate-gamma-with-docker-compose.md
@@ -8,7 +8,7 @@ noIndex: false
 Gravitee Gamma is Gravitee's next-generation unified control plane. It brings API Management, Event Management, Agent Management, Authorization Management, and Platform Management together in a single console, so you manage your APIs, Kafka streams, AI agents and MCP servers, and authorization policies from one place.
 
 {% hint style="warning" %}
-Gamma ships in 4.12 (`4.12.0`). Activating Gamma moves your stack to that build. Use this for development and quick-start purposes only. For best practices for production environments, contact your Technical Account Manager.
+Gamma ships in 4.12. Activating Gamma moves your stack to that build. Use this for development and quick-start purposes only. For best practices for production environments, contact your Technical Account Manager.
 {% endhint %}
 
 ## Overview
@@ -17,7 +17,7 @@ If you already run Gravitee API Management with Docker Compose, you turn Gamma o
 
 ## Activate Gamma
 
-1. Use the Gamma build. Set the image tags for the Management API, Gateway, APIM Console, and Developer Portal to `4.12.0`.
+1. Use the Gamma build. Set the image tags for the Management API, Gateway, APIM Console, and Developer Portal to `4.12`.
 2. Enable Gamma on the Management API. Add the following environment variables to the Management API service. Adjust the CORS origin to the URL where you serve the Gamma console:
 
    ```yaml
@@ -37,7 +37,7 @@ If you already run Gravitee API Management with Docker Compose, you turn Gamma o
 
    ```yaml
    gamma-console:
-     image: graviteeio/gamma-ui:4.12.0
+     image: graviteeio/gamma-ui:4.12
      ports:
        - "8086:8080"
      environment:

--- a/docs/gamma/4.12/platform-management/get-started/get-started-for-existing-users/activate-gamma-with-kubernetes-helm.md
+++ b/docs/gamma/4.12/platform-management/get-started/get-started-for-existing-users/activate-gamma-with-kubernetes-helm.md
@@ -8,7 +8,7 @@ noIndex: false
 Gravitee Gamma is Gravitee's next-generation unified control plane. It brings API Management, Event Management, Agent Management, Authorization Management, and Platform Management together in a single console, so you manage your APIs, Kafka streams, AI agents and MCP servers, and authorization policies from one place.
 
 {% hint style="warning" %}
-Gamma ships in 4.12 (`4.12.0`). Activating Gamma moves your deployment to that build. Use this for development and quick-start purposes only. For best practices for production environments, contact your Technical Account Manager.
+Gamma ships in 4.12. Activating Gamma moves your deployment to that build. Use this for development and quick-start purposes only. For best practices for production environments, contact your Technical Account Manager.
 {% endhint %}
 
 ## Overview
@@ -19,7 +19,7 @@ If you already run Gravitee API Management with the Helm chart, you turn Gamma o
 
 Add the following to your existing `values.yaml`, then run `helm upgrade`.
 
-1. Use the Gamma build. Set the image tags for `api`, `gateway`, `ui`, and `portal` to `4.12.0`.
+1. Use the Gamma build. Set the image tags for `api`, `gateway`, `ui`, and `portal` to `4.12`.
 2. Turn on Gamma:
 
    ```yaml
@@ -49,7 +49,7 @@ Add the following to your existing `values.yaml`, then run `helm upgrade`.
      enabled: true
      image:
        repository: graviteeio/gamma-ui
-       tag: 4.12.0
+       tag: "4.12"
      app:
        gammaBaseURL: "<your host>/gamma"
      env:

--- a/docs/gamma/4.12/platform-management/get-started/get-started-for-new-users/README.md
+++ b/docs/gamma/4.12/platform-management/get-started/get-started-for-new-users/README.md
@@ -16,7 +16,7 @@ If you're new to Gravitee and want to run Gamma, choose the path that fits how y
 
 ## Before you start
 
-Gamma ships in 4.12, so the self-hosted guides use the `4.12.0` images. Agent Management needs an enterprise license that includes the `agent-management` pack. The other modules work without a license. To get a license, contact your Technical Account Manager.
+Gamma ships in 4.12, so the self-hosted guides use the `4.12` images. Agent Management needs an enterprise license that includes the `agent-management` pack. The other modules work without a license. To get a license, contact your Technical Account Manager.
 
 ## Next steps
 

--- a/docs/gamma/4.12/platform-management/install/hybrid-installation-guides/docker/docker-cli.md
+++ b/docs/gamma/4.12/platform-management/install/hybrid-installation-guides/docker/docker-cli.md
@@ -76,7 +76,7 @@ To run the Gateway, complete the following steps:
      -e gravitee_ratelimit_redis_ssl=false \
      -e gravitee_cloud_token=<cloud-token> \
      -e gravitee_license_key=<license-key> \
-     graviteeio/apim-gateway:4.12.0
+     graviteeio/apim-gateway:4.12
    ```
 
    * Replace `<redis-password>` with the password you set for Redis.
@@ -108,7 +108,7 @@ To confirm that your hybrid installation works, complete the following checks:
 
   ```sh
   CONTAINER ID   IMAGE                                   COMMAND                  STATUS         PORTS                      NAMES
-  50016b90785e   graviteeio/apim-gateway:4.12.0   "./bin/gravitee"    Up 2 minutes   0.0.0.0:8082->8082/tcp     gio-gamma-hybrid-gateway
+  50016b90785e   graviteeio/apim-gateway:4.12   "./bin/gravitee"    Up 2 minutes   0.0.0.0:8082->8082/tcp     gio-gamma-hybrid-gateway
   a8d3e6f1c2b4   redis:7.2-alpine                        "redis-server --requ..." Up 2 minutes   0.0.0.0:6379->6379/tcp     gio-gamma-hybrid-redis
   ```
 

--- a/docs/gamma/4.12/platform-management/install/hybrid-installation-guides/docker/docker-compose.md
+++ b/docs/gamma/4.12/platform-management/install/hybrid-installation-guides/docker/docker-compose.md
@@ -47,7 +47,7 @@ To run the Gateway, complete the following steps:
 
    services:
      gio-gamma-hybrid-gateway:
-       image: graviteeio/apim-gateway:${GATEWAY_VERSION:-4.12.0}
+       image: graviteeio/apim-gateway:${GATEWAY_VERSION:-4.12}
        container_name: gio_gamma_hybrid_gateway
        hostname: gamma-gateway
        ports:
@@ -93,7 +93,7 @@ To run the Gateway, complete the following steps:
 
    ```bash
    # We recommend running the same Gateway version as your Gamma control plane, shown in Gravitee Cloud.
-   GATEWAY_VERSION=4.12.0
+   GATEWAY_VERSION=4.12
 
    # Use a Redis version that is supported by Gravitee.
    REDIS_VERSION=7.2-alpine

--- a/docs/gamma/4.12/platform-management/install/hybrid-installation-guides/kubernetes/aws-eks.md
+++ b/docs/gamma/4.12/platform-management/install/hybrid-installation-guides/kubernetes/aws-eks.md
@@ -189,7 +189,7 @@ The Helm values deploy the Gateway only. They disable the control-plane componen
      image:
        # We recommend running the same Gateway version as your Gamma control plane, shown in Gravitee Cloud.
        repository: graviteeio/apim-gateway
-       tag: 4.12.0
+       tag: "4.12"
        pullPolicy: IfNotPresent
      autoscaling:
        enabled: false

--- a/docs/gamma/4.12/platform-management/install/hybrid-installation-guides/kubernetes/azure-aks.md
+++ b/docs/gamma/4.12/platform-management/install/hybrid-installation-guides/kubernetes/azure-aks.md
@@ -126,7 +126,7 @@ The Helm values deploy the Gateway only. They disable the control-plane componen
      image:
        # We recommend running the same Gateway version as your Gamma control plane, shown in Gravitee Cloud.
        repository: graviteeio/apim-gateway
-       tag: 4.12.0
+       tag: "4.12"
        pullPolicy: IfNotPresent
      autoscaling:
        enabled: false

--- a/docs/gamma/4.12/platform-management/install/hybrid-installation-guides/kubernetes/openshift.md
+++ b/docs/gamma/4.12/platform-management/install/hybrid-installation-guides/kubernetes/openshift.md
@@ -105,7 +105,7 @@ The Helm values deploy the Gateway only. They set `openshift.enabled: true`, set
      image:
        # We recommend running the same Gateway version as your Gamma control plane, shown in Gravitee Cloud.
        repository: graviteeio/apim-gateway
-       tag: 4.12.0
+       tag: "4.12"
        pullPolicy: IfNotPresent
      autoscaling:
        enabled: false

--- a/docs/gamma/4.12/platform-management/install/hybrid-installation-guides/kubernetes/vanilla-kubernetes.md
+++ b/docs/gamma/4.12/platform-management/install/hybrid-installation-guides/kubernetes/vanilla-kubernetes.md
@@ -111,7 +111,7 @@ The Helm values deploy the Gateway only. They disable the control-plane componen
      image:
        # We recommend running the same Gateway version as your Gamma control plane, shown in Gravitee Cloud.
        repository: graviteeio/apim-gateway
-       tag: 4.12.0
+       tag: "4.12"
        pullPolicy: IfNotPresent
      autoscaling:
        enabled: false

--- a/docs/gamma/4.12/platform-management/install/self-hosted-installation-guides/docker/docker-cli.md
+++ b/docs/gamma/4.12/platform-management/install/self-hosted-installation-guides/docker/docker-cli.md
@@ -12,7 +12,7 @@ You run the standard APIM containers, turn on Gamma in both the Management API a
 
 Every component is published on `localhost` on its own port. On a single host, `localhost:8084`, `localhost:8086`, and `localhost:8083` are the **same site**, so the login session cookie is sent across ports and the consoles log in. For the detail, see [Why this works on one host](docker-cli.md#why-this-works-on-one-host).
 
-This guide uses the `4.12.0` images, which include the Agent Management module. For more information, see [Add your license key](docker-cli.md#enterprise-edition-only-add-your-license-key).
+This guide uses the `4.12` images, which include the Agent Management module. For more information, see [Add your license key](docker-cli.md#enterprise-edition-only-add-your-license-key).
 
 ## Prerequisites
 
@@ -104,7 +104,7 @@ On macOS, use `base64 -D` (capital `D`) if `base64 -d` returns an error.
       --env gravitee_http_cors_allow-credentials=true \
       --env gravitee_http_cookie_sameSite=Lax \
       --env gravitee_http_cookie_secure=false \
-      graviteeio/apim-management-api:4.12.0
+      graviteeio/apim-management-api:4.12
 
     docker network connect frontend gamma-management-api
     ```
@@ -118,7 +118,7 @@ On macOS, use `base64 -D` (capital `D`) if `base64 -d` returns an error.
       --env gravitee_management_mongodb_uri="mongodb://gamma-mongodb:27017/gravitee?serverSelectionTimeoutMS=5000&connectTimeoutMS=5000&socketTimeoutMS=5000" \
       --env gravitee_ratelimit_mongodb_uri="mongodb://gamma-mongodb:27017/gravitee?serverSelectionTimeoutMS=5000&connectTimeoutMS=5000&socketTimeoutMS=5000" \
       --env gravitee_reporters_elasticsearch_endpoints_0="http://gamma-elasticsearch:9200" \
-      graviteeio/apim-gateway:4.12.0
+      graviteeio/apim-gateway:4.12
 
     docker network connect frontend gamma-gateway
     ```
@@ -136,7 +136,7 @@ The Management API takes a few minutes to initialize. Confirm it's ready with `c
       --net frontend \
       --publish 8084:8080 \
       --env MGMT_API_URL="http://localhost:8083/management/organizations/DEFAULT/environments/DEFAULT/" \
-      graviteeio/apim-management-ui:4.12.0
+      graviteeio/apim-management-ui:4.12
     ```
 2.  Run the Developer Portal:
 
@@ -145,7 +145,7 @@ The Management API takes a few minutes to initialize. Confirm it's ready with `c
       --net frontend \
       --publish 8085:8080 \
       --env PORTAL_API_URL="http://localhost:8083/portal/environments/DEFAULT" \
-      graviteeio/apim-portal-ui:4.12.0
+      graviteeio/apim-portal-ui:4.12
     ```
 3.  Run the Gamma console:
 
@@ -157,7 +157,7 @@ The Management API takes a few minutes to initialize. Confirm it's ready with `c
       --env GAMMA_CONSOLE_BASE_HREF=/ \
       --env HTTP_PORT=8080 \
       --env SERVER_NAME=localhost \
-      graviteeio/gamma-ui:4.12.0
+      graviteeio/gamma-ui:4.12
     ```
 
 ## Access the consoles

--- a/docs/gamma/4.12/platform-management/install/self-hosted-installation-guides/docker/docker-compose.md
+++ b/docs/gamma/4.12/platform-management/install/self-hosted-installation-guides/docker/docker-compose.md
@@ -63,7 +63,7 @@ To run Gamma, complete the following steps:
         networks: [gamma]
 
       gateway:
-        image: graviteeio/apim-gateway:4.12.0
+        image: graviteeio/apim-gateway:4.12
         container_name: gamma_gateway
         restart: unless-stopped
         depends_on: [mongodb, elasticsearch]
@@ -78,7 +78,7 @@ To run Gamma, complete the following steps:
         networks: [gamma]
 
       management_api:
-        image: graviteeio/apim-management-api:4.12.0
+        image: graviteeio/apim-management-api:4.12
         container_name: gamma_management_api
         restart: unless-stopped
         depends_on: [mongodb, elasticsearch]
@@ -114,7 +114,7 @@ To run Gamma, complete the following steps:
         networks: [gamma]
 
       management_ui:
-        image: graviteeio/apim-management-ui:4.12.0
+        image: graviteeio/apim-management-ui:4.12
         container_name: gamma_apim_console
         restart: unless-stopped
         depends_on: [management_api]
@@ -125,7 +125,7 @@ To run Gamma, complete the following steps:
         networks: [gamma]
 
       portal_ui:
-        image: graviteeio/apim-portal-ui:4.12.0
+        image: graviteeio/apim-portal-ui:4.12
         container_name: gamma_portal
         restart: unless-stopped
         depends_on: [management_api]
@@ -136,7 +136,7 @@ To run Gamma, complete the following steps:
         networks: [gamma]
 
       gamma_console:
-        image: graviteeio/gamma-ui:4.12.0
+        image: graviteeio/gamma-ui:4.12
         container_name: gamma_console
         restart: unless-stopped
         depends_on: [management_api]

--- a/docs/gamma/4.12/platform-management/install/self-hosted-installation-guides/kubernetes/aws-eks.md
+++ b/docs/gamma/4.12/platform-management/install/self-hosted-installation-guides/kubernetes/aws-eks.md
@@ -13,7 +13,7 @@ This installation guide is for development and quick-start purposes only. Don't 
 
 This guide explains how to deploy a self-hosted Gravitee Gamma platform on Amazon Elastic Kubernetes Service (EKS) with Helm, fronted by a single AWS Application Load Balancer (ALB).
 
-You deploy the standard `graviteeio/apim` Helm chart, turn on Gamma with `gamma.enabled`, and add the Gamma console (`gammaUi`). This guide uses the `4.12.0` images, which include the Agent Management module.
+You deploy the standard `graviteeio/apim` Helm chart, turn on Gamma with `gamma.enabled`, and add the Gamma console (`gammaUi`). This guide uses the `4.12` images, which include the Agent Management module.
 
 Every component is served on **one hostname** through one ALB: the Gamma console at `/`, and the Management API at `/management`, `/portal`, and `/gamma`. Keeping everything on a single host makes the browser requests same-origin, so the login session cookie is sent and the consoles log in. The whole platform, including the ALB ingress, is defined in a single `values.yaml`.
 
@@ -291,7 +291,7 @@ The Gamma components run as `ClusterIP` services, and the single ALB ingress is 
      enabled: true
      image:
        repository: graviteeio/apim-management-api
-       tag: 4.12.0
+       tag: "4.12"
        pullPolicy: IfNotPresent
      env:
        - name: gravitee_installation_api_url
@@ -344,7 +344,7 @@ The Gamma components run as `ClusterIP` services, and the single ALB ingress is 
      enabled: true
      image:
        repository: graviteeio/apim-gateway
-       tag: 4.12.0
+       tag: "4.12"
        pullPolicy: IfNotPresent
      ingress:
        enabled: false
@@ -353,7 +353,7 @@ The Gamma components run as `ClusterIP` services, and the single ALB ingress is 
      enabled: true
      image:
        repository: graviteeio/apim-management-ui
-       tag: 4.12.0
+       tag: "4.12"
        pullPolicy: IfNotPresent
      ingress:
        enabled: false
@@ -363,7 +363,7 @@ The Gamma components run as `ClusterIP` services, and the single ALB ingress is 
      defaultPortal: "classic"
      image:
        repository: graviteeio/apim-portal-ui
-       tag: 4.12.0
+       tag: "4.12"
        pullPolicy: IfNotPresent
      env:
        - name: PORTAL_BASE_HREF
@@ -375,7 +375,7 @@ The Gamma components run as `ClusterIP` services, and the single ALB ingress is 
      enabled: true
      image:
        repository: graviteeio/gamma-ui
-       tag: 4.12.0
+       tag: "4.12"
        pullPolicy: IfNotPresent
      app:
        gammaBaseURL: "https://gamma.example.com/gamma"

--- a/docs/gamma/4.12/platform-management/install/self-hosted-installation-guides/kubernetes/azure-aks.md
+++ b/docs/gamma/4.12/platform-management/install/self-hosted-installation-guides/kubernetes/azure-aks.md
@@ -13,7 +13,7 @@ This installation guide is for development and quick-start purposes only. Don't 
 
 This guide explains how to deploy a self-hosted Gravitee Gamma platform on Azure Kubernetes Service (AKS) with Helm, fronted by a single NGINX Ingress Controller and an Azure Load Balancer.
 
-You deploy the standard `graviteeio/apim` Helm chart, turn on Gamma with `gamma.enabled`, and add the Gamma console (`gammaUi`). This guide uses the `4.12.0` images, which include the Agent Management module.
+You deploy the standard `graviteeio/apim` Helm chart, turn on Gamma with `gamma.enabled`, and add the Gamma console (`gammaUi`). This guide uses the `4.12` images, which include the Agent Management module.
 
 Every component is served on **one hostname** through one NGINX ingress: the Gamma console at `/`, and the Management API at `/management`, `/portal`, and `/gamma`. Keeping everything on a single host makes the browser requests same-origin, so the login session cookie is sent and the consoles log in. The whole platform, including the ingress, is defined in a single `values.yaml`.
 
@@ -167,7 +167,7 @@ The Gamma components run as `ClusterIP` services, and the single NGINX ingress i
      enabled: true
      image:
        repository: graviteeio/apim-management-api
-       tag: 4.12.0
+       tag: "4.12"
        pullPolicy: IfNotPresent
      env:
        - name: gravitee_installation_api_url
@@ -215,7 +215,7 @@ The Gamma components run as `ClusterIP` services, and the single NGINX ingress i
      enabled: true
      image:
        repository: graviteeio/apim-gateway
-       tag: 4.12.0
+       tag: "4.12"
        pullPolicy: IfNotPresent
      ingress:
        enabled: false
@@ -224,7 +224,7 @@ The Gamma components run as `ClusterIP` services, and the single NGINX ingress i
      enabled: true
      image:
        repository: graviteeio/apim-management-ui
-       tag: 4.12.0
+       tag: "4.12"
        pullPolicy: IfNotPresent
      ingress:
        enabled: false
@@ -234,7 +234,7 @@ The Gamma components run as `ClusterIP` services, and the single NGINX ingress i
      defaultPortal: "classic"
      image:
        repository: graviteeio/apim-portal-ui
-       tag: 4.12.0
+       tag: "4.12"
        pullPolicy: IfNotPresent
      env:
        - name: PORTAL_BASE_HREF
@@ -246,7 +246,7 @@ The Gamma components run as `ClusterIP` services, and the single NGINX ingress i
      enabled: true
      image:
        repository: graviteeio/gamma-ui
-       tag: 4.12.0
+       tag: "4.12"
        pullPolicy: IfNotPresent
      app:
        gammaBaseURL: "http://gamma.example.com/gamma"

--- a/docs/gamma/4.12/platform-management/install/self-hosted-installation-guides/kubernetes/openshift.md
+++ b/docs/gamma/4.12/platform-management/install/self-hosted-installation-guides/kubernetes/openshift.md
@@ -13,7 +13,7 @@ This installation guide is for development and quick-start purposes only. Don't 
 
 This guide explains how to deploy a self-hosted Gravitee Gamma platform on OpenShift with Helm. OpenShift creates a Route from the ingress definition, with edge TLS termination.
 
-You deploy the standard `graviteeio/apim` Helm chart, turn on Gamma with `gamma.enabled`, and add the Gamma console (`gammaUi`). This guide uses the `4.12.0` images, which include the Agent Management module.
+You deploy the standard `graviteeio/apim` Helm chart, turn on Gamma with `gamma.enabled`, and add the Gamma console (`gammaUi`). This guide uses the `4.12` images, which include the Agent Management module.
 
 Every component is served on **one hostname** over HTTPS: the Gamma console at `/`, and the Management API at `/management`, `/portal`, and `/gamma`. Keeping everything on a single host makes the browser requests same-origin, so the login session cookie is sent and the consoles log in. The whole platform, including the ingress, is defined in a single `values.yaml`.
 
@@ -150,7 +150,7 @@ This configuration sets `openshift.enabled: true`, sets `runAsUser: null` so Ope
      enabled: true
      image:
        repository: graviteeio/apim-management-api
-       tag: 4.12.0
+       tag: "4.12"
        pullPolicy: IfNotPresent
      env:
        - name: gravitee_installation_api_url
@@ -199,7 +199,7 @@ This configuration sets `openshift.enabled: true`, sets `runAsUser: null` so Ope
      enabled: true
      image:
        repository: graviteeio/apim-gateway
-       tag: 4.12.0
+       tag: "4.12"
        pullPolicy: IfNotPresent
      ingress:
        enabled: false
@@ -217,7 +217,7 @@ This configuration sets `openshift.enabled: true`, sets `runAsUser: null` so Ope
      enabled: true
      image:
        repository: graviteeio/apim-management-ui
-       tag: 4.12.0
+       tag: "4.12"
        pullPolicy: IfNotPresent
      ingress:
        enabled: false
@@ -236,7 +236,7 @@ This configuration sets `openshift.enabled: true`, sets `runAsUser: null` so Ope
      defaultPortal: "classic"
      image:
        repository: graviteeio/apim-portal-ui
-       tag: 4.12.0
+       tag: "4.12"
        pullPolicy: IfNotPresent
      env:
        - name: PORTAL_BASE_HREF
@@ -257,7 +257,7 @@ This configuration sets `openshift.enabled: true`, sets `runAsUser: null` so Ope
      enabled: true
      image:
        repository: graviteeio/gamma-ui
-       tag: 4.12.0
+       tag: "4.12"
        pullPolicy: IfNotPresent
      app:
        gammaBaseURL: "https://gamma.example.com/gamma"

--- a/docs/gamma/4.12/platform-management/install/self-hosted-installation-guides/kubernetes/vanilla-kubernetes.md
+++ b/docs/gamma/4.12/platform-management/install/self-hosted-installation-guides/kubernetes/vanilla-kubernetes.md
@@ -343,7 +343,7 @@ The Helm values consolidate every console and the API on `gamma.localhost`, poin
       replicaCount: 1
       image:
         repository: graviteeio/apim-management-api
-        tag: 4.12.0
+        tag: "4.12"
         pullPolicy: Always
 
       env:
@@ -431,7 +431,7 @@ The Helm values consolidate every console and the API on `gamma.localhost`, poin
       replicaCount: 1
       image:
         repository: graviteeio/apim-gateway
-        tag: 4.12.0
+        tag: "4.12"
         pullPolicy: Always
 
       service:
@@ -470,7 +470,7 @@ The Helm values consolidate every console and the API on `gamma.localhost`, poin
       replicaCount: 1
       image:
         repository: graviteeio/apim-management-ui
-        tag: 4.12.0
+        tag: "4.12"
         pullPolicy: Always
 
       service:
@@ -503,7 +503,7 @@ The Helm values consolidate every console and the API on `gamma.localhost`, poin
       replicaCount: 1
       image:
         repository: graviteeio/apim-portal-ui
-        tag: 4.12.0
+        tag: "4.12"
         pullPolicy: Always
 
       env:
@@ -538,7 +538,7 @@ The Helm values consolidate every console and the API on `gamma.localhost`, poin
       enabled: true
       image:
         repository: graviteeio/gamma-ui
-        tag: 4.12.0
+        tag: "4.12"
         pullPolicy: Always
       app:
         # URL the Gamma console uses to reach the Gamma API
@@ -660,7 +660,7 @@ The chart that includes Gamma ships as a `4.12` pre-release build for the Gamma 
     &#xNAN;**(Enterprise Edition)** If you created the license secret in [Add your license key](vanilla-kubernetes.md#enterprise-edition-only-add-your-license-key) and uncommented the secret lines in your `values.yaml`, the chart mounts the license automatically. No extra flag is needed.
 
 {% hint style="info" %}
-Gamma ships in evolving `4.12` pre-release builds for the Gamma release, so the exact chart version and image tags move. The image tags in `values.yaml` (`4.12.0`) are the public Docker Hub builds. Pick the current `4.12` chart version from the `helm search` output, and keep the release name `gamma` so the service names in the next step match.
+Gamma ships in evolving `4.12` pre-release builds for the Gamma release, so the exact chart version and image tags move. The image tags in `values.yaml` (`4.12`) are the public Docker Hub builds. Pick the current `4.12` chart version from the `helm search` output, and keep the release name `gamma` so the service names in the next step match.
 {% endhint %}
 
 ## Access the consoles

--- a/docs/gamma/4.13/platform-management/get-started/get-started-for-existing-users/README.md
+++ b/docs/gamma/4.13/platform-management/get-started/get-started-for-existing-users/README.md
@@ -6,7 +6,7 @@ noIndex: false
 
 Gravitee Gamma is Gravitee's next-generation unified control plane. It brings API Management, Event Management, Agent Management, Authorization Management, and Platform Management together in a single console, so you manage your APIs, Kafka streams, AI agents and MCP servers, and authorization policies from one place.
 
-If you already run Gravitee, you turn Gamma on rather than installing from scratch. Activating Gamma means moving to the Gamma build (the `4.12.0` images), enabling Gamma on the Management API, and adding the Gamma console. Choose the page for how you run Gravitee today.
+If you already run Gravitee, you turn Gamma on rather than installing from scratch. Activating Gamma means moving to the Gamma build (the `4.12` images), enabling Gamma on the Management API, and adding the Gamma console. Choose the page for how you run Gravitee today.
 
 ## Choose your path
 

--- a/docs/gamma/4.13/platform-management/get-started/get-started-for-existing-users/activate-gamma-with-docker-compose.md
+++ b/docs/gamma/4.13/platform-management/get-started/get-started-for-existing-users/activate-gamma-with-docker-compose.md
@@ -8,7 +8,7 @@ noIndex: false
 Gravitee Gamma is Gravitee's next-generation unified control plane. It brings API Management, Event Management, Agent Management, Authorization Management, and Platform Management together in a single console, so you manage your APIs, Kafka streams, AI agents and MCP servers, and authorization policies from one place.
 
 {% hint style="warning" %}
-Gamma ships in 4.12 (`4.12.0`). Activating Gamma moves your stack to that build. Use this for development and quick-start purposes only. For best practices for production environments, contact your Technical Account Manager.
+Gamma ships in 4.12. Activating Gamma moves your stack to that build. Use this for development and quick-start purposes only. For best practices for production environments, contact your Technical Account Manager.
 {% endhint %}
 
 ## Overview
@@ -17,7 +17,7 @@ If you already run Gravitee API Management with Docker Compose, you turn Gamma o
 
 ## Activate Gamma
 
-1. Use the Gamma build. Set the image tags for the Management API, Gateway, APIM Console, and Developer Portal to `4.12.0`.
+1. Use the Gamma build. Set the image tags for the Management API, Gateway, APIM Console, and Developer Portal to `4.12`.
 2. Enable Gamma on the Management API. Add the following environment variables to the Management API service. Adjust the CORS origin to the URL where you serve the Gamma console:
 
    ```yaml
@@ -37,7 +37,7 @@ If you already run Gravitee API Management with Docker Compose, you turn Gamma o
 
    ```yaml
    gamma-console:
-     image: graviteeio/gamma-ui:4.12.0
+     image: graviteeio/gamma-ui:4.12
      ports:
        - "8086:8080"
      environment:

--- a/docs/gamma/4.13/platform-management/get-started/get-started-for-existing-users/activate-gamma-with-kubernetes-helm.md
+++ b/docs/gamma/4.13/platform-management/get-started/get-started-for-existing-users/activate-gamma-with-kubernetes-helm.md
@@ -8,7 +8,7 @@ noIndex: false
 Gravitee Gamma is Gravitee's next-generation unified control plane. It brings API Management, Event Management, Agent Management, Authorization Management, and Platform Management together in a single console, so you manage your APIs, Kafka streams, AI agents and MCP servers, and authorization policies from one place.
 
 {% hint style="warning" %}
-Gamma ships in 4.12 (`4.12.0`). Activating Gamma moves your deployment to that build. Use this for development and quick-start purposes only. For best practices for production environments, contact your Technical Account Manager.
+Gamma ships in 4.12. Activating Gamma moves your deployment to that build. Use this for development and quick-start purposes only. For best practices for production environments, contact your Technical Account Manager.
 {% endhint %}
 
 ## Overview
@@ -19,7 +19,7 @@ If you already run Gravitee API Management with the Helm chart, you turn Gamma o
 
 Add the following to your existing `values.yaml`, then run `helm upgrade`.
 
-1. Use the Gamma build. Set the image tags for `api`, `gateway`, `ui`, and `portal` to `4.12.0`.
+1. Use the Gamma build. Set the image tags for `api`, `gateway`, `ui`, and `portal` to `4.12`.
 2. Turn on Gamma:
 
    ```yaml
@@ -49,7 +49,7 @@ Add the following to your existing `values.yaml`, then run `helm upgrade`.
      enabled: true
      image:
        repository: graviteeio/gamma-ui
-       tag: 4.12.0
+       tag: "4.12"
      app:
        gammaBaseURL: "<your host>/gamma"
      env:

--- a/docs/gamma/4.13/platform-management/get-started/get-started-for-new-users/README.md
+++ b/docs/gamma/4.13/platform-management/get-started/get-started-for-new-users/README.md
@@ -16,7 +16,7 @@ If you're new to Gravitee and want to run Gamma, choose the path that fits how y
 
 ## Before you start
 
-Gamma ships in 4.12, so the self-hosted guides use the `4.12.0` images. Agent Management needs an enterprise license that includes the `agent-management` pack. The other modules work without a license. To get a license, contact your Technical Account Manager.
+Gamma ships in 4.12, so the self-hosted guides use the `4.12` images. Agent Management needs an enterprise license that includes the `agent-management` pack. The other modules work without a license. To get a license, contact your Technical Account Manager.
 
 ## Next steps
 

--- a/docs/gamma/4.13/platform-management/install/hybrid-installation-guides/docker/docker-cli.md
+++ b/docs/gamma/4.13/platform-management/install/hybrid-installation-guides/docker/docker-cli.md
@@ -76,7 +76,7 @@ To run the Gateway, complete the following steps:
      -e gravitee_ratelimit_redis_ssl=false \
      -e gravitee_cloud_token=<cloud-token> \
      -e gravitee_license_key=<license-key> \
-     graviteeio/apim-gateway:4.12.0
+     graviteeio/apim-gateway:4.12
    ```
 
    * Replace `<redis-password>` with the password you set for Redis.
@@ -108,7 +108,7 @@ To confirm that your hybrid installation works, complete the following checks:
 
   ```sh
   CONTAINER ID   IMAGE                                   COMMAND                  STATUS         PORTS                      NAMES
-  50016b90785e   graviteeio/apim-gateway:4.12.0   "./bin/gravitee"    Up 2 minutes   0.0.0.0:8082->8082/tcp     gio-gamma-hybrid-gateway
+  50016b90785e   graviteeio/apim-gateway:4.12   "./bin/gravitee"    Up 2 minutes   0.0.0.0:8082->8082/tcp     gio-gamma-hybrid-gateway
   a8d3e6f1c2b4   redis:7.2-alpine                        "redis-server --requ..." Up 2 minutes   0.0.0.0:6379->6379/tcp     gio-gamma-hybrid-redis
   ```
 

--- a/docs/gamma/4.13/platform-management/install/hybrid-installation-guides/docker/docker-compose.md
+++ b/docs/gamma/4.13/platform-management/install/hybrid-installation-guides/docker/docker-compose.md
@@ -47,7 +47,7 @@ To run the Gateway, complete the following steps:
 
    services:
      gio-gamma-hybrid-gateway:
-       image: graviteeio/apim-gateway:${GATEWAY_VERSION:-4.12.0}
+       image: graviteeio/apim-gateway:${GATEWAY_VERSION:-4.12}
        container_name: gio_gamma_hybrid_gateway
        hostname: gamma-gateway
        ports:
@@ -93,7 +93,7 @@ To run the Gateway, complete the following steps:
 
    ```bash
    # We recommend running the same Gateway version as your Gamma control plane, shown in Gravitee Cloud.
-   GATEWAY_VERSION=4.12.0
+   GATEWAY_VERSION=4.12
 
    # Use a Redis version that is supported by Gravitee.
    REDIS_VERSION=7.2-alpine

--- a/docs/gamma/4.13/platform-management/install/hybrid-installation-guides/kubernetes/aws-eks.md
+++ b/docs/gamma/4.13/platform-management/install/hybrid-installation-guides/kubernetes/aws-eks.md
@@ -189,7 +189,7 @@ The Helm values deploy the Gateway only. They disable the control-plane componen
      image:
        # We recommend running the same Gateway version as your Gamma control plane, shown in Gravitee Cloud.
        repository: graviteeio/apim-gateway
-       tag: 4.12.0
+       tag: "4.12"
        pullPolicy: IfNotPresent
      autoscaling:
        enabled: false

--- a/docs/gamma/4.13/platform-management/install/hybrid-installation-guides/kubernetes/azure-aks.md
+++ b/docs/gamma/4.13/platform-management/install/hybrid-installation-guides/kubernetes/azure-aks.md
@@ -126,7 +126,7 @@ The Helm values deploy the Gateway only. They disable the control-plane componen
      image:
        # We recommend running the same Gateway version as your Gamma control plane, shown in Gravitee Cloud.
        repository: graviteeio/apim-gateway
-       tag: 4.12.0
+       tag: "4.12"
        pullPolicy: IfNotPresent
      autoscaling:
        enabled: false

--- a/docs/gamma/4.13/platform-management/install/hybrid-installation-guides/kubernetes/openshift.md
+++ b/docs/gamma/4.13/platform-management/install/hybrid-installation-guides/kubernetes/openshift.md
@@ -105,7 +105,7 @@ The Helm values deploy the Gateway only. They set `openshift.enabled: true`, set
      image:
        # We recommend running the same Gateway version as your Gamma control plane, shown in Gravitee Cloud.
        repository: graviteeio/apim-gateway
-       tag: 4.12.0
+       tag: "4.12"
        pullPolicy: IfNotPresent
      autoscaling:
        enabled: false

--- a/docs/gamma/4.13/platform-management/install/hybrid-installation-guides/kubernetes/vanilla-kubernetes.md
+++ b/docs/gamma/4.13/platform-management/install/hybrid-installation-guides/kubernetes/vanilla-kubernetes.md
@@ -111,7 +111,7 @@ The Helm values deploy the Gateway only. They disable the control-plane componen
      image:
        # We recommend running the same Gateway version as your Gamma control plane, shown in Gravitee Cloud.
        repository: graviteeio/apim-gateway
-       tag: 4.12.0
+       tag: "4.12"
        pullPolicy: IfNotPresent
      autoscaling:
        enabled: false

--- a/docs/gamma/4.13/platform-management/install/self-hosted-installation-guides/docker/docker-cli.md
+++ b/docs/gamma/4.13/platform-management/install/self-hosted-installation-guides/docker/docker-cli.md
@@ -12,7 +12,7 @@ You run the standard APIM containers, turn on Gamma in both the Management API a
 
 Every component is published on `localhost` on its own port. On a single host, `localhost:8084`, `localhost:8086`, and `localhost:8083` are the **same site**, so the login session cookie is sent across ports and the consoles log in. For the detail, see [Why this works on one host](docker-cli.md#why-this-works-on-one-host).
 
-This guide uses the `4.12.0` images, which include the Agent Management module. For more information, see [Add your license key](docker-cli.md#enterprise-edition-only-add-your-license-key).
+This guide uses the `4.12` images, which include the Agent Management module. For more information, see [Add your license key](docker-cli.md#enterprise-edition-only-add-your-license-key).
 
 ## Prerequisites
 
@@ -104,7 +104,7 @@ On macOS, use `base64 -D` (capital `D`) if `base64 -d` returns an error.
       --env gravitee_http_cors_allow-credentials=true \
       --env gravitee_http_cookie_sameSite=Lax \
       --env gravitee_http_cookie_secure=false \
-      graviteeio/apim-management-api:4.12.0
+      graviteeio/apim-management-api:4.12
 
     docker network connect frontend gamma-management-api
     ```
@@ -118,7 +118,7 @@ On macOS, use `base64 -D` (capital `D`) if `base64 -d` returns an error.
       --env gravitee_management_mongodb_uri="mongodb://gamma-mongodb:27017/gravitee?serverSelectionTimeoutMS=5000&connectTimeoutMS=5000&socketTimeoutMS=5000" \
       --env gravitee_ratelimit_mongodb_uri="mongodb://gamma-mongodb:27017/gravitee?serverSelectionTimeoutMS=5000&connectTimeoutMS=5000&socketTimeoutMS=5000" \
       --env gravitee_reporters_elasticsearch_endpoints_0="http://gamma-elasticsearch:9200" \
-      graviteeio/apim-gateway:4.12.0
+      graviteeio/apim-gateway:4.12
 
     docker network connect frontend gamma-gateway
     ```
@@ -136,7 +136,7 @@ The Management API takes a few minutes to initialize. Confirm it's ready with `c
       --net frontend \
       --publish 8084:8080 \
       --env MGMT_API_URL="http://localhost:8083/management/organizations/DEFAULT/environments/DEFAULT/" \
-      graviteeio/apim-management-ui:4.12.0
+      graviteeio/apim-management-ui:4.12
     ```
 2.  Run the Developer Portal:
 
@@ -145,7 +145,7 @@ The Management API takes a few minutes to initialize. Confirm it's ready with `c
       --net frontend \
       --publish 8085:8080 \
       --env PORTAL_API_URL="http://localhost:8083/portal/environments/DEFAULT" \
-      graviteeio/apim-portal-ui:4.12.0
+      graviteeio/apim-portal-ui:4.12
     ```
 3.  Run the Gamma console:
 
@@ -157,7 +157,7 @@ The Management API takes a few minutes to initialize. Confirm it's ready with `c
       --env GAMMA_CONSOLE_BASE_HREF=/ \
       --env HTTP_PORT=8080 \
       --env SERVER_NAME=localhost \
-      graviteeio/gamma-ui:4.12.0
+      graviteeio/gamma-ui:4.12
     ```
 
 ## Access the consoles

--- a/docs/gamma/4.13/platform-management/install/self-hosted-installation-guides/docker/docker-compose.md
+++ b/docs/gamma/4.13/platform-management/install/self-hosted-installation-guides/docker/docker-compose.md
@@ -63,7 +63,7 @@ To run Gamma, complete the following steps:
         networks: [gamma]
 
       gateway:
-        image: graviteeio/apim-gateway:4.12.0
+        image: graviteeio/apim-gateway:4.12
         container_name: gamma_gateway
         restart: unless-stopped
         depends_on: [mongodb, elasticsearch]
@@ -78,7 +78,7 @@ To run Gamma, complete the following steps:
         networks: [gamma]
 
       management_api:
-        image: graviteeio/apim-management-api:4.12.0
+        image: graviteeio/apim-management-api:4.12
         container_name: gamma_management_api
         restart: unless-stopped
         depends_on: [mongodb, elasticsearch]
@@ -114,7 +114,7 @@ To run Gamma, complete the following steps:
         networks: [gamma]
 
       management_ui:
-        image: graviteeio/apim-management-ui:4.12.0
+        image: graviteeio/apim-management-ui:4.12
         container_name: gamma_apim_console
         restart: unless-stopped
         depends_on: [management_api]
@@ -125,7 +125,7 @@ To run Gamma, complete the following steps:
         networks: [gamma]
 
       portal_ui:
-        image: graviteeio/apim-portal-ui:4.12.0
+        image: graviteeio/apim-portal-ui:4.12
         container_name: gamma_portal
         restart: unless-stopped
         depends_on: [management_api]
@@ -136,7 +136,7 @@ To run Gamma, complete the following steps:
         networks: [gamma]
 
       gamma_console:
-        image: graviteeio/gamma-ui:4.12.0
+        image: graviteeio/gamma-ui:4.12
         container_name: gamma_console
         restart: unless-stopped
         depends_on: [management_api]

--- a/docs/gamma/4.13/platform-management/install/self-hosted-installation-guides/kubernetes/aws-eks.md
+++ b/docs/gamma/4.13/platform-management/install/self-hosted-installation-guides/kubernetes/aws-eks.md
@@ -13,7 +13,7 @@ This installation guide is for development and quick-start purposes only. Don't 
 
 This guide explains how to deploy a self-hosted Gravitee Gamma platform on Amazon Elastic Kubernetes Service (EKS) with Helm, fronted by a single AWS Application Load Balancer (ALB).
 
-You deploy the standard `graviteeio/apim` Helm chart, turn on Gamma with `gamma.enabled`, and add the Gamma console (`gammaUi`). This guide uses the `4.12.0` images, which include the Agent Management module.
+You deploy the standard `graviteeio/apim` Helm chart, turn on Gamma with `gamma.enabled`, and add the Gamma console (`gammaUi`). This guide uses the `4.12` images, which include the Agent Management module.
 
 Every component is served on **one hostname** through one ALB: the Gamma console at `/`, and the Management API at `/management`, `/portal`, and `/gamma`. Keeping everything on a single host makes the browser requests same-origin, so the login session cookie is sent and the consoles log in. The whole platform, including the ALB ingress, is defined in a single `values.yaml`.
 
@@ -291,7 +291,7 @@ The Gamma components run as `ClusterIP` services, and the single ALB ingress is 
      enabled: true
      image:
        repository: graviteeio/apim-management-api
-       tag: 4.12.0
+       tag: "4.12"
        pullPolicy: IfNotPresent
      env:
        - name: gravitee_installation_api_url
@@ -344,7 +344,7 @@ The Gamma components run as `ClusterIP` services, and the single ALB ingress is 
      enabled: true
      image:
        repository: graviteeio/apim-gateway
-       tag: 4.12.0
+       tag: "4.12"
        pullPolicy: IfNotPresent
      ingress:
        enabled: false
@@ -353,7 +353,7 @@ The Gamma components run as `ClusterIP` services, and the single ALB ingress is 
      enabled: true
      image:
        repository: graviteeio/apim-management-ui
-       tag: 4.12.0
+       tag: "4.12"
        pullPolicy: IfNotPresent
      ingress:
        enabled: false
@@ -363,7 +363,7 @@ The Gamma components run as `ClusterIP` services, and the single ALB ingress is 
      defaultPortal: "classic"
      image:
        repository: graviteeio/apim-portal-ui
-       tag: 4.12.0
+       tag: "4.12"
        pullPolicy: IfNotPresent
      env:
        - name: PORTAL_BASE_HREF
@@ -375,7 +375,7 @@ The Gamma components run as `ClusterIP` services, and the single ALB ingress is 
      enabled: true
      image:
        repository: graviteeio/gamma-ui
-       tag: 4.12.0
+       tag: "4.12"
        pullPolicy: IfNotPresent
      app:
        gammaBaseURL: "https://gamma.example.com/gamma"

--- a/docs/gamma/4.13/platform-management/install/self-hosted-installation-guides/kubernetes/azure-aks.md
+++ b/docs/gamma/4.13/platform-management/install/self-hosted-installation-guides/kubernetes/azure-aks.md
@@ -13,7 +13,7 @@ This installation guide is for development and quick-start purposes only. Don't 
 
 This guide explains how to deploy a self-hosted Gravitee Gamma platform on Azure Kubernetes Service (AKS) with Helm, fronted by a single NGINX Ingress Controller and an Azure Load Balancer.
 
-You deploy the standard `graviteeio/apim` Helm chart, turn on Gamma with `gamma.enabled`, and add the Gamma console (`gammaUi`). This guide uses the `4.12.0` images, which include the Agent Management module.
+You deploy the standard `graviteeio/apim` Helm chart, turn on Gamma with `gamma.enabled`, and add the Gamma console (`gammaUi`). This guide uses the `4.12` images, which include the Agent Management module.
 
 Every component is served on **one hostname** through one NGINX ingress: the Gamma console at `/`, and the Management API at `/management`, `/portal`, and `/gamma`. Keeping everything on a single host makes the browser requests same-origin, so the login session cookie is sent and the consoles log in. The whole platform, including the ingress, is defined in a single `values.yaml`.
 
@@ -167,7 +167,7 @@ The Gamma components run as `ClusterIP` services, and the single NGINX ingress i
      enabled: true
      image:
        repository: graviteeio/apim-management-api
-       tag: 4.12.0
+       tag: "4.12"
        pullPolicy: IfNotPresent
      env:
        - name: gravitee_installation_api_url
@@ -215,7 +215,7 @@ The Gamma components run as `ClusterIP` services, and the single NGINX ingress i
      enabled: true
      image:
        repository: graviteeio/apim-gateway
-       tag: 4.12.0
+       tag: "4.12"
        pullPolicy: IfNotPresent
      ingress:
        enabled: false
@@ -224,7 +224,7 @@ The Gamma components run as `ClusterIP` services, and the single NGINX ingress i
      enabled: true
      image:
        repository: graviteeio/apim-management-ui
-       tag: 4.12.0
+       tag: "4.12"
        pullPolicy: IfNotPresent
      ingress:
        enabled: false
@@ -234,7 +234,7 @@ The Gamma components run as `ClusterIP` services, and the single NGINX ingress i
      defaultPortal: "classic"
      image:
        repository: graviteeio/apim-portal-ui
-       tag: 4.12.0
+       tag: "4.12"
        pullPolicy: IfNotPresent
      env:
        - name: PORTAL_BASE_HREF
@@ -246,7 +246,7 @@ The Gamma components run as `ClusterIP` services, and the single NGINX ingress i
      enabled: true
      image:
        repository: graviteeio/gamma-ui
-       tag: 4.12.0
+       tag: "4.12"
        pullPolicy: IfNotPresent
      app:
        gammaBaseURL: "http://gamma.example.com/gamma"

--- a/docs/gamma/4.13/platform-management/install/self-hosted-installation-guides/kubernetes/openshift.md
+++ b/docs/gamma/4.13/platform-management/install/self-hosted-installation-guides/kubernetes/openshift.md
@@ -13,7 +13,7 @@ This installation guide is for development and quick-start purposes only. Don't 
 
 This guide explains how to deploy a self-hosted Gravitee Gamma platform on OpenShift with Helm. OpenShift creates a Route from the ingress definition, with edge TLS termination.
 
-You deploy the standard `graviteeio/apim` Helm chart, turn on Gamma with `gamma.enabled`, and add the Gamma console (`gammaUi`). This guide uses the `4.12.0` images, which include the Agent Management module.
+You deploy the standard `graviteeio/apim` Helm chart, turn on Gamma with `gamma.enabled`, and add the Gamma console (`gammaUi`). This guide uses the `4.12` images, which include the Agent Management module.
 
 Every component is served on **one hostname** over HTTPS: the Gamma console at `/`, and the Management API at `/management`, `/portal`, and `/gamma`. Keeping everything on a single host makes the browser requests same-origin, so the login session cookie is sent and the consoles log in. The whole platform, including the ingress, is defined in a single `values.yaml`.
 
@@ -150,7 +150,7 @@ This configuration sets `openshift.enabled: true`, sets `runAsUser: null` so Ope
      enabled: true
      image:
        repository: graviteeio/apim-management-api
-       tag: 4.12.0
+       tag: "4.12"
        pullPolicy: IfNotPresent
      env:
        - name: gravitee_installation_api_url
@@ -199,7 +199,7 @@ This configuration sets `openshift.enabled: true`, sets `runAsUser: null` so Ope
      enabled: true
      image:
        repository: graviteeio/apim-gateway
-       tag: 4.12.0
+       tag: "4.12"
        pullPolicy: IfNotPresent
      ingress:
        enabled: false
@@ -217,7 +217,7 @@ This configuration sets `openshift.enabled: true`, sets `runAsUser: null` so Ope
      enabled: true
      image:
        repository: graviteeio/apim-management-ui
-       tag: 4.12.0
+       tag: "4.12"
        pullPolicy: IfNotPresent
      ingress:
        enabled: false
@@ -236,7 +236,7 @@ This configuration sets `openshift.enabled: true`, sets `runAsUser: null` so Ope
      defaultPortal: "classic"
      image:
        repository: graviteeio/apim-portal-ui
-       tag: 4.12.0
+       tag: "4.12"
        pullPolicy: IfNotPresent
      env:
        - name: PORTAL_BASE_HREF
@@ -257,7 +257,7 @@ This configuration sets `openshift.enabled: true`, sets `runAsUser: null` so Ope
      enabled: true
      image:
        repository: graviteeio/gamma-ui
-       tag: 4.12.0
+       tag: "4.12"
        pullPolicy: IfNotPresent
      app:
        gammaBaseURL: "https://gamma.example.com/gamma"

--- a/docs/gamma/4.13/platform-management/install/self-hosted-installation-guides/kubernetes/vanilla-kubernetes.md
+++ b/docs/gamma/4.13/platform-management/install/self-hosted-installation-guides/kubernetes/vanilla-kubernetes.md
@@ -343,7 +343,7 @@ The Helm values consolidate every console and the API on `gamma.localhost`, poin
       replicaCount: 1
       image:
         repository: graviteeio/apim-management-api
-        tag: 4.12.0
+        tag: "4.12"
         pullPolicy: Always
 
       env:
@@ -431,7 +431,7 @@ The Helm values consolidate every console and the API on `gamma.localhost`, poin
       replicaCount: 1
       image:
         repository: graviteeio/apim-gateway
-        tag: 4.12.0
+        tag: "4.12"
         pullPolicy: Always
 
       service:
@@ -470,7 +470,7 @@ The Helm values consolidate every console and the API on `gamma.localhost`, poin
       replicaCount: 1
       image:
         repository: graviteeio/apim-management-ui
-        tag: 4.12.0
+        tag: "4.12"
         pullPolicy: Always
 
       service:
@@ -503,7 +503,7 @@ The Helm values consolidate every console and the API on `gamma.localhost`, poin
       replicaCount: 1
       image:
         repository: graviteeio/apim-portal-ui
-        tag: 4.12.0
+        tag: "4.12"
         pullPolicy: Always
 
       env:
@@ -538,7 +538,7 @@ The Helm values consolidate every console and the API on `gamma.localhost`, poin
       enabled: true
       image:
         repository: graviteeio/gamma-ui
-        tag: 4.12.0
+        tag: "4.12"
         pullPolicy: Always
       app:
         # URL the Gamma console uses to reach the Gamma API
@@ -660,7 +660,7 @@ The chart that includes Gamma ships as a `4.12` pre-release build for the Gamma 
     &#xNAN;**(Enterprise Edition)** If you created the license secret in [Add your license key](vanilla-kubernetes.md#enterprise-edition-only-add-your-license-key) and uncommented the secret lines in your `values.yaml`, the chart mounts the license automatically. No extra flag is needed.
 
 {% hint style="info" %}
-Gamma ships in evolving `4.12` pre-release builds for the Gamma release, so the exact chart version and image tags move. The image tags in `values.yaml` (`4.12.0`) are the public Docker Hub builds. Pick the current `4.12` chart version from the `helm search` output, and keep the release name `gamma` so the service names in the next step match.
+Gamma ships in evolving `4.12` pre-release builds for the Gamma release, so the exact chart version and image tags move. The image tags in `values.yaml` (`4.12`) are the public Docker Hub builds. Pick the current `4.12` chart version from the `helm search` output, and keep the release name `gamma` so the service names in the next step match.
 {% endhint %}
 
 ## Access the consoles

--- a/vale/styles/config/vocabularies/docs/accept.txt
+++ b/vale/styles/config/vocabularies/docs/accept.txt
@@ -11,7 +11,7 @@ Cockpit
 Blackbird
 DevPortal
 [Dd]ev
-GRAVITEEIO
+[Gg][Rr][Aa][Vv][Ii][Tt][Ee][Ee][Ii][Oo]
 mAPI
 Gravitee API Management
 Gravitee Access Management

--- a/vale/styles/config/vocabularies/docs/accept.txt
+++ b/vale/styles/config/vocabularies/docs/accept.txt
@@ -527,6 +527,8 @@ Intune
 # Gamma Platform
 # ============================================
 Gamma
+# Docker image identifier (lowercase, case-sensitive), not the "Gamma" product name
+gamma-ui
 [Aa]gentic
 [Hh]yperscaler
 [Hh]yperscaler-[Ff]ederated


### PR DESCRIPTION
Replace fixed 4.12.0 image pins with the floating 4.12 minor tag across all Gamma self-hosted and hybrid install guides and the activate-gamma get-started pages, in both the 4.12 and 4.13 docs folders. Readers get the latest 4.12 patch (currently 4.12.11, verified from Docker Hub) without per-patch doc churn, while staying within the tested minor line.

- image:/CLI/compose tags graviteeio/*:4.12.0 -> :4.12
- Helm values tag: 4.12.0 -> tag: "4.12" (quoted to avoid YAML float parsing)
- ${GATEWAY_VERSION:-4.12.0} default and GATEWAY_VERSION=4.12.0 example -> 4.12
- prose references to the 4.12.0 images -> 4.12
- Helm chart --version 4.12.0 left unchanged (chart channel, not an image)