### PR TITLE
docs(gamma): fix LLM Router terminology and stale Deploy claim in configure-an-llm-proxy

### DIFF
--- a/docs/gamma/4.13/agent-management/build/configure-an-llm-proxy.md
+++ b/docs/gamma/4.13/agent-management/build/configure-an-llm-proxy.md
@@ -3,10 +3,10 @@ hidden: false
 noIndex: false
 ---
 
-# Configure an LLM Proxy
+# Configure an LLM Router
 
 
-After creating an LLM Proxy, configure guardrails, PII filtering, rate limiting, security plans, and policies. This page covers all post-creation configuration options.
+After creating an LLM Router, configure guardrails, PII filtering, rate limiting, security plans, and policies. This page covers all post-creation configuration options.
 
 ## Guardrails, PII filtering, and Rate limiting
 
@@ -15,29 +15,29 @@ Guardrails, PII filtering, and rate limiting are implemented using standard Grav
 
 The LLM Studio operates just like the API Management policy studio, supporting request/response phases. To attach these controls:
 
-1. Navigate to your LLM Proxy detail page and open **LLM Studio**.
-2. Click **+** on the request or response flow, then search for and select the desired policy (e.g., PII Filtering, Rate Limit, or AI – Prompt Guard Rails) to add it to the flow.
+1. Navigate to your LLM Router detail page and open **LLM Studio**.
+2. Click **+** on the request or response flow, and then search for and select the desired policy, such as PII Filtering, Rate Limit, or AI – Prompt Guard Rails, to add it to the flow.
 3. Configure the policy properties.
-4. Save your flows. You are prompted to **Deploy** the LLM Proxy via the Out of Sync banner for the changes to take effect.
+4. Save your flows to apply the changes.
 
 ## Structured output
 
 <!-- Source: src/main/ui/lib/api/llm-proxy.types.ts -->
 Structured output enforces response format constraints on model responses. You can enforce structured output natively by overriding model parameters.
-When configuring a model within the LLM Proxy, you can supply a `parametersOverride` JSON object (with Expression Language support). This JSON object is automatically merged into the request payload by the connector before it reaches the upstream provider, allowing you to enforce formatting (e.g., `{"response_format": { "type": "json_object" }}`) transparently.
+When configuring a model within the LLM Router, you can supply a `parametersOverride` JSON object that supports Expression Language. The connector automatically merges this JSON object into the request payload before it reaches the upstream provider, so you can transparently enforce formatting such as `{"response_format": { "type": "json_object" }}`.
 
 ## Security
 
 <!-- Source: src/main/ui/app/components/create-plan/types.ts -->
-Security plans control how consumers authenticate when sending prompts through the LLM Proxy. You can add, modify, or replace plans after creation.
+Security plans control how consumers authenticate when sending prompts through the LLM Router. You can add, modify, or replace plans after creation.
 
 To manage security plans:
 
-1. Navigate to the LLM Proxy detail page.
+1. Navigate to the LLM Router detail page.
 2. Open the **Plans** section.
 3. Add a new plan or modify an existing one.
 
-The LLM Proxy supports the same comprehensive plan types as API proxies:
+The LLM Router supports the following comprehensive plan types, the same as those available for API proxies:
 * **Keyless** (`KEY_LESS`)
 * **API Key** (`API_KEY`)
 * **OAuth2** (`OAUTH2`)
@@ -49,7 +49,7 @@ See [Secure your API proxy](../../api-management/build/secure-your-api-proxy.md)
 ## Cost visibility
 
 <!-- Source: src/main/ui/config/templates/llm.template.ts -->
-The LLM Proxy provides real-time per-token cost attribution by provider and model. Every request records the model used, tokens consumed (input and output), and cost based on the model's configured rate.
+The LLM Router provides real-time per-token cost attribution by provider and model. Every request records the model used, the input and output tokens consumed, and the cost based on the model's configured rate.
 
 This data is visualized in the **LLM — Overview** dashboard, which tracks `LLM_PROMPT_TOKEN_TOTAL_COST` alongside metrics like Requests by Provider and Tokens by Model.
 

--- a/docs/gamma/4.13/agent-management/build/configure-an-llm-proxy.md
+++ b/docs/gamma/4.13/agent-management/build/configure-an-llm-proxy.md
@@ -3,10 +3,10 @@ hidden: false
 noIndex: false
 ---
 
