### PR TITLE
docs(gamma): fix A2A Proxy detail sidebar nav in configure-your-a2a-proxy

### DIFF
--- a/docs/gamma/4.13/agent-management/build/configure-your-a2a-proxy/README.md
+++ b/docs/gamma/4.13/agent-management/build/configure-your-a2a-proxy/README.md
@@ -18,7 +18,8 @@ When you open an A2A Proxy from the dashboard, you can configure it using the si
 * **General**: 
   * **Overview**: View proxy status and deployment history.
   * **General**: Manage the proxy's name, description, and status.
+  * **Endpoint**: Configure the target URL of the upstream agent.
   * **API Properties**: Manage dynamic properties that can be evaluated at runtime.
 * **Design**:
   * **Policy Studio**: Design your flows and apply policies to agent-to-agent communication.
-* **Observability**: Monitor the proxy with **Metrics**, **Logs**, and **Traces**.
+* **Observability**: Monitor the proxy with **Dashboard**, **Logs**, and **Tracing**.


### PR DESCRIPTION
## Summary

Verified `configure-your-a2a-proxy/README.md` (the A2A Proxy detail sidebar navigation) against the live console.

## Changes

- Added the **Endpoint** item to the General group of the sidebar (present in the console, missing from the doc).
- Corrected the Observability tab labels to **Dashboard, Logs, Tracing** (the doc previously said "Metrics, Logs, Traces").

## Verification

Confirmed live by creating a test A2A proxy and inspecting its detail sidebar:
- General: Overview, General, Endpoint, API Properties.
- Observability: Dashboard, Logs, Tracing.

The test proxy was deleted afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
