### PR TITLE
docs(apim): fix stale OAS validation error keys in 4.8-4.13 docs

### DIFF
--- a/docs/apim/4.10/create-and-configure-apis/apply-policies/policy-reference/oas-validation.md
+++ b/docs/apim/4.10/create-and-configure-apis/apply-policies/policy-reference/oas-validation.md
@@ -95,10 +95,11 @@ The following table shows the compatibility matrix for APIM and the `json-valida
 
 | Phase              | Code                          | Error key                   | Description                                       |
 | ------------------ | ----------------------------- | --------------------------- | ------------------------------------------------- |
-| REQUEST            | `400 - BAD REQUEST`           | OAS\_VALIDATION\_ERROR\_KEY | Request does not match the OpenAPI Specification  |
-| RESPONSE           | `500 - INTERNAL SERVER ERROR` | NO\_OAS\_RESOURCE\_KEY      | No resource configured                            |
-| REQUEST / RESPONSE | `500 - INTERNAL SERVER ERROR` | NO\_OAS\_PROVIDED\_KEY      | No OpenAPI Specification provided                 |
-| RESPONSE           | `500 - INTERNAL SERVER ERROR` | OAS\_VALIDATION\_ERROR\_KEY | Response does not match the OpenAPI Specification |
+| REQUEST            | `400 - BAD REQUEST`           | OAS\_VALIDATION\_ERROR      | Request does not match the OpenAPI Specification  |
+| REQUEST / RESPONSE | `500 - INTERNAL SERVER ERROR` | NO\_OAS\_RESOURCE           | No resource configured                            |
+| REQUEST / RESPONSE | `500 - INTERNAL SERVER ERROR` | NO\_OAS\_PROVIDED           | No OpenAPI Specification provided                 |
+| RESPONSE           | `500 - INTERNAL SERVER ERROR` | OAS\_VALIDATION\_ERROR      | Response does not match the OpenAPI Specification |
+| REQUEST / RESPONSE | `500 - INTERNAL SERVER ERROR` | UNABLE\_TO\_LOAD\_OAS\_KEY  | The OpenAPI Specification could not be loaded or is unsupported |
 
 ## Changelogs
 

--- a/docs/apim/4.11/create-and-configure-apis/apply-policies/policy-reference/oas-validation.md
+++ b/docs/apim/4.11/create-and-configure-apis/apply-policies/policy-reference/oas-validation.md
@@ -95,10 +95,11 @@ The following table shows the compatibility matrix for APIM and the `json-valida
 
 | Phase              | Code                          | Error key                   | Description                                       |
 | ------------------ | ----------------------------- | --------------------------- | ------------------------------------------------- |
-| REQUEST            | `400 - BAD REQUEST`           | OAS\_VALIDATION\_ERROR\_KEY | Request does not match the OpenAPI Specification  |
-| RESPONSE           | `500 - INTERNAL SERVER ERROR` | NO\_OAS\_RESOURCE\_KEY      | No resource configured                            |
-| REQUEST / RESPONSE | `500 - INTERNAL SERVER ERROR` | NO\_OAS\_PROVIDED\_KEY      | No OpenAPI Specification provided                 |
-| RESPONSE           | `500 - INTERNAL SERVER ERROR` | OAS\_VALIDATION\_ERROR\_KEY | Response does not match the OpenAPI Specification |
+| REQUEST            | `400 - BAD REQUEST`           | OAS\_VALIDATION\_ERROR      | Request does not match the OpenAPI Specification  |
+| REQUEST / RESPONSE | `500 - INTERNAL SERVER ERROR` | NO\_OAS\_RESOURCE           | No resource configured                            |
+| REQUEST / RESPONSE | `500 - INTERNAL SERVER ERROR` | NO\_OAS\_PROVIDED           | No OpenAPI Specification provided                 |
+| RESPONSE           | `500 - INTERNAL SERVER ERROR` | OAS\_VALIDATION\_ERROR      | Response does not match the OpenAPI Specification |
+| REQUEST / RESPONSE | `500 - INTERNAL SERVER ERROR` | UNABLE\_TO\_LOAD\_OAS\_KEY  | The OpenAPI Specification could not be loaded or is unsupported |
 
 ## Changelogs
 

