### PR TITLE
docs(apim): add Java version requirements notice to 4.12 release notes

### DIFF
--- a/docs/apim/4.12/release-information/release-notes/apim-4.12.md
+++ b/docs/apim/4.12/release-information/release-notes/apim-4.12.md
@@ -1,5 +1,15 @@
 # APIM 4.12
 
+{% hint style="warning" %}
+**Important: Java Version Requirements**
+
+APIM 4.12 is not compatible with Java 25. If deploying with the RPM or ZIP distribution, ensure you use JRE 21.
+
+If AM and APIM are installed on the same host using RPM or ZIP packages, ensure APIM 4.12 runs on JRE 21 and AM runs on JRE 25. To do this, configure a dedicated `JAVA_HOME` for each Gateway and Management API instance.
+
+Docker deployments are unaffected, as official images come pre-configured with the correct Java version.
+{% endhint %}
+
 ## New Features
 
 #### **Hazelcast Rate Limit Repository**

--- a/docs/apim/4.13/release-information/release-notes/apim-4.12.md
+++ b/docs/apim/4.13/release-information/release-notes/apim-4.12.md
@@ -1,5 +1,15 @@
 # APIM 4.12
 
+{% hint style="warning" %}
+**Important: Java Version Requirements**
+
+APIM 4.12 is not compatible with Java 25. If deploying with the RPM or ZIP distribution, ensure you use JRE 21.
+
+If AM and APIM are installed on the same host using RPM or ZIP packages, ensure APIM 4.12 runs on JRE 21 and AM runs on JRE 25. To do this, configure a dedicated `JAVA_HOME` for each Gateway and Management API instance.
+
+Docker deployments are unaffected, as official images come pre-configured with the correct Java version.
+{% endhint %}
+
 ## New Features
 
 #### **Hazelcast Rate Limit Repository**


### PR DESCRIPTION
## Summary
- Adds a warning callout to the top of the APIM 4.12 release notes about Java version compatibility.
- APIM 4.12 is not compatible with Java 25; RPM/ZIP distribution deployments must use JRE 21.
- Notes the dedicated `JAVA_HOME` configuration needed when AM and APIM share a host via RPM/ZIP, and that Docker deployments are unaffected.
- Applied to both locations where this release notes page is duplicated (4.12 and 4.13 version spaces).

## Test plan
- [ ] Preview rendered page in GitBook to confirm the hint block renders correctly