### PR TITLE
docs(gamma): correct AM connection button label to "Verify & Load" (4.13 agent-management)

### DIFF
--- a/docs/gamma/4.13/agent-management/build/configure-your-access-management-instance.md
+++ b/docs/gamma/4.13/agent-management/build/configure-your-access-management-instance.md
@@ -35,7 +35,7 @@ Open the **AM connection** panel for the Agent Management module and provide:
 | **Base URL**                     | The AM management API base URL (for example, `http://localhost:8093`).    |
 | **Service-account access token** | The bearer token issued by AM for the service account. Encrypted at rest. |
 
-Select **Test connection**. A successful test verifies the credentials and persists the connection so the next steps can query AM. If the test fails, the status message shows the error returned by AM.
+Select **Verify & Load**. A successful verification confirms the credentials and persists the connection so the next steps can query AM. If verification fails, the status message shows the error returned by AM.
 
 ## Step 2: Select the scope
 


### PR DESCRIPTION
## Summary

Re-verification of `docs/gamma/4.13/agent-management/build/configure-your-access-management-instance.md` via the Doc Verification Pipeline, run against the **GA build** (`gamma-ui` / `apim-management-api` **4.12.11**) after the earlier pre-GA milestone run.

**One contradiction found and fixed:** the connect action is labeled **Verify & Load** in the live console, not **Test connection**.

The AM connection panel actually lives at **Platform Management -> Access Management** (org-scoped), confirmed both live and in code (`gravitee-gamma-module-aim` `AmConnectionView` is a *read-only view* of a connection "configured via the Platform module"; `gravitee-gamma-module-authz` hints "configure the AM connection in Platform -> Access Management"). The Agent Management module has no connection page of its own.

## Environment / method

- **Code (Step 2):** `rag_search` (ollama backend, healthy) + direct source read of `gravitee-gamma-module-aim` and `gravitee-gamma-module-authz`.
- **Live (Step 3):** GA stack at `http://localhost:8086`, driven by `gravitee-browser-agent`.
- **Live limitation:** the AM demo containers (`gio_am_*`) run on network `graviteeio-am-demo_default`, separate from the gamma stack's `gamma` network. The gamma management API cannot reach AM at the configured `http://localhost:8093` (HTTP 000), so **Verify & Load** cannot complete. The scope and readiness UI sections only render after a successful connection, so they could not be live-verified. This limitation is unchanged from the earlier pre-GA run.

## Step 4 verdict table

| Claim | Code truth | Live truth (GA 4.12.11) | Verdict |
|---|---|---|---|
| Connection is configured once per organization | Org-scoped `AmConnectionView` / `useAmConfig` | Panel at Platform Mgmt -> Access Management, org field defaults `DEFAULT` | Confirmed |
| Field: **Organization**, defaults to `DEFAULT` | n/a (platform module) | Field "Access Management organization", value `DEFAULT` | Confirmed |
| Field: **Base URL**, e.g. `http://localhost:8093` | n/a | Field "Gravitee Access Management base URL", value `http://localhost:8093` | Confirmed |
| Field: **Service-account access token**, encrypted at rest | n/a | Field present (password); helper text "The service-account access token is encrypted at rest" | Confirmed |
| Button label **Test connection** | n/a | Button reads **Verify & Load** | **Contradicted -> fixed** |
| **Save** button | n/a | **Save** button present | Confirmed |
| Step 2 scope: Environment / Domain / Gateway entrypoint | Not in aim/authz (platform module) | Not rendered without a live connection | Not determined |
| Step 3 readiness probes: Connection, Domain, DCR, CIMD, CIBA, SPIFFE (ok/fail/skipped) + "Open in Gravitee Access Management" link | Not in aim/authz (platform module) | Not rendered without a live connection | Not determined |
| Troubleshooting: `am_not_configured` when AM unreachable | Confirmed: `am_not_configured` -> "Access Management is not configured for this organization." (`error-format.ts`) | (banner not reproducible live) | Confirmed (code) |
| Troubleshooting: AM upstream 4xx/5xx surfaces original status + message | Confirmed: `am_upstream_error` carries `upstreamStatus` (`error-format.test.ts`) | n/a | Confirmed (code) |

## GA re-verify vs earlier conclusion

The GA upgrade did **not** change the outcome for this page. The `Test connection` -> `Verify & Load` label discrepancy stands in GA, and the AM instance is still unreachable (same separate-network issue), so the scope/readiness sections remain code-only / not-determined.

## Out-of-scope observations (not edited)

- Step 1 says "Open the AM connection panel for the Agent Management module." The panel is actually located under **Platform Management -> Access Management**, not inside the Agent Management module. The phrasing is arguably about purpose rather than location, so it was left unchanged, but it may confuse readers looking in the Agent Management UI.
- Unrelated to this page: the live GA left-nav still shows "LLM Router" / "Agent Runtime" (not "LLM Proxies" / "A2A Proxies"); the source tree uses `llm-proxy` / `a2a-proxy`. Flagging only; not touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)