--- a/docs/apim/4.12/create-and-configure-apis/apply-policies/policy-reference/oas-validation.md
+++ b/docs/apim/4.12/create-and-configure-apis/apply-policies/policy-reference/oas-validation.md
@@ -95,10 +95,11 @@ The following table shows the compatibility matrix for APIM and the `json-valida
 
 | Phase              | Code                          | Error key                   | Description                                       |
 | ------------------ | ----------------------------- | --------------------------- | ------------------------------------------------- |
-| REQUEST            | `400 - BAD REQUEST`           | OAS\_VALIDATION\_ERROR\_KEY | Request does not match the OpenAPI Specification  |
-| RESPONSE           | `500 - INTERNAL SERVER ERROR` | NO\_OAS\_RESOURCE\_KEY      | No resource configured                            |
-| REQUEST / RESPONSE | `500 - INTERNAL SERVER ERROR` | NO\_OAS\_PROVIDED\_KEY      | No OpenAPI Specification provided                 |
-| RESPONSE           | `500 - INTERNAL SERVER ERROR` | OAS\_VALIDATION\_ERROR\_KEY | Response does not match the OpenAPI Specification |
+| REQUEST            | `400 - BAD REQUEST`           | OAS\_VALIDATION\_ERROR      | Request does not match the OpenAPI Specification  |
+| REQUEST / RESPONSE | `500 - INTERNAL SERVER ERROR` | NO\_OAS\_RESOURCE           | No resource configured                            |
+| REQUEST / RESPONSE | `500 - INTERNAL SERVER ERROR` | NO\_OAS\_PROVIDED           | No OpenAPI Specification provided                 |
+| RESPONSE           | `500 - INTERNAL SERVER ERROR` | OAS\_VALIDATION\_ERROR      | Response does not match the OpenAPI Specification |
+| REQUEST / RESPONSE | `500 - INTERNAL SERVER ERROR` | UNABLE\_TO\_LOAD\_OAS\_KEY  | The OpenAPI Specification could not be loaded or is unsupported |
 
 ## Changelogs
 

--- a/docs/apim/4.13/create-and-configure-apis/apply-policies/policy-reference/oas-validation.md
+++ b/docs/apim/4.13/create-and-configure-apis/apply-policies/policy-reference/oas-validation.md
@@ -95,10 +95,11 @@ The following table shows the compatibility matrix for APIM and the `json-valida
 
 | Phase              | Code                          | Error key                   | Description                                       |
 | ------------------ | ----------------------------- | --------------------------- | ------------------------------------------------- |
-| REQUEST            | `400 - BAD REQUEST`           | OAS\_VALIDATION\_ERROR\_KEY | Request does not match the OpenAPI Specification  |
-| RESPONSE           | `500 - INTERNAL SERVER ERROR` | NO\_OAS\_RESOURCE\_KEY      | No resource configured                            |
-| REQUEST / RESPONSE | `500 - INTERNAL SERVER ERROR` | NO\_OAS\_PROVIDED\_KEY      | No OpenAPI Specification provided                 |
-| RESPONSE           | `500 - INTERNAL SERVER ERROR` | OAS\_VALIDATION\_ERROR\_KEY | Response does not match the OpenAPI Specification |
+| REQUEST            | `400 - BAD REQUEST`           | OAS\_VALIDATION\_ERROR      | Request does not match the OpenAPI Specification  |
+| REQUEST / RESPONSE | `500 - INTERNAL SERVER ERROR` | NO\_OAS\_RESOURCE           | No resource configured                            |
+| REQUEST / RESPONSE | `500 - INTERNAL SERVER ERROR` | NO\_OAS\_PROVIDED           | No OpenAPI Specification provided                 |
+| RESPONSE           | `500 - INTERNAL SERVER ERROR` | OAS\_VALIDATION\_ERROR      | Response does not match the OpenAPI Specification |
+| REQUEST / RESPONSE | `500 - INTERNAL SERVER ERROR` | UNABLE\_TO\_LOAD\_OAS\_KEY  | The OpenAPI Specification could not be loaded or is unsupported |
 
 ## Changelogs
 

--- a/docs/apim/4.8/create-and-configure-apis/apply-policies/policy-reference/oas-validation.md
+++ b/docs/apim/4.8/create-and-configure-apis/apply-policies/policy-reference/oas-validation.md
@@ -92,10 +92,11 @@ The following table shows the compatibility matrix for APIM and the `json-valida
 
 | Phase              | Code                          | Error key                   | Description                                       |
 | ------------------ | ----------------------------- | --------------------------- | ------------------------------------------------- |
-| REQUEST            | `400 - BAD REQUEST`           | OAS\_VALIDATION\_ERROR\_KEY | Request does not match the OpenAPI Specification  |
-| RESPONSE           | `500 - INTERNAL SERVER ERROR` | NO\_OAS\_RESOURCE\_KEY      | No resource configured                            |
-| REQUEST / RESPONSE | `500 - INTERNAL SERVER ERROR` | NO\_OAS\_PROVIDED\_KEY      | No OpenAPI Specification provided                 |
-| RESPONSE           | `500 - INTERNAL SERVER ERROR` | OAS\_VALIDATION\_ERROR\_KEY | Response does not match the OpenAPI Specification |
+| REQUEST            | `400 - BAD REQUEST`           | OAS\_VALIDATION\_ERROR      | Request does not match the OpenAPI Specification  |
+| REQUEST / RESPONSE | `500 - INTERNAL SERVER ERROR` | NO\_OAS\_RESOURCE           | No resource configured                            |
+| REQUEST / RESPONSE | `500 - INTERNAL SERVER ERROR` | NO\_OAS\_PROVIDED           | No OpenAPI Specification provided                 |
+| RESPONSE           | `500 - INTERNAL SERVER ERROR` | OAS\_VALIDATION\_ERROR      | Response does not match the OpenAPI Specification |
+| REQUEST / RESPONSE | `500 - INTERNAL SERVER ERROR` | UNABLE\_TO\_LOAD\_OAS\_KEY  | The OpenAPI Specification could not be loaded or is unsupported |
 
 ## Changelogs
 

--- a/docs/apim/4.9/create-and-configure-apis/apply-policies/policy-reference/oas-validation.md
+++ b/docs/apim/4.9/create-and-configure-apis/apply-policies/policy-reference/oas-validation.md
@@ -96,10 +96,11 @@ The following table shows the compatibility matrix for APIM and the `json-valida
 
 | Phase              | Code                          | Error key                   | Description                                       |
 | ------------------ | ----------------------------- | --------------------------- | ------------------------------------------------- |
