### PR TITLE
docs(gamma): remove 'to be published' placeholder markers from Event Stream Management

### DIFF
--- a/docs/gamma/4.12/event-stream-management/build/kafka-virtual-cluster-runtime-behavior-reference.md
+++ b/docs/gamma/4.12/event-stream-management/build/kafka-virtual-cluster-runtime-behavior-reference.md
@@ -2,7 +2,6 @@
 hidden: false
 noIndex: false
 ---
-<-- to be published -->
 # Virtual Cluster runtime behavior
 <!-- GAP-STRUCTURAL: Missing procedural content source -->
 

--- a/docs/gamma/4.12/event-stream-management/build/kafka-virtual-clusters-overview.md
+++ b/docs/gamma/4.12/event-stream-management/build/kafka-virtual-clusters-overview.md
@@ -2,7 +2,6 @@
 hidden: false
 noIndex: false
 ---
-<-- to be published -->
 # Virtual Clusters overview
 
 A Virtual Cluster federates multiple independent Kafka backends into a single unified cluster endpoint. Client applications connect to one address and interact with topics spread across any number of underlying Registered Clusters — without needing to know which backend owns which topic.

--- a/docs/gamma/4.12/event-stream-management/get-started/README.md
+++ b/docs/gamma/4.12/event-stream-management/get-started/README.md
@@ -4,7 +4,6 @@ noIndex: false
 ---
 
 # Get started
-<-- to be published -->
 New to Event Stream Management in Gamma? Start here.
 
 * [**Event Stream Management overview**](event-stream-management-overview.md) — What Event Stream Management does and how it fits into the Gamma platform.

--- a/docs/gamma/4.12/event-stream-management/get-started/create-your-first-kafka-service.md
+++ b/docs/gamma/4.12/event-stream-management/get-started/create-your-first-kafka-service.md
@@ -2,7 +2,6 @@
 hidden: false
 noIndex: false
 ---
-<-- to be published -->
 # Create your first Kafka service
 <!-- Source: gravitee-gamma-module-esm/src/main/ui/features/kafka-apis/components/create/CreateNativeApiWizard.tsx -->
 

--- a/docs/gamma/4.12/event-stream-management/get-started/event-stream-management-overview.md
+++ b/docs/gamma/4.12/event-stream-management/get-started/event-stream-management-overview.md
@@ -2,7 +2,6 @@
 hidden: false
 noIndex: false
 ---
-<-- to be published -->
 # Event Stream Management overview
 
 Event Stream Management is Gravitee's product line for governing Kafka clusters, event-driven data flows, and streaming infrastructure. Within Gamma, Event Stream Management provides a dedicated console for registering Kafka clusters, creating governed Kafka Services, and provisioning Virtual Clusters for multi-tenant isolation.

--- a/docs/gamma/4.12/event-stream-management/get-started/register-your-first-cluster.md
+++ b/docs/gamma/4.12/event-stream-management/get-started/register-your-first-cluster.md
@@ -2,7 +2,6 @@
 hidden: false
 noIndex: false
 ---
-<-- to be published -->
 # Register your first cluster
 <!-- Source: gravitee-gamma-module-esm/src/main/ui/features/clusters/components/create/CreateClusterWizard.tsx -->
 

--- a/docs/gamma/4.12/event-stream-management/import/README.md
+++ b/docs/gamma/4.12/event-stream-management/import/README.md
@@ -2,7 +2,6 @@
 hidden: false
 noIndex: false
 ---
-<-- to be published -->
 # Import
 
 Register your existing Kafka infrastructure with Gamma so it can be governed, monitored, and composed into higher-level services.

--- a/docs/gamma/4.13/event-stream-management/build/kafka-virtual-cluster-runtime-behavior-reference.md
+++ b/docs/gamma/4.13/event-stream-management/build/kafka-virtual-cluster-runtime-behavior-reference.md
@@ -2,7 +2,6 @@
 hidden: false
 noIndex: false
 ---
-<-- to be published -->
 # Virtual Cluster runtime behavior
 <!-- GAP-STRUCTURAL: Missing procedural content source -->
 

--- a/docs/gamma/4.13/event-stream-management/build/kafka-virtual-clusters-overview.md
+++ b/docs/gamma/4.13/event-stream-management/build/kafka-virtual-clusters-overview.md
@@ -2,7 +2,6 @@
 hidden: false
 noIndex: false
 ---
-<-- to be published -->
 # Virtual Clusters overview
 
 A Virtual Cluster federates multiple independent Kafka backends into a single unified cluster endpoint. Client applications connect to one address and interact with topics spread across any number of underlying Registered Clusters — without needing to know which backend owns which topic.

--- a/docs/gamma/4.13/event-stream-management/get-started/README.md
+++ b/docs/gamma/4.13/event-stream-management/get-started/README.md
@@ -4,7 +4,6 @@ noIndex: false
 ---
 
 # Get started
-<-- to be published -->
 New to Event Stream Management in Gamma? Start here.
 
 * [**Event Stream Management overview**](event-stream-management-overview.md) — What Event Stream Management does and how it fits into the Gamma platform.

--- a/docs/gamma/4.13/event-stream-management/get-started/create-your-first-kafka-service.md
+++ b/docs/gamma/4.13/event-stream-management/get-started/create-your-first-kafka-service.md
@@ -2,7 +2,6 @@
 hidden: false
 noIndex: false
 ---
-<-- to be published -->
 # Create your first Kafka service
 <!-- Source: gravitee-gamma-module-esm/src/main/ui/features/kafka-apis/components/create/CreateNativeApiWizard.tsx -->
 

--- a/docs/gamma/4.13/event-stream-management/get-started/event-stream-management-overview.md
+++ b/docs/gamma/4.13/event-stream-management/get-started/event-stream-management-overview.md
@@ -2,7 +2,6 @@
 hidden: false
 noIndex: false
 ---
-<-- to be published -->
 # Event Stream Management overview
 
 Event Stream Management is Gravitee's product line for governing Kafka clusters, event-driven data flows, and streaming infrastructure. Within Gamma, Event Stream Management provides a dedicated console for registering Kafka clusters, creating governed Kafka Services, and provisioning Virtual Clusters for multi-tenant isolation.

--- a/docs/gamma/4.13/event-stream-management/get-started/register-your-first-cluster.md
+++ b/docs/gamma/4.13/event-stream-management/get-started/register-your-first-cluster.md
@@ -2,7 +2,6 @@
 hidden: false
 noIndex: false
 ---
-<-- to be published -->
 # Register your first cluster
 <!-- Source: gravitee-gamma-module-esm/src/main/ui/features/clusters/components/create/CreateClusterWizard.tsx -->
 

--- a/docs/gamma/4.13/event-stream-management/import/README.md
+++ b/docs/gamma/4.13/event-stream-management/import/README.md
@@ -2,7 +2,6 @@
 hidden: false
 noIndex: false
 ---
-<-- to be published -->
 # Import
 
 Register your existing Kafka infrastructure with Gamma so it can be governed, monitored, and composed into higher-level services.


### PR DESCRIPTION
Backlog. Removes the stray `<-- to be published -->` marker (a malformed HTML comment that rendered as visible text) from the 14 Gamma Event Stream Management pages in 4.12 and 4.13.

The GKO `managementcontext.md` hit for 'to be published' was left untouched — it's a real sentence ('...to be published on the Developer Portal'), not the marker.