-# Configure an LLM Router
+# Configure an LLM Proxy
 
 
-After creating an LLM Router, configure guardrails, PII filtering, rate limiting, security plans, and policies. This page covers all post-creation configuration options.
+After creating an LLM Proxy, configure guardrails, PII filtering, rate limiting, security plans, and policies. This page covers all post-creation configuration options.
 
 ## Guardrails, PII filtering, and Rate limiting
 
@@ -15,7 +15,7 @@ Guardrails, PII filtering, and rate limiting are implemented using standard Grav
 
 The LLM Studio operates just like the API Management policy studio, supporting request/response phases. To attach these controls:
 
-1. Navigate to your LLM Router detail page and open **LLM Studio**.
+1. Navigate to your LLM Proxy detail page and open **LLM Studio**.
 2. Click **+** on the request or response flow, and then search for and select the desired policy, such as PII Filtering, Rate Limit, or AI – Prompt Guard Rails, to add it to the flow.
 3. Configure the policy properties.
 4. Save your flows to apply the changes.
@@ -24,20 +24,20 @@ The LLM Studio operates just like the API Management policy studio, supporting r
 
 <!-- Source: src/main/ui/lib/api/llm-proxy.types.ts -->
 Structured output enforces response format constraints on model responses. You can enforce structured output natively by overriding model parameters.
-When configuring a model within the LLM Router, you can supply a `parametersOverride` JSON object that supports Expression Language. The connector automatically merges this JSON object into the request payload before it reaches the upstream provider, so you can transparently enforce formatting such as `{"response_format": { "type": "json_object" }}`.
+When configuring a model within the LLM Proxy, you can supply a `parametersOverride` JSON object that supports Expression Language. The connector automatically merges this JSON object into the request payload before it reaches the upstream provider, so you can transparently enforce formatting such as `{"response_format": { "type": "json_object" }}`.
 
 ## Security
 
 <!-- Source: src/main/ui/app/components/create-plan/types.ts -->
-Security plans control how consumers authenticate when sending prompts through the LLM Router. You can add, modify, or replace plans after creation.
+Security plans control how consumers authenticate when sending prompts through the LLM Proxy. You can add, modify, or replace plans after creation.
 
 To manage security plans:
 
-1. Navigate to the LLM Router detail page.
+1. Navigate to the LLM Proxy detail page.
 2. Open the **Plans** section.
 3. Add a new plan or modify an existing one.
 
-The LLM Router supports the following comprehensive plan types, the same as those available for API proxies:
+The LLM Proxy supports the following comprehensive plan types, the same as those available for API proxies:
 * **Keyless** (`KEY_LESS`)
 * **API Key** (`API_KEY`)
 * **OAuth2** (`OAUTH2`)
@@ -49,7 +49,7 @@ See [Secure your API proxy](../../api-management/build/secure-your-api-proxy.md)
 ## Cost visibility
 
 <!-- Source: src/main/ui/config/templates/llm.template.ts -->
-The LLM Router provides real-time per-token cost attribution by provider and model. Every request records the model used, the input and output tokens consumed, and the cost based on the model's configured rate.
+The LLM Proxy provides real-time per-token cost attribution by provider and model. Every request records the model used, the input and output tokens consumed, and the cost based on the model's configured rate.
 
 This data is visualized in the **LLM — Overview** dashboard, which tracks `LLM_PROMPT_TOKEN_TOTAL_COST` alongside metrics like Requests by Provider and Tokens by Model.
 


### PR DESCRIPTION
## Summary

Verified `configure-an-llm-proxy.md` against the live console (GA build) and corrected one inaccurate step.

## Changes

- Removed an inaccurate instruction to **Deploy** via an "Out of Sync" banner after saving flows; replaced with "Save your flows to apply the changes." The banner does not appear — flows apply on save.
- Style pass: removed parenthetical asides, added a list introduction, and used "and then" for sequential steps.

## Verification

Confirmed live in the console:
- LLM Studio shows Request and Response phases.
- The three policies (PII Filtering, Rate Limit, AI - Prompt Guard Rails) are searchable in the flow policy picker.
- The five plan types (Keyless, API Key, OAuth2, JWT, mTLS).
- The "LLM — Overview" dashboard and its per-token cost metric.

Terminology: the console nav reads **"LLM Proxies"**, matching the doc. (An earlier revision of this PR briefly renamed toward "LLM Router" based on a pre-GA build; that was reverted — the GA console confirms "LLM Proxy".)

## Note

- The doc says "OAuth2" while the console displays "OAuth 2.0" — left as-is for consistency with the rest of this docs set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