-| REQUEST            | `400 - BAD REQUEST`           | OAS\_VALIDATION\_ERROR\_KEY | Request does not match the OpenAPI Specification  |
-| RESPONSE           | `500 - INTERNAL SERVER ERROR` | NO\_OAS\_RESOURCE\_KEY      | No resource configured                            |
-| REQUEST / RESPONSE | `500 - INTERNAL SERVER ERROR` | NO\_OAS\_PROVIDED\_KEY      | No OpenAPI Specification provided                 |
-| RESPONSE           | `500 - INTERNAL SERVER ERROR` | OAS\_VALIDATION\_ERROR\_KEY | Response does not match the OpenAPI Specification |
+| REQUEST            | `400 - BAD REQUEST`           | OAS\_VALIDATION\_ERROR      | Request does not match the OpenAPI Specification  |
+| REQUEST / RESPONSE | `500 - INTERNAL SERVER ERROR` | NO\_OAS\_RESOURCE           | No resource configured                            |
+| REQUEST / RESPONSE | `500 - INTERNAL SERVER ERROR` | NO\_OAS\_PROVIDED           | No OpenAPI Specification provided                 |
+| RESPONSE           | `500 - INTERNAL SERVER ERROR` | OAS\_VALIDATION\_ERROR      | Response does not match the OpenAPI Specification |
+| REQUEST / RESPONSE | `500 - INTERNAL SERVER ERROR` | UNABLE\_TO\_LOAD\_OAS\_KEY  | The OpenAPI Specification could not be loaded or is unsupported |
 
 ## Changelogs
 


### PR DESCRIPTION
## Summary
- The OAS Validation policy page's Errors table (in every version from 4.8 through 4.13) still listed the pre-`gravitee-policy-oas-validation` PR #55 error keys and phases.
- Updates `docs/apim/{4.8,4.9,4.10,4.11,4.12,4.13}/create-and-configure-apis/apply-policies/policy-reference/oas-validation.md` to match the plugin's current `README.adoc`. All six versions had the identical stale table, so the same fix applies verbatim across them.

## Verdict table (Step 4 of the Doc Verification Pipeline)

Source of truth: [gravitee-io/gravitee-policy-oas-validation#55](https://github.com/gravitee-io/gravitee-policy-oas-validation/pull/55) diff (used in place of the RAG cross-check, since this plugin repo isn't in the indexed profile list). Live-environment verification (Step 3) was explicitly skipped for this run.

| Claim (doc, before) | Code truth (PR #55) | Verdict |
|---|---|---|
| `REQUEST`, 400, `OAS_VALIDATION_ERROR_KEY` | Renamed to `OAS_VALIDATION_ERROR` | Fixed |
| `RESPONSE`, 500, `NO_OAS_RESOURCE_KEY` | Phase corrected to `REQUEST / RESPONSE`; key renamed to `NO_OAS_RESOURCE` | Fixed |
| `REQUEST / RESPONSE`, 500, `NO_OAS_PROVIDED_KEY` | Key renamed to `NO_OAS_PROVIDED` | Fixed |
| `RESPONSE`, 500, `OAS_VALIDATION_ERROR_KEY` | Renamed to `OAS_VALIDATION_ERROR` | Fixed |
| (missing row) | New error: `REQUEST / RESPONSE`, 500, `UNABLE_TO_LOAD_OAS_KEY`, "The OpenAPI Specification could not be loaded or is unsupported" | Added |
| All other claims on the page (phases table, config options, compatibility matrix, examples) | Not cross-checked in this pass — PR #55 doesn't touch them, and this plugin's repo isn't in the RAG index | Not verified, left unchanged |

Applied identically to 4.8, 4.9, 4.10, 4.11, 4.12, and 4.13.

## Note for reviewers
PR #55's description also asks the docs team to apply the identical fix to `plugins/plugin-reference.md` (4.11, 4.12, and master). That file is not touched here — I confirmed it still has the old keys in 4.12 and 4.13, but it's a separate, differently-structured (auto-generated-looking) table and out of scope for this PR, which covers the standalone `oas-validation.md` policy reference pages only.

## Test plan
- [ ] Confirm the updated error keys match the plugin's current `README.adoc`
- [ ] Decide on follow-up scope for `plugin-reference.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)