### PR TITLE
docs: remove misplaced screenshot from migrate-apis pages

### DIFF
--- a/docs/apim/4.11/create-and-configure-apis/create-apis/migrate-apis.md
+++ b/docs/apim/4.11/create-and-configure-apis/create-apis/migrate-apis.md
@@ -78,7 +78,6 @@ Once validation passes, convert your API with the following steps:
     <figure><img src="../../.gitbook/assets/Screenshot 2025-09-11 at 19.14.33.png" alt=""><figcaption></figcaption></figure>
 2.  Click the **Continue** button. A pop-up box appears showing you details about what you should be aware of before migrating to API V4.
 
-    <figure><img src="../../.gitbook/assets/Screenshot 2023-11-14 at 10.32.02 AM.png" alt=""><figcaption></figcaption></figure>
 3.  Confirm the migration details in the pop-up, and then click **Start Migration** in the confirmation dialog.
 
     <figure><img src="../../.gitbook/assets/Screenshot 2025-09-11 at 19.13.15 (1).png" alt=""><figcaption></figcaption></figure>

--- a/docs/apim/4.12/create-and-configure-apis/create-apis/migrate-apis.md
+++ b/docs/apim/4.12/create-and-configure-apis/create-apis/migrate-apis.md
@@ -78,7 +78,6 @@ Once validation passes, convert your API with the following steps:
     <figure><img src="../../.gitbook/assets/Screenshot 2025-09-11 at 19.14.33.png" alt=""><figcaption></figcaption></figure>
 2.  Click the **Continue** button. A pop-up box appears showing you details about what you should be aware of before migrating to API V4.
 
-    <figure><img src="../../.gitbook/assets/Screenshot 2023-11-14 at 10.32.02 AM.png" alt=""><figcaption></figcaption></figure>
 3.  Confirm the migration details in the pop-up, and then click **Start Migration** in the confirmation dialog.
 
     <figure><img src="../../.gitbook/assets/Screenshot 2025-09-11 at 19.13.15 (1).png" alt=""><figcaption></figcaption></figure>

--- a/docs/apim/4.13/create-and-configure-apis/create-apis/migrate-apis.md
+++ b/docs/apim/4.13/create-and-configure-apis/create-apis/migrate-apis.md
@@ -78,7 +78,6 @@ Once validation passes, convert your API with the following steps:
     <figure><img src="../../.gitbook/assets/Screenshot 2025-09-11 at 19.14.33.png" alt=""><figcaption></figcaption></figure>
 2.  Click the **Continue** button. A pop-up box appears showing you details about what you should be aware of before migrating to API V4.
 
-    <figure><img src="../../.gitbook/assets/Screenshot 2023-11-14 at 10.32.02 AM.png" alt=""><figcaption></figcaption></figure>
 3.  Confirm the migration details in the pop-up, and then click **Start Migration** in the confirmation dialog.
 
     <figure><img src="../../.gitbook/assets/Screenshot 2025-09-11 at 19.13.15 (1).png" alt=""><figcaption></figcaption></figure>


### PR DESCRIPTION
## Summary
- Removes a screenshot (`Screenshot 2023-11-14 at 10.32.02 AM.png`) that was placed in the wrong step of the Migrate APIs guide, across all three affected versions (4.11, 4.12, 4.13).

## Test plan
- [x] Confirmed the image line was identical and in the same position in all three version files before removal
- [x] Verified the resulting diff only removes the one misplaced figure line, leaving surrounding steps intact