### PR TITLE
docs(gamma): remove internal authoring comments from published docs

### DIFF
--- a/docs/gamma/4.12/agent-management/build/configure-an-llm-proxy.md
+++ b/docs/gamma/4.12/agent-management/build/configure-an-llm-proxy.md
@@ -10,7 +10,6 @@ After creating an LLM Proxy, configure guardrails, PII filtering, rate limiting,
 
 ## Guardrails, PII filtering, and Rate limiting
 
-<!-- Source: src/main/ui/app/features/secure/pages/llm-router-detail/llm-studio/LlmStudioPage.tsx -->
 Guardrails, PII filtering, and rate limiting are implemented using standard Gravitee policies. You configure them by attaching policies with the LLM Studio.
 
 The LLM Studio operates just like the API Management policy studio, supporting request/response phases. To attach these controls:
@@ -22,13 +21,11 @@ The LLM Studio operates just like the API Management policy studio, supporting r
 
 ## Structured output
 
-<!-- Source: src/main/ui/lib/api/llm-proxy.types.ts -->
 Structured output enforces response format constraints on model responses. You can enforce structured output natively by overriding model parameters.
 When configuring a model within the LLM Proxy, you can supply a `parametersOverride` JSON object (with Expression Language support). This JSON object is automatically merged into the request payload by the connector before it reaches the upstream provider, allowing you to enforce formatting (e.g., `{"response_format": { "type": "json_object" }}`) transparently.
 
 ## Security
 
-<!-- Source: src/main/ui/app/components/create-plan/types.ts -->
 Security plans control how consumers authenticate when sending prompts through the LLM Proxy. You can add, modify, or replace plans after creation.
 
 To manage security plans:
@@ -48,7 +45,6 @@ See [Secure your API proxy](../../api-management/build/secure-your-api-proxy.md)
 
 ## Cost visibility
 
-<!-- Source: src/main/ui/config/templates/llm.template.ts -->
 The LLM Proxy provides real-time per-token cost attribution by provider and model. Every request records the model used, tokens consumed (input and output), and cost based on the model's configured rate.
 
 This data is visualized in the **LLM — Overview** dashboard, which tracks `LLM_PROMPT_TOKEN_TOTAL_COST` alongside metrics like Requests by Provider and Tokens by Model.

--- a/docs/gamma/4.12/agent-management/build/configure-your-a2a-proxy/add-policies-to-a2a-proxy.md
+++ b/docs/gamma/4.12/agent-management/build/configure-your-a2a-proxy/add-policies-to-a2a-proxy.md
@@ -20,6 +20,5 @@ To attach policies to your A2A Proxy:
 7. Select the policy in the flow to configure its specific properties.
 8. Click **Save** to persist and apply your changes.
 
-<!-- Source: PolicyStudioPage.tsx @ 2a91746280 -->
 
 

--- a/docs/gamma/4.12/agent-management/build/configure-your-mcp/README.md
+++ b/docs/gamma/4.12/agent-management/build/configure-your-mcp/README.md
@@ -4,7 +4,6 @@ noIndex: false
 ---
 
 # Configure your MCP proxy
-<!-- GAP-STRUCTURAL: Missing procedural content source -->
 
 After creating an MCP Proxy, configure how it handles upstream authentication. These settings control how the proxy authenticates with upstream MCP servers on behalf of your users and agents.
 

--- a/docs/gamma/4.12/agent-management/build/configure-your-mcp/add-policies-to-mcp-server.md
+++ b/docs/gamma/4.12/agent-management/build/configure-your-mcp/add-policies-to-mcp-server.md
@@ -20,7 +20,6 @@ Policies operate on typed MCP objects — tool name, arguments, and resource URI
 
 ## Create a policy
 
-<!-- Source: mcp.ts (mcpServiceConfig), PolicyEditorSheet.tsx, PolicyStatementCard.tsx @ c07f5cdff9 -->
 
 MCP policies are managed through the **MCP Policies** page in Authorization Management. You can also access this page from within an MCP Proxy's detail view.
 
@@ -68,7 +67,6 @@ After creating a policy in Draft status:
 3. To suspend a deployed policy, select **Undeploy**. The gateway drops it within 30 seconds.
 
 ## SCIM integration for principals
-<!-- GAP: 30 · Confirmable · Document the SCIM connector setup flow for use with MCP Proxy policies. Demo 2 (00:35:57) and May 22 demo (00:06:13, Stuart Clark) confirm SCIM synchronization is functional. Needs: Demo session, Engineering input, UI verification -->
 
 You can sync users and groups from your enterprise identity provider into Authorization Management using SCIM (System for Cross-domain Identity Management) connectors. Synced users and groups become available as principals in your policies.
 

--- a/docs/gamma/4.12/agent-management/build/configure-your-mcp/apply-policies-to-mcp-methods.md
+++ b/docs/gamma/4.12/agent-management/build/configure-your-mcp/apply-policies-to-mcp-methods.md
@@ -16,8 +16,6 @@ To apply policies to a specific MCP method:
 3. In the sidebar, select **Policy Studio**.
 4. Create a new flow or select an existing one.
 5. In the flow configuration, define a selector for the target MCP method.
-<!-- GAP: 129 · Documentable · Document the exact UI fields or flow selectors used to target MCP methods (e.g., path operators, headers, or method types) in Policy Studio. Needs: Demo session, Source code -->
 6. Open the policy palette and drag your chosen policies onto the flow.
 7. Click **Save** to persist your changes.
 
-<!-- Source: PolicyStudioPage.tsx @ 2a91746280 -->

--- a/docs/gamma/4.12/agent-management/build/configure-your-mcp/apply-policies-to-tool-invocations.md
+++ b/docs/gamma/4.12/agent-management/build/configure-your-mcp/apply-policies-to-tool-invocations.md
@@ -16,8 +16,6 @@ To apply policies to a specific tool invocation:
 3. In the sidebar, select **Policy Studio**.
 4. Create a new flow or select an existing one.
 5. In the flow configuration, define a selector for the target tool.
-<!-- GAP: 130 · Documentable · Document the exact UI fields or flow selectors used to target individual tool invocations (e.g., tool name parameters) in Policy Studio. Needs: Demo session, Source code -->
 6. Open the policy palette and drag your chosen policies onto the flow.
 7. Click **Save** to persist your changes.
 
-<!-- Source: PolicyStudioPage.tsx @ 2a91746280 -->

--- a/docs/gamma/4.12/agent-management/build/create-an-llm-proxy.md
+++ b/docs/gamma/4.12/agent-management/build/create-an-llm-proxy.md
@@ -25,7 +25,6 @@ The LLM Proxy supports two modes for selecting upstream models:
 
 In **Inline mode**, you configure the provider and model directly in the wizard:
 
-<!-- Source: src/main/ui/app/features/secure/pages/llm-router-create/Step1Models.tsx -->
 | Field                     | Required | Description                                                                                                      |
 | ------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------- |
 | **Provider**              | Yes      | The upstream model format (`OPEN_AI`, `GEMINI`, `ANTHROPIC`, or `BEDROCK`).                                      |
@@ -53,7 +52,6 @@ You can configure multiple models on a single LLM Proxy. See [Configure an LLM P
 
 ## Step 4: Select a consumer plan
 
-<!-- Source: src/main/ui/app/components/create-plan/types.ts -->
 Choose how consumers authenticate when sending prompts through this LLM Proxy. The LLM Proxy supports the standard Gravitee API plan types:
 
 | Plan type   | Description                                                                                       |

--- a/docs/gamma/4.12/agent-management/build/create-an-mcp-proxy.md
+++ b/docs/gamma/4.12/agent-management/build/create-an-mcp-proxy.md
@@ -4,7 +4,6 @@ noIndex: false
 ---
 
 # Create an MCP proxy
-<!-- GAP-STRUCTURAL: Missing procedural content source -->
 
 An MCP Proxy sits in front of an upstream MCP server and applies governance — authentication, fine-grained authorization, observability, and rate limiting — to every tool invocation. The proxy speaks protocol-native MCP (JSON-RPC 2.0), operates on typed MCP objects (tool name, arguments, resource URI), and supports OAuth authorization discovery.
 

--- a/docs/gamma/4.12/agent-management/build/create-an-mcp-studio.md
+++ b/docs/gamma/4.12/agent-management/build/create-an-mcp-studio.md
@@ -4,7 +4,6 @@ noIndex: false
 ---
 
 # Create an MCP Studio
-<!-- GAP-STRUCTURAL: Missing procedural content source -->
 
 MCP Studio is a **mode** of the MCP Proxy — not a separate product. It's the authoring environment where you compose tools, resources, prompts, and skills from multiple sources into a **Composite MCP Server**: a new, governed MCP server that didn't exist as a single unit upstream.
 

--- a/docs/gamma/4.12/agent-management/build/edit-mcp-studio-composition.md
+++ b/docs/gamma/4.12/agent-management/build/edit-mcp-studio-composition.md
@@ -9,7 +9,6 @@ After creating an MCP Studio, you can modify its tool composition and upstream a
 
 ## Select and alias tools
 
-<!-- Source: gravitee-gamma-module-aim/src/main/ui/app/features/secure/pages/mcp-studio-wizard/steps/ComposeStep.tsx @ 167439e1 -->
 When building an MCP Studio, you can select which tools from your registered MCP servers to include in the composition. 
 
 If multiple upstream servers provide tools with identical names, you must configure an **Alias** for the colliding tools to ensure they can be uniquely identified by the Agent Identity. The Studio interface automatically flags colliding tool IDs and prevents saving the composition until unique aliases are provided.
@@ -23,7 +22,6 @@ To edit your tool composition:
 
 ## Configure upstream authentication
 
-<!-- Source: gravitee-gamma-module-aim/src/main/ui/app/features/secure/pages/mcp-studio-wizard/steps/UpstreamAuthStep.tsx @ 167439e1 -->
 If the tools you selected originate from an MCP server that requires upstream authentication (such as an OAuth2 provider or API Key), you must configure the credentials before the Studio can be published.
 
 The Studio automatically detects which upstream servers require authentication based on the selected tools.

--- a/docs/gamma/4.12/agent-management/build/expose-agent-with-a2a-proxy.md
+++ b/docs/gamma/4.12/agent-management/build/expose-agent-with-a2a-proxy.md
@@ -4,7 +4,6 @@ noIndex: false
 ---
 
 # Expose your agent with the A2A Proxy
-<!-- Source: CreateA2aProxyPage.tsx, FetchAgentCardUseCase.java -->
 
 The A2A (Agent-to-Agent) Proxy makes an agent's skills discoverable and callable by other agents — across trust boundaries, providers, and organizations. It implements the A2A protocol by serving a `/.well-known/agent.json` descriptor that advertises the agent's skills, and then governs every invocation through the AI Gateway.
 

--- a/docs/gamma/4.12/agent-management/get-started/ai-management-overview.md
+++ b/docs/gamma/4.12/agent-management/get-started/ai-management-overview.md
@@ -4,8 +4,6 @@ noIndex: false
 ---
 
 # Agent Management overview
-<!-- GAP-STRUCTURAL: Missing procedural content source -->
-<!-- GAP: 43 · Investigable · Add a platform architecture diagram showing the AI Gateway, Catalog, Agent Identity, and Edge Management components. Needs: Visual asset -->
 
 Agent Management (AM) is Gravitee's product line for governing AI agent traffic. It provides a unified control plane and runtime for every protocol in the agentic stack: LLM calls, MCP tool invocations, and agent-to-agent (A2A) delegations. It adds end-to-end observability, fine-grained authorization, and identity for every agent that touches your enterprise infrastructure.
 

--- a/docs/gamma/4.12/agent-management/get-started/create-your-first-mcp-server.md
+++ b/docs/gamma/4.12/agent-management/get-started/create-your-first-mcp-server.md
@@ -4,7 +4,6 @@ noIndex: false
 ---
 
 # Create your first MCP server
-<!-- GAP-STRUCTURAL: Missing procedural content source -->
 
 This quickstart walks you through creating an MCP Proxy in front of an upstream MCP server, so that every tool invocation passes through the AI Gateway with authentication, policy enforcement, and observability. You'll use the simplest configuration — Proxy mode with API key security — to get a governed MCP server running in under five minutes.
 

--- a/docs/gamma/4.12/agent-management/get-started/create-your-llm-proxy.md
+++ b/docs/gamma/4.12/agent-management/get-started/create-your-llm-proxy.md
@@ -4,7 +4,6 @@ noIndex: false
 ---
 
 # Create your LLM Proxy
-<!-- GAP-STRUCTURAL: Missing procedural content source -->
 
 
 This quickstart walks you through creating an LLM Proxy, connecting it to an upstream model provider, and sending a test prompt through the AI Gateway. You'll use the simplest configuration, a single model with API key authentication and a keyless consumer plan, to get a working LLM Proxy in under five minutes.

--- a/docs/gamma/4.12/agent-management/get-started/roles-and-permissions.md
+++ b/docs/gamma/4.12/agent-management/get-started/roles-and-permissions.md
@@ -9,7 +9,6 @@ Gravitee Agent Management uses a Role-Based Access Control (RBAC) system to gove
 
 ## Agent Management permissions
 
-<!-- Source: gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/access-management/utils/amConfig.ts @ 6f18c36855 -->
 The following core permissions govern access to Agent Management capabilities within a given environment:
 
 | Permission | Description |

--- a/docs/gamma/4.12/agent-management/import/add-an-ai-model.md
+++ b/docs/gamma/4.12/agent-management/import/add-an-ai-model.md
@@ -51,5 +51,3 @@ You can adjust the display name and description of an imported model:
 
 * **Create an LLM Proxy**: Route traffic to cataloged models. See [Create an LLM Proxy](../build/create-an-llm-proxy.md).
 
-<!-- Source: gravitee-gamma-module-aim/src/main/ui/app/features/catalog/models/ModelForm.tsx -->
-<!-- Source: gravitee-gamma-module-aim/src/main/ui/app/features/catalog/models/ImportModelsPage.tsx -->

--- a/docs/gamma/4.12/agent-management/import/add-an-mcp-registry.md
+++ b/docs/gamma/4.12/agent-management/import/add-an-mcp-registry.md
@@ -4,9 +4,6 @@ noIndex: false
 ---
 
 # Add an MCP Registry
-<!-- GAP-STRUCTURAL: Missing procedural content source -->
-<!-- GAP: 52 · Confirmable · Confirm the full list of supported registries in the June release. Needs: Engineering input -->
-<!-- GAP: 53 · Documentable · Document the exact UI steps for adding an MCP Registry. Needs: Demo session, Source code -->
 
 {% hint style="warning" %}
 **Coming soon.** Connecting to an external MCP registry and browsing or importing its servers is planned for a future release. To add an MCP server today, register it individually by URL. See [Register an MCP server](register-an-mcp-server.md).

--- a/docs/gamma/4.12/agent-management/import/add-knowledge-source.md
+++ b/docs/gamma/4.12/agent-management/import/add-knowledge-source.md
@@ -43,4 +43,3 @@ For Remote fetch, you can configure the **Document type**:
 * **Add MCP resources** — Catalog server resources. See [Add MCP resources](add-mcp-resources.md).
 * **Compose into a Studio** — Include knowledge sources as context in a Composite MCP Server. See [Create an MCP Studio](../build/create-an-mcp-studio.md).
 
-<!-- Source: gravitee-gamma-module-aim/src/main/ui/app/features/catalog/knowledge/KnowledgeForm.tsx -->

--- a/docs/gamma/4.12/agent-management/import/add-mcp-resources.md
+++ b/docs/gamma/4.12/agent-management/import/add-mcp-resources.md
@@ -29,4 +29,3 @@ If you want to manually upload structured documentation, files, or reference mat
 
 * **Compose into a Studio** — Include cataloged resources as context in a Composite MCP Server. See [Create an MCP Studio](../build/create-an-mcp-studio.md).
 
-<!-- Source: gravitee-gamma-module-aim/src/main/ui/app/features/catalog/resources/McpResourcesPage.tsx -->

--- a/docs/gamma/4.12/agent-management/import/connect-integrations.md
+++ b/docs/gamma/4.12/agent-management/import/connect-integrations.md
@@ -44,4 +44,3 @@ Once connected and imported, the models appear in the AI Models catalog and beco
 * **Add models manually** — For providers without an integration, register models individually. See [Add an AI model](add-an-ai-model.md).
 * **Import agents** — View and manage agents synced from connected integrations. See [Import an agent](import-an-agent.md).
 
-<!-- Source: gravitee-gamma-module-aim/src/main/ui/app/features/catalog/models/ImportModelsPage.tsx -->

--- a/docs/gamma/4.12/agent-management/import/create-api-tools.md
+++ b/docs/gamma/4.12/agent-management/import/create-api-tools.md
@@ -47,5 +47,3 @@ When you create an API Tool from an API proxy, the tool inherits:
 
 * **Compose into a Studio** — Include API Tools in a Composite MCP Server alongside MCP-native tools. See [Create an MCP Studio](../build/create-an-mcp-studio.md).
 
-<!-- Source: gravitee-gamma-module-aim/src/main/ui/app/features/catalog/tools/api-tools/Step1Sources.tsx -->
-<!-- Source: gravitee-gamma-module-aim/src/main/ui/app/features/catalog/tools/api-tools/Step2Capabilities.tsx -->

--- a/docs/gamma/4.12/agent-management/import/import-an-agent.md
+++ b/docs/gamma/4.12/agent-management/import/import-an-agent.md
@@ -49,4 +49,3 @@ Once an agent is registered in the Catalog, you can:
 * [Create an agent identity](../build/create-an-agent-identity.md) — Assign a verifiable identity to a registered agent.
 * [Expose your agent with the A2A Proxy](../build/expose-agent-with-a2a-proxy.md) — Make agent skills available across trust boundaries.
 
-<!-- Source: gravitee-gamma-module-aim/src/main/ui/app/features/catalog/agents/NewAgentPage.tsx -->

--- a/docs/gamma/4.12/agent-management/import/import-prompts.md
+++ b/docs/gamma/4.12/agent-management/import/import-prompts.md
@@ -35,4 +35,3 @@ To review cataloged prompts:
 
 * **Compose into a Studio** — Include cataloged prompts in a Composite MCP Server. See [Create an MCP Studio](../build/create-an-mcp-studio.md).
 
-<!-- Source: gravitee-gamma-module-aim/src/main/ui/app/features/catalog/prompts/McpPromptsPage.tsx -->

--- a/docs/gamma/4.12/agent-management/import/register-an-mcp-server.md
+++ b/docs/gamma/4.12/agent-management/import/register-an-mcp-server.md
@@ -4,7 +4,6 @@ noIndex: false
 ---
 
 # Register an MCP server
-<!-- GAP-STRUCTURAL: Missing procedural content source -->
 
 Registering an MCP server adds it to the Catalog as a first-class entity — along with its tools, resources, and prompts. Once registered, the server's capabilities become available for use in MCP Proxies, MCP Studios, and authorization policies.
 

--- a/docs/gamma/4.12/agent-management/import/upload-skills.md
+++ b/docs/gamma/4.12/agent-management/import/upload-skills.md
@@ -38,4 +38,3 @@ The skill is extracted, analyzed, and added to the Catalog. It becomes available
 
 * **Compose into a Studio** — Include skills as resources in a Composite MCP Server. See [Create an MCP Studio](../build/create-an-mcp-studio.md).
 
-<!-- Source: gravitee-gamma-module-aim/src/main/ui/app/features/catalog/skills/UploadSkillPage.tsx -->

--- a/docs/gamma/4.12/agent-management/observe/inspect-your-agent-log.md
+++ b/docs/gamma/4.12/agent-management/observe/inspect-your-agent-log.md
@@ -4,9 +4,6 @@ noIndex: false
 ---
 
 # Inspect your agent log
-<!-- GAP-STRUCTURAL: Missing procedural content source -->
-<!-- GAP: 70 · Documentable · Document the lineage view UI — how to navigate traces, expand spans, filter. Needs: Demo session -->
-<!-- GAP: 71 · Documentable · Document the search and filter capabilities in the agent log. Needs: UI verification -->
 
 The agent log provides a detailed trace of every agent invocation through the AI Gateway, using OpenTelemetry (OTel) spans. Each span captures the full context of a single operation — who made the call, what tool was invoked, what data was sent and received, how long it took, what policies were evaluated, and what it cost.
 

--- a/docs/gamma/4.12/agent-management/observe/monitor-ai-gateway-from-devices.md
+++ b/docs/gamma/4.12/agent-management/observe/monitor-ai-gateway-from-devices.md
@@ -4,8 +4,6 @@ noIndex: false
 ---
 
 # Monitor AI Gateway usage from employee systems
-<!-- GAP-STRUCTURAL: Missing procedural content source -->
-<!-- GAP: 72 · Confirmable · Confirm the full set of metrics available and the time range/granularity options. Needs: Demo session, Engineering input -->
 
 The Edge Management dashboard provides centralized visibility into AI traffic originating from employee devices where the Edge Daemon is installed. This dashboard is the control plane complement to the Edge Daemon's local enforcement — it shows what's happening across your entire device fleet.
 

--- a/docs/gamma/4.12/agent-management/observe/monitor-your-mcp-servers.md
+++ b/docs/gamma/4.12/agent-management/observe/monitor-your-mcp-servers.md
@@ -4,9 +4,6 @@ noIndex: false
 ---
 
 # Monitor your MCP servers
-<!-- GAP-STRUCTURAL: Missing procedural content source -->
-<!-- GAP: 73 · Investigable · No source material covers the MCP-specific observability UI. Needs: Demo session, Source code, Engineering input, UI verification -->
-<!-- GAP: 74 · Documentable · Document the MCP server metrics dashboard. Needs: Investigation -->
 
 Monitor tool invocation metrics, error rates, and latency for your MCP Proxies through the AI Gateway observability layer.
 

--- a/docs/gamma/4.12/agent-management/publish/expose-an-mcp-registry.md
+++ b/docs/gamma/4.12/agent-management/publish/expose-an-mcp-registry.md
@@ -4,8 +4,6 @@ noIndex: true
 ---
 
 # Expose an MCP Registry
-<!-- GAP-STRUCTURAL: Missing procedural content source -->
-<!-- GAP: 75 · Documentable · Document the exact UI steps for exposing the Catalog as an MCP Registry. Needs: Demo session, Source code, UI verification -->
 
 {% hint style="warning" %}
 **Coming soon.** Exposing the Catalog as a discoverable MCP Registry (outbound federation) is part of the platform vision and is planned for a future release. This page describes the intended capability, not a shipped flow.

--- a/docs/gamma/4.12/agent-management/publish/manage-subscriptions.md
+++ b/docs/gamma/4.12/agent-management/publish/manage-subscriptions.md
@@ -9,7 +9,6 @@ Consumers access your LLM Proxies and MCP Proxies by subscribing to the security
 
 ## Subscription lifecycle
 
-<!-- Source: gravitee-gamma-module-aim/src/test/java/com/graviteesource/gamma/module/aim/infra/service_provider/subscription/SubscriptionApimInMemory.java @ 9e2bb196 -->
 Subscriptions to Agent Management resources follow a strict approval lifecycle:
 
 1. **Pending**: When a consumer requests access to a plan that requires validation, the subscription is placed in a `PENDING` state.

--- a/docs/gamma/4.12/agent-management/publish/publish-your-llm-proxy.md
+++ b/docs/gamma/4.12/agent-management/publish/publish-your-llm-proxy.md
@@ -15,13 +15,11 @@ Publishing an LLM Proxy makes it accessible to consumers through the AI Gateway.
 
 ## Publish the LLM Proxy
 
-<!-- Source: src/main/ui/app/features/secure/pages/llm-router-detail/LlmRouterDetailLayout.tsx -->
 1. Navigate to the LLM Proxy detail page.
 2. If the LLM Proxy was created without the **Deploy** option or if you have unpublished changes, a banner will appear at the top indicating that the proxy is **Out of Sync**.
 3. Select **Deploy** from the banner to push the configuration to the AI Gateway.
 4. Once deployed, the LLM Proxy is live at its configured context path.
 
-<!-- Source: src/main/ui/app/features/secure/pages/llm-router-create/Step1Models.tsx -->
 The Universal LLM Router exposes a single endpoint that simultaneously supports multiple formats (OpenAI API, Anthropic API, and Gemini API). You can send prompts using any of these native formats; the router will route across providers and convert the responses back to the format you requested.
 
 Consumers can now send prompts to paths such as:

--- a/docs/gamma/4.12/api-management/build/api-products.md
+++ b/docs/gamma/4.12/api-management/build/api-products.md
@@ -4,7 +4,6 @@ noIndex: false
 ---
 
 # Create API Products
-<!-- GAP-STRUCTURAL: Missing procedural content source -->
 
 API Products let you bundle multiple API proxies into a single consumer-facing product. Instead of subscribing to individual APIs, consumers subscribe to an API Product plan and gain access to all APIs in the product.
 

--- a/docs/gamma/4.12/api-management/build/configure-your-api-product/README.md
+++ b/docs/gamma/4.12/api-management/build/configure-your-api-product/README.md
@@ -4,7 +4,6 @@ noIndex: false
 ---
 
 # Configure API products
-<!-- GAP-STRUCTURAL: Missing procedural content source -->
 
 After creating an API product, use the product detail page to attach APIs, create plans, manage consumers, and control team access.
 

--- a/docs/gamma/4.12/api-management/build/configure-your-api-product/manage-product-apis.md
+++ b/docs/gamma/4.12/api-management/build/configure-your-api-product/manage-product-apis.md
@@ -4,7 +4,6 @@ noIndex: false
 ---
 
 # Manage product APIs
-<!-- GAP-STRUCTURAL: Missing procedural content source -->
 
 The **APIs** tab in the API Product detail page lets you attach and detach API proxies from the product. Consumers who subscribe to the product's plans gain access to all attached APIs.
 

--- a/docs/gamma/4.12/api-management/build/configure-your-api-proxy/README.md
+++ b/docs/gamma/4.12/api-management/build/configure-your-api-proxy/README.md
@@ -4,7 +4,6 @@ noIndex: false
 ---
 
 # Configure your API proxy
-<!-- GAP-STRUCTURAL: Missing procedural content source -->
 
 After creating and securing an API proxy, you can refine its behavior through additional configuration. This section covers endpoint configuration, consumer access management, and policy enforcement.
 

--- a/docs/gamma/4.12/api-management/build/configure-your-api-proxy/apply-security-policies.md
+++ b/docs/gamma/4.12/api-management/build/configure-your-api-proxy/apply-security-policies.md
@@ -18,7 +18,6 @@ Each policy in the chain can inspect, transform, or reject the request or respon
 
 ## Authorization Management integration
 
-<!-- Source: apis.ts (apisServiceConfig), PolicyEditorSheet.tsx, ServicePolicyPage.tsx @ c07f5cdff9 -->
 
 In Gamma, API proxies can use **Authorization Management** for fine-grained, catalog-aware authorization that goes beyond plan-level authentication. The Policy Decision Point (PDP) runs directly inside the API Gateway with microsecond-scale latency and no network hop.
 

--- a/docs/gamma/4.12/api-management/build/configure-your-api-proxy/configure-backend-security.md
+++ b/docs/gamma/4.12/api-management/build/configure-your-api-proxy/configure-backend-security.md
@@ -4,7 +4,6 @@ noIndex: false
 ---
 
 # Configure endpoints
-<!-- GAP-STRUCTURAL: Missing procedural content source -->
 
 Endpoints define where the API Gateway routes requests after authentication. Each endpoint group points to one or more backend services and controls how the Gateway connects to them — load balancing, timeouts, SSL/TLS, proxy settings, and custom headers.
 

--- a/docs/gamma/4.12/api-management/build/configure-your-api-proxy/configure-flow-execution.md
+++ b/docs/gamma/4.12/api-management/build/configure-your-api-proxy/configure-flow-execution.md
@@ -16,12 +16,10 @@ Gamma supports two flow execution modes for API Proxies:
 * **Default (`DEFAULT`)**: The Gateway executes all flows that match the incoming request. This is useful when you want to apply multiple cross-cutting policies (like logging or header injection) that should trigger cumulatively on a request.
 * **Best match (`BEST_MATCH`)**: The Gateway evaluates all flows and executes only the *single* flow that is the closest match to the incoming request. This is useful when you have mutually exclusive behaviors defined on overlapping paths or conditions.
 
-<!-- Source: usePolicyStudioData.ts, types/policyStudio.ts @ 2a91746280 -->
 
 > [!NOTE]
 > V2 API definition proxies support the same flow execution semantics via their legacy `flowMode` configuration, which is fully compatible with the new Policy Studio interface.
 
-<!-- Source: v2FlowAdapter.ts @ 2a91746280 -->
 
 ## Configure flow execution
 
@@ -33,4 +31,3 @@ To change the flow execution mode for your API:
 4. Adjust the **Flow Execution** setting to either `DEFAULT` or `BEST_MATCH`.
 5. Click **Save** to persist your changes.
 
-<!-- Source: PolicyStudioPage.tsx, usePolicyStudioSave.ts @ 2a91746280 -->

--- a/docs/gamma/4.12/api-management/build/configure-your-api-proxy/establish-consumer-access.md
+++ b/docs/gamma/4.12/api-management/build/configure-your-api-proxy/establish-consumer-access.md
@@ -4,7 +4,6 @@ noIndex: false
 ---
 
 # Establish consumer access
-<!-- GAP-STRUCTURAL: Missing procedural content source -->
 
 Consumer access controls how external applications discover, subscribe to, and authenticate with your API. This page covers the application model, subscription workflows, and API key management in the Gamma console.
 

--- a/docs/gamma/4.12/api-management/build/create-an-api-proxy.md
+++ b/docs/gamma/4.12/api-management/build/create-an-api-proxy.md
@@ -4,7 +4,6 @@ noIndex: false
 ---
 
 # Create an API proxy
-<!-- GAP-STRUCTURAL: Missing procedural content source -->
 
 An API proxy is the core artifact in API Management. It defines a context path or virtual host that consumers use to reach your API, forwards requests to an upstream backend, and applies security plans and policies at runtime through the API Gateway.
 

--- a/docs/gamma/4.12/api-management/build/secure-your-api-proxy.md
+++ b/docs/gamma/4.12/api-management/build/secure-your-api-proxy.md
@@ -4,7 +4,6 @@ noIndex: false
 ---
 
 # Secure your API proxy
-<!-- GAP-STRUCTURAL: Missing procedural content source -->
 
 After creating an API proxy, attach one or more security plans to control how consumers authenticate. Plans define the authentication mechanism the API Gateway enforces at runtime — every incoming request is evaluated against the active plans before it reaches your backend.
 

--- a/docs/gamma/4.12/api-management/build/shared-policy-groups.md
+++ b/docs/gamma/4.12/api-management/build/shared-policy-groups.md
@@ -16,7 +16,6 @@ Shared Policy Groups integrate seamlessly into your API proxy flows:
 * **API type compatibility**: Shared policy groups are typed and validate compatibility with your API proxy's protocol type.
 * **Prerequisite messaging**: If a shared policy group has unfulfilled prerequisites, the Policy Studio will display its configuration prerequisites in the builder.
 
-<!-- Source: types/policyStudio.ts, usePolicyStudioData.ts @ 2a91746280 -->
 
 ## Attach a Shared Policy Group
 
@@ -30,4 +29,3 @@ To reuse a Shared Policy Group in your API flows:
 6. Drag and drop the Shared Policy Group onto the desired phase in your flow.
 7. Click **Save** to deploy the updated flow.
 
-<!-- Source: PolicyStudioPage.tsx, usePolicyStudioData.ts @ 2a91746280 -->

--- a/docs/gamma/4.12/api-management/get-started/api-management-overview.md
+++ b/docs/gamma/4.12/api-management/get-started/api-management-overview.md
@@ -4,7 +4,6 @@ noIndex: false
 ---
 
 # API Management overview
-<!-- GAP-STRUCTURAL: Missing procedural content source -->
 
 API Management is Gravitee's product line for governing REST, GraphQL, and gRPC traffic. Within Gamma, API Management provides a dedicated console for creating, securing, and monitoring API proxies — the core building block that mediates between consumers and backend services.
 

--- a/docs/gamma/4.12/api-management/get-started/create-your-first-api.md
+++ b/docs/gamma/4.12/api-management/get-started/create-your-first-api.md
@@ -4,7 +4,6 @@ noIndex: false
 ---
 
 # Create your first API
-<!-- GAP-STRUCTURAL: Missing procedural content source -->
 
 This quickstart walks you through creating an API proxy in the Gamma console, deploying it to the API Gateway, and verifying it with a test request. You'll use the simplest configuration — a keyless plan with a single upstream — to get a working proxy in under five minutes.
 

--- a/docs/gamma/4.12/api-management/observe/monitor-api-usage.md
+++ b/docs/gamma/4.12/api-management/observe/monitor-api-usage.md
@@ -4,7 +4,6 @@ noIndex: false
 ---
 
 # Monitor API usage
-<!-- GAP-STRUCTURAL: Missing procedural content source -->
 The API usage dashboard provides real-time and historical metrics for your API proxies, including request volume, latency distribution, error rates, and consumer-level analytics.
 
 ## Dashboard overview

--- a/docs/gamma/4.12/api-management/observe/monitor-endpoint-health.md
+++ b/docs/gamma/4.12/api-management/observe/monitor-endpoint-health.md
@@ -15,7 +15,6 @@ The Endpoint Health Check Dashboard provides real-time visibility into the avail
 1. From the Gamma console sidebar, select **API Management**, then navigate to **APIs**.
 2. Select an API from the list to view its detail page.
 3. In the API sub-navigation menu, select **Endpoints**, then select the **Health Check Dashboard** tab.
-   <!-- Source: ApiDetailSidebarNav.tsx L20-L30, gravitee-gamma-module-apim @ d1bb5f8af7 -->
 
 ## Dashboard metrics
 
@@ -23,9 +22,7 @@ The dashboard displays several key metrics and visualizations:
 
 * **Global Metrics**: High-level summary of availability, average response time, and total failures over the selected timeframe.
 * **Availability by Field**: A table breaking down availability statistics by specific endpoint or group.
-  <!-- Source: AvailabilityByFieldTable.tsx L15-L45, gravitee-gamma-module-apim @ d1bb5f8af7 -->
 * **Response Time Trend**: A chart displaying the historical trend of endpoint response times.
-  <!-- Source: ResponseTimeTrendChart.tsx L15-L50, gravitee-gamma-module-apim @ d1bb5f8af7 -->
 
 Use the timeframe filter at the top of the dashboard to adjust the monitoring window (e.g., last hour, last 24 hours).
 
@@ -34,13 +31,10 @@ Use the timeframe filter at the top of the dashboard to adjust the monitoring wi
 The **Failed Health Checks** table lists all unsuccessful endpoint verification attempts within the selected timeframe.
 
 1. Locate the **Failed Health Checks** table at the bottom of the dashboard.
-   <!-- Source: FailedHealthChecksTable.tsx L20-L60, gravitee-gamma-module-apim @ d1bb5f8af7 -->
 2. Review the list of failures, which includes the timestamp, endpoint name, HTTP status, and error message.
 3. Select the **Details** icon next to a failed check to open the log detail sheet.
 4. Review the raw request and response data in the log detail sheet to diagnose the root cause of the failure.
-   <!-- Source: HealthCheckLogDetailSheet.tsx L30-L80, gravitee-gamma-module-apim @ d1bb5f8af7 -->
 
-<!-- GAP: 128 · Confirmable · Confirm if the health check dashboard supports exporting logs or metrics to external monitoring systems. Needs: UI verification -->
 
 ## Next steps
 

--- a/docs/gamma/4.12/api-management/observe/view-api-logs.md
+++ b/docs/gamma/4.12/api-management/observe/view-api-logs.md
@@ -4,7 +4,6 @@ noIndex: false
 ---
 
 # View API logs
-<!-- GAP-STRUCTURAL: Missing procedural content source -->
 API logs provide a detailed record of every request processed by the API Gateway for a specific API proxy. Gamma exposes native log viewing and a **Trace Explorer** under the Observability section, giving you full request traces and span data to help you debug and analyze your API traffic.
 
 ## Access logs and traces

--- a/docs/gamma/4.12/authorization-management/authz-gateway-sync.md
+++ b/docs/gamma/4.12/authorization-management/authz-gateway-sync.md
@@ -22,4 +22,3 @@ By evaluating authorization rules locally at the Gateway (the Policy Enforcement
 
 Gamma's AuthZEN PDP is fully multi-tenant. If you run multiple environments or tenants on the same Gateway, the PDP strongly isolates the policies and authorization data, ensuring that decisions are always scoped strictly to the calling tenant.
 
-<!-- Source: AimResourceIntegrationTest.java — gravitee-gamma-module-aim -->

--- a/docs/gamma/4.12/authorization-management/evaluate/analytics-sent-to-control-plane.md
+++ b/docs/gamma/4.12/authorization-management/evaluate/analytics-sent-to-control-plane.md
@@ -9,7 +9,6 @@ Understand the observability data that PDP gateways send back to the Gravitee co
 
 {% hint style="warning" %}
 This feature is under active development and may not be available in all environments at this time.
-<!-- GAP: Analytics reporting from PDP gateways to the control plane is referenced in the QuickStart page KPI tiles and the DashboardPage infrastructure, but the specific metrics payload, collection interval, and dashboard visualizations need engineering confirmation. -->
 {% endhint %}
 
 ## Overview

--- a/docs/gamma/4.12/authorization-management/get-started/authorization-management-overview.md
+++ b/docs/gamma/4.12/authorization-management/get-started/authorization-management-overview.md
@@ -4,7 +4,6 @@ noIndex: false
 ---
 
 # Authorization Management overview
-<!-- GAP-STRUCTURAL: Missing procedural content source -->
 
 Authorization Management provides fine-grained, catalog-aware access control across all Gamma traffic types — APIs, MCP servers, AI models, agents, events, and custom resources. Policies are written in GAPL (Gravitee Authorization Policy Language), a subset of the Cedar policy language, and enforced at the wire level by Gamma's gateways.
 
@@ -90,7 +89,6 @@ Each policy has a status:
 | **Disabled** | The policy was previously deployed but is now suspended without deletion.             |
 
 ## Integration with other product areas
-<!-- GAP: 126 · Narrowed · AGENT and EVENT policy types exist in entity-kind-registry.ts but have no dedicated ServicePageConfig files or policy management pages. DashboardPage.tsx confirms Agents and 'Users and groups' cards show 'Coming soon'. Needs: Engineering input -->
 
 Authorization Management is not isolated — it integrates with the API Gateway, AI Gateway, and Event Gateway as a shared enforcement layer:
 

--- a/docs/gamma/4.12/authorization-management/manage/schemas/edit-your-schema.md
+++ b/docs/gamma/4.12/authorization-management/manage/schemas/edit-your-schema.md
@@ -9,7 +9,6 @@ Modify an existing schema to add entity types, attributes, relationships, or act
 
 {% hint style="warning" %}
 This feature is under active development and may not be available in all environments at this time.
-<!-- GAP: Schema editing UI exists in SchemaPage.tsx (Edit button, Monaco editor, Save/Cancel, validation diagnostics), but the schema DSL syntax and advanced editing workflows need SME confirmation for documentation completeness. -->
 {% endhint %}
 
 ## Editing workflow

--- a/docs/gamma/4.12/authorization-management/manage/schemas/validate-schema-changes.md
+++ b/docs/gamma/4.12/authorization-management/manage/schemas/validate-schema-changes.md
@@ -9,7 +9,6 @@ Understand how the console validates schema changes before saving and what error
 
 {% hint style="warning" %}
 This feature is under active development and may not be available in all environments at this time.
-<!-- GAP: Schema validation backend endpoint behavior and specific error codes need SME confirmation. Current documentation covers the client-side validation UX from SchemaPage.tsx and useSchemaValidation.ts. -->
 {% endhint %}
 
 ## Validation pipeline

--- a/docs/gamma/4.12/edge-management/connect/configure-kandji-daemon.md
+++ b/docs/gamma/4.12/edge-management/connect/configure-kandji-daemon.md
@@ -5,7 +5,6 @@ description: How to deploy the Edge Daemon to your macOS device fleet using Kand
 ---
 
 # Configure Kandji to deploy the Edge Daemon
-<!-- GAP-STRUCTURAL: Missing procedural content source -->
 
 Deploy the Edge Daemon to your device fleet using Kandji MDM. The Gamma console generates the download URL and the Kandji installation script for you, from the **Daemon Deployment** section of the Edge Management configuration page.
 

--- a/docs/gamma/4.12/event-stream-management/build/create-a-kafka-service-with-a-registered-cluster.md
+++ b/docs/gamma/4.12/event-stream-management/build/create-a-kafka-service-with-a-registered-cluster.md
@@ -5,7 +5,6 @@ noIndex: false
 <--- to be published --->
 
 # Create a Kafka service with a registered cluster
-<!-- Source: gravitee-gamma-module-esm/src/main/ui/features/kafka-apis/components/create/CreateNativeApiWizard.tsx -->
 
 A Kafka Service is the client-facing endpoint managed by Gravitee. It is the Event Stream Management equivalent of an API proxy — the Kafka Service is the governance layer that enforces authentication, security plans, ACLs, and quotas before routing traffic to the backend infrastructure. 
 

--- a/docs/gamma/4.12/event-stream-management/build/create-a-kafka-service-with-a-virtual-cluster.md
+++ b/docs/gamma/4.12/event-stream-management/build/create-a-kafka-service-with-a-virtual-cluster.md
@@ -5,7 +5,6 @@ noIndex: false
 <--- to be published --->
 
 # Create a Kafka service with a Virtual Cluster
-<!-- GAP-STRUCTURAL: Missing procedural content source -->
 
 A Kafka Service backed by a Virtual Cluster lets you govern access to a federated multi-cluster Kafka environment through a single endpoint. The Virtual Cluster fans out requests across its backend Registered Clusters, while the Kafka Service adds the governance layer — security plans, policies, and observability — on top of that unified endpoint.
 

--- a/docs/gamma/4.12/event-stream-management/build/establish-a-virtual-cluster.md
+++ b/docs/gamma/4.12/event-stream-management/build/establish-a-virtual-cluster.md
@@ -4,7 +4,6 @@ noIndex: false
 ---
 <-- to be published-->
 # Establish a Virtual Cluster
-<!-- Source: CreateVirtualClusterPage.tsx — gravitee-gamma-module-esm -->
 
 A Virtual Cluster federates multiple independent Kafka backends into a single unified endpoint. Instead of managing separate cluster connections for each team or workload, a Virtual Cluster lets clients connect to one endpoint and transparently interact with topics spread across multiple underlying Registered Clusters.
 

--- a/docs/gamma/4.12/event-stream-management/build/kafka-virtual-cluster-runtime-behavior-reference.md
+++ b/docs/gamma/4.12/event-stream-management/build/kafka-virtual-cluster-runtime-behavior-reference.md
@@ -3,7 +3,6 @@ hidden: false
 noIndex: false
 ---
 # Virtual Cluster runtime behavior
-<!-- GAP-STRUCTURAL: Missing procedural content source -->
 
 This page describes what happens when a Virtual Cluster is active on the Event Gateway — how it handles client requests, routes them across backends, and presents a unified view to clients.
 

--- a/docs/gamma/4.12/event-stream-management/get-started/create-your-first-kafka-service.md
+++ b/docs/gamma/4.12/event-stream-management/get-started/create-your-first-kafka-service.md
@@ -3,7 +3,6 @@ hidden: false
 noIndex: false
 ---
 # Create your first Kafka service
-<!-- Source: gravitee-gamma-module-esm/src/main/ui/features/kafka-apis/components/create/CreateNativeApiWizard.tsx -->
 
 This quickstart walks you through creating a governed Kafka Service in the Gamma console. You'll use the simplest configuration — a standalone endpoint with a keyless plan — to get a working Kafka Service in under five minutes.
 

--- a/docs/gamma/4.12/event-stream-management/get-started/create-your-first-virtual-cluster.md
+++ b/docs/gamma/4.12/event-stream-management/get-started/create-your-first-virtual-cluster.md
@@ -56,4 +56,3 @@ After creation, you are navigated to the Virtual Cluster's overview page, where 
 
 * **Add a Kafka Service** — Apply security plans and policies on top of the Virtual Cluster. See [Establish a Virtual Cluster](../build/establish-a-virtual-cluster.md).
 
-<!-- Source: CreateVirtualClusterPage.tsx — gravitee-gamma-module-esm -->

--- a/docs/gamma/4.12/event-stream-management/get-started/event-stream-management-overview.md
+++ b/docs/gamma/4.12/event-stream-management/get-started/event-stream-management-overview.md
@@ -8,7 +8,6 @@ Event Stream Management is Gravitee's product line for governing Kafka clusters,
 
 <figure><img src="../../.gitbook/assets/gamma-esm-dashboard.png" alt="Event Stream Management dashboard showing Kafka Services, Virtual Clusters, and Clusters cards with counts and status breakdowns"><figcaption><p>The Event Stream Management dashboard. The three cards show Kafka Services (lifecycle management), Virtual Clusters (Kafka Mesh composition), and Clusters (multi-connection registrations).</p></figcaption></figure>
 
-<!-- Source: applications.ts — gravitee-gamma-control-plane-webui @ cb0911bad0 -->
 
 ## What Event Stream Management does
 

--- a/docs/gamma/4.12/event-stream-management/get-started/register-your-first-cluster.md
+++ b/docs/gamma/4.12/event-stream-management/get-started/register-your-first-cluster.md
@@ -3,7 +3,6 @@ hidden: false
 noIndex: false
 ---
 # Register your first cluster
-<!-- Source: gravitee-gamma-module-esm/src/main/ui/features/clusters/components/create/CreateClusterWizard.tsx -->
 
 This quickstart walks you through registering your first Kafka cluster in the Gamma console and adding its first connection. Registering a cluster is the foundational first step — Kafka Services and Virtual Clusters are built on top of registered clusters.
 

--- a/docs/gamma/4.12/event-stream-management/import/register-your-kafka-clusters.md
+++ b/docs/gamma/4.12/event-stream-management/import/register-your-kafka-clusters.md
@@ -54,7 +54,6 @@ After registration, you can view and update cluster details from the Clusters pa
 Removing a cluster registration does not affect the cluster itself — it only removes Gamma's connection to it. Any Kafka Services or Virtual Clusters built on top of the cluster will lose their underlying connection.
 {% endhint %}
 
-<!-- Source: ClustersPage.tsx and CreateClusterWizard.tsx — gravitee-gamma-module-esm -->
 
 ## Next steps
 

--- a/docs/gamma/4.12/platform-management/configure-access-management.md
+++ b/docs/gamma/4.12/platform-management/configure-access-management.md
@@ -15,13 +15,10 @@ The Access Management settings page allows you to connect the Gamma console to y
 
 1. From the Gamma console sidebar, select **Platform Management**, then navigate to **Access Management**.
 2. In the **Connection details** section, provide your AM instance credentials:
-   <!-- Source: AmConfigPanel.tsx L50-L60, gravitee-gamma-module-platform @ d1bb5f8af7 -->
    * **Base URL**: The base URL of your AM management API.
    * **Access Token**: An administrative access token.
 3. Select **Verify Connection** to authenticate with your AM instance.
-   <!-- Source: AmConfigPanel.tsx L80-L90, gravitee-gamma-module-platform @ d1bb5f8af7 -->
 4. Once verified, select your **Environment** from the dropdown list.
-   <!-- Source: AmConnectionServiceImpl.java, fc993610d0 — environment_id now persisted -->
 5. Select your **Domain** from the available domains in the chosen environment.
 6. Select **Save** to apply the configuration.
 

--- a/docs/gamma/4.12/platform-management/configure-openapi-viewer.md
+++ b/docs/gamma/4.12/platform-management/configure-openapi-viewer.md
@@ -29,4 +29,3 @@ To configure the default OpenAPI viewer for your environment:
 
 The selected viewer will automatically be used to render all OpenAPI documentation pages in both the console and the Developer Portal.
 
-<!-- Source: OpenapiViewerPage.tsx — gravitee-gamma-module-aim -->

--- a/docs/gamma/4.12/platform-management/get-started/get-started-for-existing-users/activate-gamma-with-docker-compose.md
+++ b/docs/gamma/4.12/platform-management/get-started/get-started-for-existing-users/activate-gamma-with-docker-compose.md
@@ -3,7 +3,6 @@ hidden: false
 noIndex: false
 ---
 # Activate Gamma with Docker Compose
-<!-- GAP-STRUCTURAL: Missing procedural content source -->
 
 Gravitee Gamma is Gravitee's next-generation unified control plane. It brings API Management, Event Management, Agent Management, Authorization Management, and Platform Management together in a single console, so you manage your APIs, Kafka streams, AI agents and MCP servers, and authorization policies from one place.
 

--- a/docs/gamma/4.12/platform-management/get-started/get-started-for-existing-users/activate-gamma-with-kubernetes-helm.md
+++ b/docs/gamma/4.12/platform-management/get-started/get-started-for-existing-users/activate-gamma-with-kubernetes-helm.md
@@ -3,7 +3,6 @@ hidden: false
 noIndex: false
 ---
 # Activate Gamma with Kubernetes (Helm)
-<!-- GAP-STRUCTURAL: Missing procedural content source -->
 
 Gravitee Gamma is Gravitee's next-generation unified control plane. It brings API Management, Event Management, Agent Management, Authorization Management, and Platform Management together in a single console, so you manage your APIs, Kafka streams, AI agents and MCP servers, and authorization policies from one place.
 

--- a/docs/gamma/4.12/platform-management/install/hybrid-installation-guides/docker/README.md
+++ b/docs/gamma/4.12/platform-management/install/hybrid-installation-guides/docker/README.md
@@ -17,4 +17,3 @@ A hybrid Docker deployment runs the data plane only. The following table lists t
 
 <table><thead><tr><th>Component</th><th>Container name</th><th>Published port</th></tr></thead><tbody><tr><td>API Gateway</td><td><code>gio_gamma_hybrid_gateway</code></td><td><code>8082</code></td></tr><tr><td>Redis (rate limiting)</td><td><code>gio_gamma_hybrid_redis</code></td><td><code>6379</code></td></tr></tbody></table>
 
-<!-- TODO: Add a Gamma hybrid Docker architecture diagram -->

--- a/docs/gamma/4.12/platform-management/install/hybrid-installation-guides/docker/docker-cli.md
+++ b/docs/gamma/4.12/platform-management/install/hybrid-installation-guides/docker/docker-cli.md
@@ -3,7 +3,6 @@ hidden: false
 noIndex: false
 ---
 # Run a hybrid Gamma Gateway with Docker CLI
-<!-- GAP-STRUCTURAL: Missing procedural content source -->
 
 {% hint style="warning" %}
 This installation guide is for development and quick-start purposes only. Don't use it for production environments. For best practices for production environments, contact your Technical Account Manager.

--- a/docs/gamma/4.12/platform-management/install/hybrid-installation-guides/docker/docker-compose.md
+++ b/docs/gamma/4.12/platform-management/install/hybrid-installation-guides/docker/docker-compose.md
@@ -3,7 +3,6 @@ hidden: false
 noIndex: false
 ---
 # Run a hybrid Gamma Gateway with Docker Compose
-<!-- GAP-STRUCTURAL: Missing procedural content source -->
 
 {% hint style="warning" %}
 This installation guide is for development and quick-start purposes only. Don't use it for production environments. For best practices for production environments, contact your Technical Account Manager.

--- a/docs/gamma/4.12/platform-management/install/hybrid-installation-guides/kubernetes/aws-eks.md
+++ b/docs/gamma/4.12/platform-management/install/hybrid-installation-guides/kubernetes/aws-eks.md
@@ -3,7 +3,6 @@ hidden: false
 noIndex: false
 ---
 # Install a hybrid Gamma Gateway on AWS EKS
-<!-- GAP-STRUCTURAL: Missing procedural content source -->
 
 {% hint style="warning" %}
 This installation guide is for development and quick-start purposes only. Don't use it for production environments. For best practices for production environments, contact your Technical Account Manager.

--- a/docs/gamma/4.12/platform-management/install/hybrid-installation-guides/kubernetes/azure-aks.md
+++ b/docs/gamma/4.12/platform-management/install/hybrid-installation-guides/kubernetes/azure-aks.md
@@ -3,7 +3,6 @@ hidden: false
 noIndex: false
 ---
 # Install a hybrid Gamma Gateway on Azure AKS
-<!-- GAP-STRUCTURAL: Missing procedural content source -->
 
 {% hint style="warning" %}
 This installation guide is for development and quick-start purposes only. Don't use it for production environments. For best practices for production environments, contact your Technical Account Manager.

--- a/docs/gamma/4.12/platform-management/install/hybrid-installation-guides/kubernetes/openshift.md
+++ b/docs/gamma/4.12/platform-management/install/hybrid-installation-guides/kubernetes/openshift.md
@@ -3,7 +3,6 @@ hidden: false
 noIndex: false
 ---
 # Install a hybrid Gamma Gateway on OpenShift
-<!-- GAP-STRUCTURAL: Missing procedural content source -->
 
 {% hint style="warning" %}
 This installation guide is for development and quick-start purposes only. Don't use it for production environments. For best practices for production environments, contact your Technical Account Manager.

--- a/docs/gamma/4.12/platform-management/install/hybrid-installation-guides/kubernetes/vanilla-kubernetes.md
+++ b/docs/gamma/4.12/platform-management/install/hybrid-installation-guides/kubernetes/vanilla-kubernetes.md
@@ -3,7 +3,6 @@ hidden: false
 noIndex: false
 ---
 # Install a hybrid Gamma Gateway on Vanilla Kubernetes
-<!-- GAP-STRUCTURAL: Missing procedural content source -->
 
 {% hint style="warning" %}
 This installation guide is for development and quick-start purposes only. Don't use it for production environments. For best practices for production environments, contact your Technical Account Manager.

--- a/docs/gamma/4.12/platform-management/install/self-hosted-installation-guides/docker/README.md
+++ b/docs/gamma/4.12/platform-management/install/self-hosted-installation-guides/docker/README.md
@@ -17,4 +17,3 @@ Both Docker methods run the same set of containers. The following table lists th
 
 <table><thead><tr><th>Component</th><th>Container name</th><th>Published port</th></tr></thead><tbody><tr><td>API Gateway</td><td><code>gamma_gateway</code></td><td><code>8082</code></td></tr><tr><td>Management API (Gamma enabled)</td><td><code>gamma_management_api</code></td><td><code>8083</code></td></tr><tr><td>APIM Console</td><td><code>gamma_apim_console</code></td><td><code>8084</code></td></tr><tr><td>Developer Portal</td><td><code>gamma_portal</code></td><td><code>8085</code></td></tr><tr><td>Gamma console</td><td><code>gamma_console</code></td><td><code>8086</code></td></tr><tr><td>MongoDB</td><td><code>gamma_mongodb</code></td><td>n/a</td></tr><tr><td>Elasticsearch</td><td><code>gamma_elasticsearch</code></td><td>n/a</td></tr></tbody></table>
 
-<!-- TODO: Add a Gamma self-hosted Docker architecture diagram -->

--- a/docs/gamma/4.12/platform-management/install/self-hosted-installation-guides/kubernetes/aws-eks.md
+++ b/docs/gamma/4.12/platform-management/install/self-hosted-installation-guides/kubernetes/aws-eks.md
@@ -3,7 +3,6 @@ hidden: false
 noIndex: false
 ---
 # Install Gamma on AWS EKS
-<!-- GAP-STRUCTURAL: Missing procedural content source -->
 
 {% hint style="warning" %}
 This installation guide is for development and quick-start purposes only. Don't use it for production environments. For best practices for production environments, contact your Technical Account Manager.

--- a/docs/gamma/4.12/platform-management/install/self-hosted-installation-guides/kubernetes/azure-aks.md
+++ b/docs/gamma/4.12/platform-management/install/self-hosted-installation-guides/kubernetes/azure-aks.md
@@ -3,7 +3,6 @@ hidden: false
 noIndex: false
 ---
 # Install Gamma on Azure AKS
-<!-- GAP-STRUCTURAL: Missing procedural content source -->
 
 {% hint style="warning" %}
 This installation guide is for development and quick-start purposes only. Don't use it for production environments. For best practices for production environments, contact your Technical Account Manager.

--- a/docs/gamma/4.12/platform-management/install/self-hosted-installation-guides/kubernetes/openshift.md
+++ b/docs/gamma/4.12/platform-management/install/self-hosted-installation-guides/kubernetes/openshift.md
@@ -3,7 +3,6 @@ hidden: false
 noIndex: false
 ---
 # Install Gamma on OpenShift
-<!-- GAP-STRUCTURAL: Missing procedural content source -->
 
 {% hint style="warning" %}
 This installation guide is for development and quick-start purposes only. Don't use it for production environments. For best practices for production environments, contact your Technical Account Manager.

--- a/docs/gamma/4.12/platform-management/manage-applications.md
+++ b/docs/gamma/4.12/platform-management/manage-applications.md
@@ -57,7 +57,6 @@ Select an application from the list to view its detail page, which includes:
 * **User Permissions** — Manage direct members, configure group access, and transfer application ownership.
 * **Notifications** — Configure email and webhook notifications for application events.
 * **Subscriptions** — Active subscriptions to API plans. View subscription status, manage API keys, and see subscription history.
-<!-- Source: ApplicationUserPermissionsPage.tsx L1-L100, ApplicationNotificationSettingsPage.tsx L1-L100, gravitee-gamma-module-platform @ d1bb5f8af7 -->
 
 ## Next steps
 

--- a/docs/gamma/4.13/agent-management/build/configure-an-llm-proxy.md
+++ b/docs/gamma/4.13/agent-management/build/configure-an-llm-proxy.md
@@ -10,7 +10,6 @@ After creating an LLM Proxy, configure guardrails, PII filtering, rate limiting,
 
 ## Guardrails, PII filtering, and Rate limiting
 
-<!-- Source: src/main/ui/app/features/secure/pages/llm-router-detail/llm-studio/LlmStudioPage.tsx -->
 Guardrails, PII filtering, and rate limiting are implemented using standard Gravitee policies. You configure them by attaching policies with the LLM Studio.
 
 The LLM Studio operates just like the API Management policy studio, supporting request/response phases. To attach these controls:
@@ -22,13 +21,11 @@ The LLM Studio operates just like the API Management policy studio, supporting r
 
 ## Structured output
 
-<!-- Source: src/main/ui/lib/api/llm-proxy.types.ts -->
 Structured output enforces response format constraints on model responses. You can enforce structured output natively by overriding model parameters.
 When configuring a model within the LLM Proxy, you can supply a `parametersOverride` JSON object that supports Expression Language. The connector automatically merges this JSON object into the request payload before it reaches the upstream provider, so you can transparently enforce formatting such as `{"response_format": { "type": "json_object" }}`.
 
 ## Security
 
-<!-- Source: src/main/ui/app/components/create-plan/types.ts -->
 Security plans control how consumers authenticate when sending prompts through the LLM Proxy. You can add, modify, or replace plans after creation.
 
 To manage security plans:
@@ -48,7 +45,6 @@ See [Secure your API proxy](../../api-management/build/secure-your-api-proxy.md)
 
 ## Cost visibility
 
-<!-- Source: src/main/ui/config/templates/llm.template.ts -->
 The LLM Proxy provides real-time per-token cost attribution by provider and model. Every request records the model used, the input and output tokens consumed, and the cost based on the model's configured rate.
 
 This data is visualized in the **LLM — Overview** dashboard, which tracks `LLM_PROMPT_TOKEN_TOTAL_COST` alongside metrics like Requests by Provider and Tokens by Model.

--- a/docs/gamma/4.13/agent-management/build/configure-your-a2a-proxy/add-policies-to-a2a-proxy.md
+++ b/docs/gamma/4.13/agent-management/build/configure-your-a2a-proxy/add-policies-to-a2a-proxy.md
@@ -20,6 +20,5 @@ To attach policies to your A2A Proxy:
 7. Select the policy in the flow to configure its specific properties.
 8. Click **Save** to persist and apply your changes.
 
-<!-- Source: PolicyStudioPage.tsx @ 2a91746280 -->
 
 

--- a/docs/gamma/4.13/agent-management/build/configure-your-mcp/README.md
+++ b/docs/gamma/4.13/agent-management/build/configure-your-mcp/README.md
@@ -4,7 +4,6 @@ noIndex: false
 ---
 
 # Configure your MCP proxy
-<!-- GAP-STRUCTURAL: Missing procedural content source -->
 
 After creating an MCP Proxy, configure how it handles upstream authentication. These settings control how the proxy authenticates with upstream MCP servers on behalf of your users and agents.
 

--- a/docs/gamma/4.13/agent-management/build/configure-your-mcp/add-policies-to-mcp-server.md
+++ b/docs/gamma/4.13/agent-management/build/configure-your-mcp/add-policies-to-mcp-server.md
@@ -20,7 +20,6 @@ Policies operate on typed MCP objects — tool name, arguments, and resource URI
 
 ## Create a policy
 
-<!-- Source: mcp.ts (mcpServiceConfig), PolicyEditorSheet.tsx, PolicyStatementCard.tsx @ c07f5cdff9 -->
 
 MCP policies are managed through the **MCP Policies** page in Authorization Management. You can also access this page from within an MCP Proxy's detail view.
 
@@ -68,7 +67,6 @@ After creating a policy in Draft status:
 3. To suspend a deployed policy, select **Undeploy**. The gateway drops it within 30 seconds.
 
 ## SCIM integration for principals
-<!-- GAP: 30 · Confirmable · Document the SCIM connector setup flow for use with MCP Proxy policies. Demo 2 (00:35:57) and May 22 demo (00:06:13, Stuart Clark) confirm SCIM synchronization is functional. Needs: Demo session, Engineering input, UI verification -->
 
 You can sync users and groups from your enterprise identity provider into Authorization Management using SCIM (System for Cross-domain Identity Management) connectors. Synced users and groups become available as principals in your policies.
 

--- a/docs/gamma/4.13/agent-management/build/configure-your-mcp/apply-policies-to-mcp-methods.md
+++ b/docs/gamma/4.13/agent-management/build/configure-your-mcp/apply-policies-to-mcp-methods.md
@@ -16,8 +16,6 @@ To apply policies to a specific MCP method:
 3. In the sidebar, select **Policy Studio**.
 4. Create a new flow or select an existing one.
 5. In the flow configuration, define a selector for the target MCP method.
-<!-- GAP: 129 · Documentable · Document the exact UI fields or flow selectors used to target MCP methods (e.g., path operators, headers, or method types) in Policy Studio. Needs: Demo session, Source code -->
 6. Open the policy palette and drag your chosen policies onto the flow.
 7. Click **Save** to persist your changes.
 
-<!-- Source: PolicyStudioPage.tsx @ 2a91746280 -->

--- a/docs/gamma/4.13/agent-management/build/configure-your-mcp/apply-policies-to-tool-invocations.md
+++ b/docs/gamma/4.13/agent-management/build/configure-your-mcp/apply-policies-to-tool-invocations.md
@@ -16,8 +16,6 @@ To apply policies to a specific tool invocation:
 3. In the sidebar, select **Policy Studio**.
 4. Create a new flow or select an existing one.
 5. In the flow configuration, define a selector for the target tool.
-<!-- GAP: 130 · Documentable · Document the exact UI fields or flow selectors used to target individual tool invocations (e.g., tool name parameters) in Policy Studio. Needs: Demo session, Source code -->
 6. Open the policy palette and drag your chosen policies onto the flow.
 7. Click **Save** to persist your changes.
 
-<!-- Source: PolicyStudioPage.tsx @ 2a91746280 -->

--- a/docs/gamma/4.13/agent-management/build/create-an-llm-proxy.md
+++ b/docs/gamma/4.13/agent-management/build/create-an-llm-proxy.md
@@ -25,7 +25,6 @@ The LLM Proxy supports two modes for selecting upstream models:
 
 In **Inline mode**, you configure the provider and model directly in the wizard:
 
-<!-- Source: src/main/ui/app/features/secure/pages/llm-router-create/Step1Models.tsx -->
 | Field                     | Required | Description                                                                                                      |
 | ------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------- |
 | **Provider**              | Yes      | The upstream model format (`OPEN_AI`, `GEMINI`, `ANTHROPIC`, or `BEDROCK`).                                      |
@@ -53,7 +52,6 @@ You can configure multiple models on a single LLM Proxy. See [Configure an LLM P
 
 ## Step 4: Select a consumer plan
 
-<!-- Source: src/main/ui/app/components/create-plan/types.ts -->
 Choose how consumers authenticate when sending prompts through this LLM Proxy. The LLM Proxy supports the standard Gravitee API plan types:
 
 | Plan type   | Description                                                                                       |

--- a/docs/gamma/4.13/agent-management/build/create-an-mcp-proxy.md
+++ b/docs/gamma/4.13/agent-management/build/create-an-mcp-proxy.md
@@ -4,7 +4,6 @@ noIndex: false
 ---
 
 # Create an MCP proxy
-<!-- GAP-STRUCTURAL: Missing procedural content source -->
 
 An MCP Proxy sits in front of an upstream MCP server and applies governance — authentication, fine-grained authorization, observability, and rate limiting — to every tool invocation. The proxy speaks protocol-native MCP (JSON-RPC 2.0), operates on typed MCP objects (tool name, arguments, resource URI), and supports OAuth authorization discovery.
 

--- a/docs/gamma/4.13/agent-management/build/create-an-mcp-studio.md
+++ b/docs/gamma/4.13/agent-management/build/create-an-mcp-studio.md
@@ -4,7 +4,6 @@ noIndex: false
 ---
 
 # Create an MCP Studio
-<!-- GAP-STRUCTURAL: Missing procedural content source -->
 
 MCP Studio is a **mode** of the MCP Proxy — not a separate product. It's the authoring environment where you compose tools, resources, prompts, and skills from multiple sources into a **Composite MCP Server**: a new, governed MCP server that didn't exist as a single unit upstream.
 

--- a/docs/gamma/4.13/agent-management/build/edit-mcp-studio-composition.md
+++ b/docs/gamma/4.13/agent-management/build/edit-mcp-studio-composition.md
@@ -9,7 +9,6 @@ After creating an MCP Studio, you can modify its tool composition and upstream a
 
 ## Select and alias tools
 
-<!-- Source: gravitee-gamma-module-aim/src/main/ui/app/features/secure/pages/mcp-studio-wizard/steps/ComposeStep.tsx @ 167439e1 -->
 When building an MCP Studio, you can select which tools from your registered MCP servers to include in the composition. 
 
 If multiple upstream servers provide tools with identical names, you must configure an **Alias** for the colliding tools to ensure they can be uniquely identified by the Agent Identity. The Studio interface automatically flags colliding tool IDs and prevents saving the composition until unique aliases are provided.
@@ -23,7 +22,6 @@ To edit your tool composition:
 
 ## Configure upstream authentication
 
-<!-- Source: gravitee-gamma-module-aim/src/main/ui/app/features/secure/pages/mcp-studio-wizard/steps/UpstreamAuthStep.tsx @ 167439e1 -->
 If the tools you selected originate from an MCP server that requires upstream authentication (such as an OAuth2 provider or API Key), you must configure the credentials before the Studio can be published.
 
 The Studio automatically detects which upstream servers require authentication based on the selected tools.

--- a/docs/gamma/4.13/agent-management/build/expose-agent-with-a2a-proxy.md
+++ b/docs/gamma/4.13/agent-management/build/expose-agent-with-a2a-proxy.md
@@ -4,7 +4,6 @@ noIndex: false
 ---
 
 # Expose your agent with the A2A Proxy
-<!-- Source: CreateA2aProxyPage.tsx, FetchAgentCardUseCase.java -->
 
 The A2A (Agent-to-Agent) Proxy makes an agent's skills discoverable and callable by other agents — across trust boundaries, providers, and organizations. It implements the A2A protocol by serving a `/.well-known/agent.json` descriptor that advertises the agent's skills, and then governs every invocation through the AI Gateway.
 

--- a/docs/gamma/4.13/agent-management/get-started/ai-management-overview.md
+++ b/docs/gamma/4.13/agent-management/get-started/ai-management-overview.md
@@ -4,8 +4,6 @@ noIndex: false
 ---
 
 # Agent Management overview
-<!-- GAP-STRUCTURAL: Missing procedural content source -->
-<!-- GAP: 43 · Investigable · Add a platform architecture diagram showing the AI Gateway, Catalog, Agent Identity, and Edge Management components. Needs: Visual asset -->
 
 Agent Management (AM) is Gravitee's product line for governing AI agent traffic. It provides a unified control plane and runtime for every protocol in the agentic stack: LLM calls, MCP tool invocations, and agent-to-agent (A2A) delegations. It adds end-to-end observability, fine-grained authorization, and identity for every agent that touches your enterprise infrastructure.
 

--- a/docs/gamma/4.13/agent-management/get-started/create-your-first-mcp-server.md
+++ b/docs/gamma/4.13/agent-management/get-started/create-your-first-mcp-server.md
@@ -4,7 +4,6 @@ noIndex: false
 ---
 
 # Create your first MCP server
-<!-- GAP-STRUCTURAL: Missing procedural content source -->
 
 This quickstart walks you through creating an MCP Proxy in front of an upstream MCP server, so that every tool invocation passes through the AI Gateway with authentication, policy enforcement, and observability. You'll use the simplest configuration — Proxy mode with API key security — to get a governed MCP server running in under five minutes.
 

--- a/docs/gamma/4.13/agent-management/get-started/create-your-llm-proxy.md
+++ b/docs/gamma/4.13/agent-management/get-started/create-your-llm-proxy.md
@@ -4,7 +4,6 @@ noIndex: false
 ---
 
 # Create your LLM Proxy
-<!-- GAP-STRUCTURAL: Missing procedural content source -->
 
 
 This quickstart walks you through creating an LLM Proxy, connecting it to an upstream model provider, and sending a test prompt through the AI Gateway. You'll use the simplest configuration, a single model with API key authentication and a keyless consumer plan, to get a working LLM Proxy in under five minutes.

--- a/docs/gamma/4.13/agent-management/get-started/roles-and-permissions.md
+++ b/docs/gamma/4.13/agent-management/get-started/roles-and-permissions.md
@@ -9,7 +9,6 @@ Gravitee Agent Management uses a Role-Based Access Control (RBAC) system to gove
 
 ## Agent Management permissions
 
-<!-- Source: gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/access-management/utils/amConfig.ts @ 6f18c36855 -->
 The following core permissions govern access to Agent Management capabilities within a given environment:
 
 | Permission | Description |

--- a/docs/gamma/4.13/agent-management/import/add-an-ai-model.md
+++ b/docs/gamma/4.13/agent-management/import/add-an-ai-model.md
@@ -51,5 +51,3 @@ You can adjust the display name and description of an imported model:
 
 * **Create an LLM Proxy**: Route traffic to cataloged models. See [Create an LLM Proxy](../build/create-an-llm-proxy.md).
 
-<!-- Source: gravitee-gamma-module-aim/src/main/ui/app/features/catalog/models/ModelForm.tsx -->
-<!-- Source: gravitee-gamma-module-aim/src/main/ui/app/features/catalog/models/ImportModelsPage.tsx -->

--- a/docs/gamma/4.13/agent-management/import/add-an-mcp-registry.md
+++ b/docs/gamma/4.13/agent-management/import/add-an-mcp-registry.md
@@ -4,9 +4,6 @@ noIndex: false
 ---
 
 # Add an MCP Registry
-<!-- GAP-STRUCTURAL: Missing procedural content source -->
-<!-- GAP: 52 · Confirmable · Confirm the full list of supported registries in the June release. Needs: Engineering input -->
-<!-- GAP: 53 · Documentable · Document the exact UI steps for adding an MCP Registry. Needs: Demo session, Source code -->
 
 {% hint style="warning" %}
 **Coming soon.** Connecting to an external MCP registry and browsing or importing its servers is planned for a future release. To add an MCP server today, register it individually by URL. See [Register an MCP server](register-an-mcp-server.md).

--- a/docs/gamma/4.13/agent-management/import/add-knowledge-source.md
+++ b/docs/gamma/4.13/agent-management/import/add-knowledge-source.md
@@ -43,4 +43,3 @@ For Remote fetch, you can configure the **Document type**:
 * **Add MCP resources** — Catalog server resources. See [Add MCP resources](add-mcp-resources.md).
 * **Compose into a Studio** — Include knowledge sources as context in a Composite MCP Server. See [Create an MCP Studio](../build/create-an-mcp-studio.md).
 
-<!-- Source: gravitee-gamma-module-aim/src/main/ui/app/features/catalog/knowledge/KnowledgeForm.tsx -->

--- a/docs/gamma/4.13/agent-management/import/add-mcp-resources.md
+++ b/docs/gamma/4.13/agent-management/import/add-mcp-resources.md
@@ -29,4 +29,3 @@ If you want to manually upload structured documentation, files, or reference mat
 
 * **Compose into a Studio** — Include cataloged resources as context in a Composite MCP Server. See [Create an MCP Studio](../build/create-an-mcp-studio.md).
 
-<!-- Source: gravitee-gamma-module-aim/src/main/ui/app/features/catalog/resources/McpResourcesPage.tsx -->

--- a/docs/gamma/4.13/agent-management/import/connect-integrations.md
+++ b/docs/gamma/4.13/agent-management/import/connect-integrations.md
@@ -44,4 +44,3 @@ Once connected and imported, the models appear in the AI Models catalog and beco
 * **Add models manually** — For providers without an integration, register models individually. See [Add an AI model](add-an-ai-model.md).
 * **Import agents** — View and manage agents synced from connected integrations. See [Import an agent](import-an-agent.md).
 
-<!-- Source: gravitee-gamma-module-aim/src/main/ui/app/features/catalog/models/ImportModelsPage.tsx -->

--- a/docs/gamma/4.13/agent-management/import/create-api-tools.md
+++ b/docs/gamma/4.13/agent-management/import/create-api-tools.md
@@ -47,5 +47,3 @@ When you create an API Tool from an API proxy, the tool inherits:
 
 * **Compose into a Studio** — Include API Tools in a Composite MCP Server alongside MCP-native tools. See [Create an MCP Studio](../build/create-an-mcp-studio.md).
 
-<!-- Source: gravitee-gamma-module-aim/src/main/ui/app/features/catalog/tools/api-tools/Step1Sources.tsx -->
-<!-- Source: gravitee-gamma-module-aim/src/main/ui/app/features/catalog/tools/api-tools/Step2Capabilities.tsx -->

--- a/docs/gamma/4.13/agent-management/import/import-an-agent.md
+++ b/docs/gamma/4.13/agent-management/import/import-an-agent.md
@@ -49,4 +49,3 @@ Once an agent is registered in the Catalog, you can:
 * [Create an agent identity](../build/create-an-agent-identity.md) — Assign a verifiable identity to a registered agent.
 * [Expose your agent with the A2A Proxy](../build/expose-agent-with-a2a-proxy.md) — Make agent skills available across trust boundaries.
 
-<!-- Source: gravitee-gamma-module-aim/src/main/ui/app/features/catalog/agents/NewAgentPage.tsx -->

--- a/docs/gamma/4.13/agent-management/import/import-prompts.md
+++ b/docs/gamma/4.13/agent-management/import/import-prompts.md
@@ -35,4 +35,3 @@ To review cataloged prompts:
 
 * **Compose into a Studio** — Include cataloged prompts in a Composite MCP Server. See [Create an MCP Studio](../build/create-an-mcp-studio.md).
 
-<!-- Source: gravitee-gamma-module-aim/src/main/ui/app/features/catalog/prompts/McpPromptsPage.tsx -->

--- a/docs/gamma/4.13/agent-management/import/register-an-mcp-server.md
+++ b/docs/gamma/4.13/agent-management/import/register-an-mcp-server.md
@@ -4,7 +4,6 @@ noIndex: false
 ---
 
 # Register an MCP server
-<!-- GAP-STRUCTURAL: Missing procedural content source -->
 
 Registering an MCP server adds it to the Catalog as a first-class entity — along with its tools, resources, and prompts. Once registered, the server's capabilities become available for use in MCP Proxies, MCP Studios, and authorization policies.
 

--- a/docs/gamma/4.13/agent-management/import/upload-skills.md
+++ b/docs/gamma/4.13/agent-management/import/upload-skills.md
@@ -38,4 +38,3 @@ The skill is extracted, analyzed, and added to the Catalog. It becomes available
 
 * **Compose into a Studio** — Include skills as resources in a Composite MCP Server. See [Create an MCP Studio](../build/create-an-mcp-studio.md).
 
-<!-- Source: gravitee-gamma-module-aim/src/main/ui/app/features/catalog/skills/UploadSkillPage.tsx -->

--- a/docs/gamma/4.13/agent-management/observe/inspect-your-agent-log.md
+++ b/docs/gamma/4.13/agent-management/observe/inspect-your-agent-log.md
@@ -4,9 +4,6 @@ noIndex: false
 ---
 
 # Inspect your agent log
-<!-- GAP-STRUCTURAL: Missing procedural content source -->
-<!-- GAP: 70 · Documentable · Document the lineage view UI — how to navigate traces, expand spans, filter. Needs: Demo session -->
-<!-- GAP: 71 · Documentable · Document the search and filter capabilities in the agent log. Needs: UI verification -->
 
 The agent log provides a detailed trace of every agent invocation through the AI Gateway, using OpenTelemetry (OTel) spans. Each span captures the full context of a single operation — who made the call, what tool was invoked, what data was sent and received, how long it took, what policies were evaluated, and what it cost.
 

--- a/docs/gamma/4.13/agent-management/observe/monitor-ai-gateway-from-devices.md
+++ b/docs/gamma/4.13/agent-management/observe/monitor-ai-gateway-from-devices.md
@@ -4,8 +4,6 @@ noIndex: false
 ---
 
 # Monitor AI Gateway usage from employee systems
-<!-- GAP-STRUCTURAL: Missing procedural content source -->
-<!-- GAP: 72 · Confirmable · Confirm the full set of metrics available and the time range/granularity options. Needs: Demo session, Engineering input -->
 
 The Edge Management dashboard provides centralized visibility into AI traffic originating from employee devices where the Edge Daemon is installed. This dashboard is the control plane complement to the Edge Daemon's local enforcement — it shows what's happening across your entire device fleet.
 

--- a/docs/gamma/4.13/agent-management/observe/monitor-your-mcp-servers.md
+++ b/docs/gamma/4.13/agent-management/observe/monitor-your-mcp-servers.md
@@ -4,9 +4,6 @@ noIndex: false
 ---
 
 # Monitor your MCP servers
-<!-- GAP-STRUCTURAL: Missing procedural content source -->
-<!-- GAP: 73 · Investigable · No source material covers the MCP-specific observability UI. Needs: Demo session, Source code, Engineering input, UI verification -->
-<!-- GAP: 74 · Documentable · Document the MCP server metrics dashboard. Needs: Investigation -->
 
 Monitor tool invocation metrics, error rates, and latency for your MCP Proxies through the AI Gateway observability layer.
 

--- a/docs/gamma/4.13/agent-management/publish/expose-an-mcp-registry.md
+++ b/docs/gamma/4.13/agent-management/publish/expose-an-mcp-registry.md
@@ -4,8 +4,6 @@ noIndex: true
 ---
 
 # Expose an MCP Registry
-<!-- GAP-STRUCTURAL: Missing procedural content source -->
-<!-- GAP: 75 · Documentable · Document the exact UI steps for exposing the Catalog as an MCP Registry. Needs: Demo session, Source code, UI verification -->
 
 {% hint style="warning" %}
 **Coming soon.** Exposing the Catalog as a discoverable MCP Registry (outbound federation) is part of the platform vision and is planned for a future release. This page describes the intended capability, not a shipped flow.

--- a/docs/gamma/4.13/agent-management/publish/manage-subscriptions.md
+++ b/docs/gamma/4.13/agent-management/publish/manage-subscriptions.md
@@ -9,7 +9,6 @@ Consumers access your LLM Proxies and MCP Proxies by subscribing to the security
 
 ## Subscription lifecycle
 
-<!-- Source: gravitee-gamma-module-aim/src/test/java/com/graviteesource/gamma/module/aim/infra/service_provider/subscription/SubscriptionApimInMemory.java @ 9e2bb196 -->
 Subscriptions to Agent Management resources follow a strict approval lifecycle:
 
 1. **Pending**: When a consumer requests access to a plan that requires validation, the subscription is placed in a `PENDING` state.

--- a/docs/gamma/4.13/agent-management/publish/publish-your-llm-proxy.md
+++ b/docs/gamma/4.13/agent-management/publish/publish-your-llm-proxy.md
@@ -15,13 +15,11 @@ Publishing an LLM Proxy makes it accessible to consumers through the AI Gateway.
 
 ## Publish the LLM Proxy
 
-<!-- Source: src/main/ui/app/features/secure/pages/llm-router-detail/LlmRouterDetailLayout.tsx -->
 1. Navigate to the LLM Proxy detail page.
 2. If the LLM Proxy was created without the **Deploy** option or if you have unpublished changes, a banner will appear at the top indicating that the proxy is **Out of Sync**.
 3. Select **Deploy** from the banner to push the configuration to the AI Gateway.
 4. Once deployed, the LLM Proxy is live at its configured context path.
 
-<!-- Source: src/main/ui/app/features/secure/pages/llm-router-create/Step1Models.tsx -->
 The Universal LLM Router exposes a single endpoint that simultaneously supports multiple formats (OpenAI API, Anthropic API, and Gemini API). You can send prompts using any of these native formats; the router will route across providers and convert the responses back to the format you requested.
 
 Consumers can now send prompts to paths such as:

--- a/docs/gamma/4.13/api-management/build/api-products.md
+++ b/docs/gamma/4.13/api-management/build/api-products.md
@@ -4,7 +4,6 @@ noIndex: false
 ---
 
 # Create API Products
-<!-- GAP-STRUCTURAL: Missing procedural content source -->
 
 API Products let you bundle multiple API proxies into a single consumer-facing product. Instead of subscribing to individual APIs, consumers subscribe to an API Product plan and gain access to all APIs in the product.
 

--- a/docs/gamma/4.13/api-management/build/configure-your-api-product/README.md
+++ b/docs/gamma/4.13/api-management/build/configure-your-api-product/README.md
@@ -4,7 +4,6 @@ noIndex: false
 ---
 
 # Configure API products
-<!-- GAP-STRUCTURAL: Missing procedural content source -->
 
 After creating an API product, use the product detail page to attach APIs, create plans, manage consumers, and control team access.
 

--- a/docs/gamma/4.13/api-management/build/configure-your-api-product/manage-product-apis.md
+++ b/docs/gamma/4.13/api-management/build/configure-your-api-product/manage-product-apis.md
@@ -4,7 +4,6 @@ noIndex: false
 ---
 
 # Manage product APIs
-<!-- GAP-STRUCTURAL: Missing procedural content source -->
 
 The **APIs** tab in the API Product detail page lets you attach and detach API proxies from the product. Consumers who subscribe to the product's plans gain access to all attached APIs.
 

--- a/docs/gamma/4.13/api-management/build/configure-your-api-proxy/README.md
+++ b/docs/gamma/4.13/api-management/build/configure-your-api-proxy/README.md
@@ -4,7 +4,6 @@ noIndex: false
 ---
 
 # Configure your API proxy
-<!-- GAP-STRUCTURAL: Missing procedural content source -->
 
 After creating and securing an API proxy, you can refine its behavior through additional configuration. This section covers endpoint configuration, consumer access management, and policy enforcement.
 

--- a/docs/gamma/4.13/api-management/build/configure-your-api-proxy/apply-security-policies.md
+++ b/docs/gamma/4.13/api-management/build/configure-your-api-proxy/apply-security-policies.md
@@ -18,7 +18,6 @@ Each policy in the chain can inspect, transform, or reject the request or respon
 
 ## Authorization Management integration
 
-<!-- Source: apis.ts (apisServiceConfig), PolicyEditorSheet.tsx, ServicePolicyPage.tsx @ c07f5cdff9 -->
 
 In Gamma, API proxies can use **Authorization Management** for fine-grained, catalog-aware authorization that goes beyond plan-level authentication. The Policy Decision Point (PDP) runs directly inside the API Gateway with microsecond-scale latency and no network hop.
 

--- a/docs/gamma/4.13/api-management/build/configure-your-api-proxy/configure-backend-security.md
+++ b/docs/gamma/4.13/api-management/build/configure-your-api-proxy/configure-backend-security.md
@@ -4,7 +4,6 @@ noIndex: false
 ---
 
 # Configure endpoints
-<!-- GAP-STRUCTURAL: Missing procedural content source -->
 
 Endpoints define where the API Gateway routes requests after authentication. Each endpoint group points to one or more backend services and controls how the Gateway connects to them — load balancing, timeouts, SSL/TLS, proxy settings, and custom headers.
 

--- a/docs/gamma/4.13/api-management/build/configure-your-api-proxy/configure-flow-execution.md
+++ b/docs/gamma/4.13/api-management/build/configure-your-api-proxy/configure-flow-execution.md
@@ -16,12 +16,10 @@ Gamma supports two flow execution modes for API Proxies:
 * **Default (`DEFAULT`)**: The Gateway executes all flows that match the incoming request. This is useful when you want to apply multiple cross-cutting policies (like logging or header injection) that should trigger cumulatively on a request.
 * **Best match (`BEST_MATCH`)**: The Gateway evaluates all flows and executes only the *single* flow that is the closest match to the incoming request. This is useful when you have mutually exclusive behaviors defined on overlapping paths or conditions.
 
-<!-- Source: usePolicyStudioData.ts, types/policyStudio.ts @ 2a91746280 -->
 
 > [!NOTE]
 > V2 API definition proxies support the same flow execution semantics via their legacy `flowMode` configuration, which is fully compatible with the new Policy Studio interface.
 
-<!-- Source: v2FlowAdapter.ts @ 2a91746280 -->
 
 ## Configure flow execution
 
@@ -33,4 +31,3 @@ To change the flow execution mode for your API:
 4. Adjust the **Flow Execution** setting to either `DEFAULT` or `BEST_MATCH`.
 5. Click **Save** to persist your changes.
 
-<!-- Source: PolicyStudioPage.tsx, usePolicyStudioSave.ts @ 2a91746280 -->

--- a/docs/gamma/4.13/api-management/build/configure-your-api-proxy/establish-consumer-access.md
+++ b/docs/gamma/4.13/api-management/build/configure-your-api-proxy/establish-consumer-access.md
@@ -4,7 +4,6 @@ noIndex: false
 ---
 
 # Establish consumer access
-<!-- GAP-STRUCTURAL: Missing procedural content source -->
 
 Consumer access controls how external applications discover, subscribe to, and authenticate with your API. This page covers the application model, subscription workflows, and API key management in the Gamma console.
 

--- a/docs/gamma/4.13/api-management/build/create-an-api-proxy.md
+++ b/docs/gamma/4.13/api-management/build/create-an-api-proxy.md
@@ -4,7 +4,6 @@ noIndex: false
 ---
 
 # Create an API proxy
-<!-- GAP-STRUCTURAL: Missing procedural content source -->
 
 An API proxy is the core artifact in API Management. It defines a context path or virtual host that consumers use to reach your API, forwards requests to an upstream backend, and applies security plans and policies at runtime through the API Gateway.
 

--- a/docs/gamma/4.13/api-management/build/secure-your-api-proxy.md
+++ b/docs/gamma/4.13/api-management/build/secure-your-api-proxy.md
@@ -4,7 +4,6 @@ noIndex: false
 ---
 
 # Secure your API proxy
-<!-- GAP-STRUCTURAL: Missing procedural content source -->
 
 After creating an API proxy, attach one or more security plans to control how consumers authenticate. Plans define the authentication mechanism the API Gateway enforces at runtime — every incoming request is evaluated against the active plans before it reaches your backend.
 

--- a/docs/gamma/4.13/api-management/build/shared-policy-groups.md
+++ b/docs/gamma/4.13/api-management/build/shared-policy-groups.md
@@ -16,7 +16,6 @@ Shared Policy Groups integrate seamlessly into your API proxy flows:
 * **API type compatibility**: Shared policy groups are typed and validate compatibility with your API proxy's protocol type.
 * **Prerequisite messaging**: If a shared policy group has unfulfilled prerequisites, the Policy Studio will display its configuration prerequisites in the builder.
 
-<!-- Source: types/policyStudio.ts, usePolicyStudioData.ts @ 2a91746280 -->
 
 ## Attach a Shared Policy Group
 
@@ -30,4 +29,3 @@ To reuse a Shared Policy Group in your API flows:
 6. Drag and drop the Shared Policy Group onto the desired phase in your flow.
 7. Click **Save** to deploy the updated flow.
 
-<!-- Source: PolicyStudioPage.tsx, usePolicyStudioData.ts @ 2a91746280 -->

--- a/docs/gamma/4.13/api-management/get-started/api-management-overview.md
+++ b/docs/gamma/4.13/api-management/get-started/api-management-overview.md
@@ -4,7 +4,6 @@ noIndex: false
 ---
 
 # API Management overview
-<!-- GAP-STRUCTURAL: Missing procedural content source -->
 
 API Management is Gravitee's product line for governing REST, GraphQL, and gRPC traffic. Within Gamma, API Management provides a dedicated console for creating, securing, and monitoring API proxies — the core building block that mediates between consumers and backend services.
 

--- a/docs/gamma/4.13/api-management/get-started/create-your-first-api.md
+++ b/docs/gamma/4.13/api-management/get-started/create-your-first-api.md
@@ -4,7 +4,6 @@ noIndex: false
 ---
 
 # Create your first API
-<!-- GAP-STRUCTURAL: Missing procedural content source -->
 
 This quickstart walks you through creating an API proxy in the Gamma console, deploying it to the API Gateway, and verifying it with a test request. You'll use the simplest configuration — a keyless plan with a single upstream — to get a working proxy in under five minutes.
 

--- a/docs/gamma/4.13/api-management/observe/monitor-api-usage.md
+++ b/docs/gamma/4.13/api-management/observe/monitor-api-usage.md
@@ -4,7 +4,6 @@ noIndex: false
 ---
 
 # Monitor API usage
-<!-- GAP-STRUCTURAL: Missing procedural content source -->
 The API usage dashboard provides real-time and historical metrics for your API proxies, including request volume, latency distribution, error rates, and consumer-level analytics.
 
 ## Dashboard overview

--- a/docs/gamma/4.13/api-management/observe/monitor-endpoint-health.md
+++ b/docs/gamma/4.13/api-management/observe/monitor-endpoint-health.md
@@ -15,7 +15,6 @@ The Endpoint Health Check Dashboard provides real-time visibility into the avail
 1. From the Gamma console sidebar, select **API Management**, then navigate to **APIs**.
 2. Select an API from the list to view its detail page.
 3. In the API sub-navigation menu, select **Endpoints**, then select the **Health Check Dashboard** tab.
-   <!-- Source: ApiDetailSidebarNav.tsx L20-L30, gravitee-gamma-module-apim @ d1bb5f8af7 -->
 
 ## Dashboard metrics
 
@@ -23,9 +22,7 @@ The dashboard displays several key metrics and visualizations:
 
 * **Global Metrics**: High-level summary of availability, average response time, and total failures over the selected timeframe.
 * **Availability by Field**: A table breaking down availability statistics by specific endpoint or group.
-  <!-- Source: AvailabilityByFieldTable.tsx L15-L45, gravitee-gamma-module-apim @ d1bb5f8af7 -->
 * **Response Time Trend**: A chart displaying the historical trend of endpoint response times.
-  <!-- Source: ResponseTimeTrendChart.tsx L15-L50, gravitee-gamma-module-apim @ d1bb5f8af7 -->
 
 Use the timeframe filter at the top of the dashboard to adjust the monitoring window (e.g., last hour, last 24 hours).
 
@@ -34,13 +31,10 @@ Use the timeframe filter at the top of the dashboard to adjust the monitoring wi
 The **Failed Health Checks** table lists all unsuccessful endpoint verification attempts within the selected timeframe.
 
 1. Locate the **Failed Health Checks** table at the bottom of the dashboard.
-   <!-- Source: FailedHealthChecksTable.tsx L20-L60, gravitee-gamma-module-apim @ d1bb5f8af7 -->
 2. Review the list of failures, which includes the timestamp, endpoint name, HTTP status, and error message.
 3. Select the **Details** icon next to a failed check to open the log detail sheet.
 4. Review the raw request and response data in the log detail sheet to diagnose the root cause of the failure.
-   <!-- Source: HealthCheckLogDetailSheet.tsx L30-L80, gravitee-gamma-module-apim @ d1bb5f8af7 -->
 
-<!-- GAP: 128 · Confirmable · Confirm if the health check dashboard supports exporting logs or metrics to external monitoring systems. Needs: UI verification -->
 
 ## Next steps
 

--- a/docs/gamma/4.13/api-management/observe/view-api-logs.md
+++ b/docs/gamma/4.13/api-management/observe/view-api-logs.md
@@ -4,7 +4,6 @@ noIndex: false
 ---
 
 # View API logs
-<!-- GAP-STRUCTURAL: Missing procedural content source -->
 API logs provide a detailed record of every request processed by the API Gateway for a specific API proxy. Gamma exposes native log viewing and a **Trace Explorer** under the Observability section, giving you full request traces and span data to help you debug and analyze your API traffic.
 
 ## Access logs and traces

--- a/docs/gamma/4.13/authorization-management/authz-gateway-sync.md
+++ b/docs/gamma/4.13/authorization-management/authz-gateway-sync.md
@@ -22,4 +22,3 @@ By evaluating authorization rules locally at the Gateway (the Policy Enforcement
 
 Gamma's AuthZEN PDP is fully multi-tenant. If you run multiple environments or tenants on the same Gateway, the PDP strongly isolates the policies and authorization data, ensuring that decisions are always scoped strictly to the calling tenant.
 
-<!-- Source: AimResourceIntegrationTest.java — gravitee-gamma-module-aim -->

--- a/docs/gamma/4.13/authorization-management/evaluate/analytics-sent-to-control-plane.md
+++ b/docs/gamma/4.13/authorization-management/evaluate/analytics-sent-to-control-plane.md
@@ -9,7 +9,6 @@ Understand the observability data that PDP gateways send back to the Gravitee co
 
 {% hint style="warning" %}
 This feature is under active development and may not be available in all environments at this time.
-<!-- GAP: Analytics reporting from PDP gateways to the control plane is referenced in the QuickStart page KPI tiles and the DashboardPage infrastructure, but the specific metrics payload, collection interval, and dashboard visualizations need engineering confirmation. -->
 {% endhint %}
 
 ## Overview

--- a/docs/gamma/4.13/authorization-management/get-started/authorization-management-overview.md
+++ b/docs/gamma/4.13/authorization-management/get-started/authorization-management-overview.md
@@ -4,7 +4,6 @@ noIndex: false
 ---
 
 # Authorization Management overview
-<!-- GAP-STRUCTURAL: Missing procedural content source -->
 
 Authorization Management provides fine-grained, catalog-aware access control across all Gamma traffic types — APIs, MCP servers, AI models, agents, events, and custom resources. Policies are written in GAPL (Gravitee Authorization Policy Language), a subset of the Cedar policy language, and enforced at the wire level by Gamma's gateways.
 
@@ -90,7 +89,6 @@ Each policy has a status:
 | **Disabled** | The policy was previously deployed but is now suspended without deletion.             |
 
 ## Integration with other product areas
-<!-- GAP: 126 · Narrowed · AGENT and EVENT policy types exist in entity-kind-registry.ts but have no dedicated ServicePageConfig files or policy management pages. DashboardPage.tsx confirms Agents and 'Users and groups' cards show 'Coming soon'. Needs: Engineering input -->
 
 Authorization Management is not isolated — it integrates with the API Gateway, AI Gateway, and Event Gateway as a shared enforcement layer:
 

--- a/docs/gamma/4.13/authorization-management/manage/schemas/edit-your-schema.md
+++ b/docs/gamma/4.13/authorization-management/manage/schemas/edit-your-schema.md
@@ -9,7 +9,6 @@ Modify an existing schema to add entity types, attributes, relationships, or act
 
 {% hint style="warning" %}
 This feature is under active development and may not be available in all environments at this time.
-<!-- GAP: Schema editing UI exists in SchemaPage.tsx (Edit button, Monaco editor, Save/Cancel, validation diagnostics), but the schema DSL syntax and advanced editing workflows need SME confirmation for documentation completeness. -->
 {% endhint %}
 
 ## Editing workflow

--- a/docs/gamma/4.13/authorization-management/manage/schemas/validate-schema-changes.md
+++ b/docs/gamma/4.13/authorization-management/manage/schemas/validate-schema-changes.md
@@ -9,7 +9,6 @@ Understand how the console validates schema changes before saving and what error
 
 {% hint style="warning" %}
 This feature is under active development and may not be available in all environments at this time.
-<!-- GAP: Schema validation backend endpoint behavior and specific error codes need SME confirmation. Current documentation covers the client-side validation UX from SchemaPage.tsx and useSchemaValidation.ts. -->
 {% endhint %}
 
 ## Validation pipeline

--- a/docs/gamma/4.13/edge-management/connect/configure-kandji-daemon.md
+++ b/docs/gamma/4.13/edge-management/connect/configure-kandji-daemon.md
@@ -5,7 +5,6 @@ description: How to deploy the Edge Daemon to your macOS device fleet using Kand
 ---
 
 # Configure Kandji to deploy the Edge Daemon
-<!-- GAP-STRUCTURAL: Missing procedural content source -->
 
 Deploy the Edge Daemon to your device fleet using Kandji MDM. The Gamma console generates the download URL and the Kandji installation script for you, from the **Daemon Deployment** section of the Edge Management configuration page.
 

--- a/docs/gamma/4.13/event-stream-management/build/create-a-kafka-service-with-a-registered-cluster.md
+++ b/docs/gamma/4.13/event-stream-management/build/create-a-kafka-service-with-a-registered-cluster.md
@@ -5,7 +5,6 @@ noIndex: false
 <--- to be published --->
 
 # Create a Kafka service with a registered cluster
-<!-- Source: gravitee-gamma-module-esm/src/main/ui/features/kafka-apis/components/create/CreateNativeApiWizard.tsx -->
 
 A Kafka Service is the client-facing endpoint managed by Gravitee. It is the Event Stream Management equivalent of an API proxy — the Kafka Service is the governance layer that enforces authentication, security plans, ACLs, and quotas before routing traffic to the backend infrastructure. 
 

--- a/docs/gamma/4.13/event-stream-management/build/create-a-kafka-service-with-a-virtual-cluster.md
+++ b/docs/gamma/4.13/event-stream-management/build/create-a-kafka-service-with-a-virtual-cluster.md
@@ -5,7 +5,6 @@ noIndex: false
 <--- to be published --->
 
 # Create a Kafka service with a Virtual Cluster
-<!-- GAP-STRUCTURAL: Missing procedural content source -->
 
 A Kafka Service backed by a Virtual Cluster lets you govern access to a federated multi-cluster Kafka environment through a single endpoint. The Virtual Cluster fans out requests across its backend Registered Clusters, while the Kafka Service adds the governance layer — security plans, policies, and observability — on top of that unified endpoint.
 

--- a/docs/gamma/4.13/event-stream-management/build/establish-a-virtual-cluster.md
+++ b/docs/gamma/4.13/event-stream-management/build/establish-a-virtual-cluster.md
@@ -4,7 +4,6 @@ noIndex: false
 ---
 <-- to be published-->
 # Establish a Virtual Cluster
-<!-- Source: CreateVirtualClusterPage.tsx — gravitee-gamma-module-esm -->
 
 A Virtual Cluster federates multiple independent Kafka backends into a single unified endpoint. Instead of managing separate cluster connections for each team or workload, a Virtual Cluster lets clients connect to one endpoint and transparently interact with topics spread across multiple underlying Registered Clusters.
 

--- a/docs/gamma/4.13/event-stream-management/build/kafka-virtual-cluster-runtime-behavior-reference.md
+++ b/docs/gamma/4.13/event-stream-management/build/kafka-virtual-cluster-runtime-behavior-reference.md
@@ -3,7 +3,6 @@ hidden: false
 noIndex: false
 ---
 # Virtual Cluster runtime behavior
-<!-- GAP-STRUCTURAL: Missing procedural content source -->
 
 This page describes what happens when a Virtual Cluster is active on the Event Gateway — how it handles client requests, routes them across backends, and presents a unified view to clients.
 

--- a/docs/gamma/4.13/event-stream-management/get-started/create-your-first-kafka-service.md
+++ b/docs/gamma/4.13/event-stream-management/get-started/create-your-first-kafka-service.md
@@ -3,7 +3,6 @@ hidden: false
 noIndex: false
 ---
 # Create your first Kafka service
-<!-- Source: gravitee-gamma-module-esm/src/main/ui/features/kafka-apis/components/create/CreateNativeApiWizard.tsx -->
 
 This quickstart walks you through creating a governed Kafka Service in the Gamma console. You'll use the simplest configuration — a standalone endpoint with a keyless plan — to get a working Kafka Service in under five minutes.
 

--- a/docs/gamma/4.13/event-stream-management/get-started/create-your-first-virtual-cluster.md
+++ b/docs/gamma/4.13/event-stream-management/get-started/create-your-first-virtual-cluster.md
@@ -56,4 +56,3 @@ After creation, you are navigated to the Virtual Cluster's overview page, where 
 
 * **Add a Kafka Service** — Apply security plans and policies on top of the Virtual Cluster. See [Establish a Virtual Cluster](../build/establish-a-virtual-cluster.md).
 
-<!-- Source: CreateVirtualClusterPage.tsx — gravitee-gamma-module-esm -->

--- a/docs/gamma/4.13/event-stream-management/get-started/event-stream-management-overview.md
+++ b/docs/gamma/4.13/event-stream-management/get-started/event-stream-management-overview.md
@@ -8,7 +8,6 @@ Event Stream Management is Gravitee's product line for governing Kafka clusters,
 
 <figure><img src="../../.gitbook/assets/gamma-esm-dashboard.png" alt="Event Stream Management dashboard showing Kafka Services, Virtual Clusters, and Clusters cards with counts and status breakdowns"><figcaption><p>The Event Stream Management dashboard. The three cards show Kafka Services (lifecycle management), Virtual Clusters (Kafka Mesh composition), and Clusters (multi-connection registrations).</p></figcaption></figure>
 
-<!-- Source: applications.ts — gravitee-gamma-control-plane-webui @ cb0911bad0 -->
 
 ## What Event Stream Management does
 

--- a/docs/gamma/4.13/event-stream-management/get-started/register-your-first-cluster.md
+++ b/docs/gamma/4.13/event-stream-management/get-started/register-your-first-cluster.md
@@ -3,7 +3,6 @@ hidden: false
 noIndex: false
 ---
 # Register your first cluster
-<!-- Source: gravitee-gamma-module-esm/src/main/ui/features/clusters/components/create/CreateClusterWizard.tsx -->
 
 This quickstart walks you through registering your first Kafka cluster in the Gamma console and adding its first connection. Registering a cluster is the foundational first step — Kafka Services and Virtual Clusters are built on top of registered clusters.
 

--- a/docs/gamma/4.13/event-stream-management/import/register-your-kafka-clusters.md
+++ b/docs/gamma/4.13/event-stream-management/import/register-your-kafka-clusters.md
@@ -54,7 +54,6 @@ After registration, you can view and update cluster details from the Clusters pa
 Removing a cluster registration does not affect the cluster itself — it only removes Gamma's connection to it. Any Kafka Services or Virtual Clusters built on top of the cluster will lose their underlying connection.
 {% endhint %}
 
-<!-- Source: ClustersPage.tsx and CreateClusterWizard.tsx — gravitee-gamma-module-esm -->
 
 ## Next steps
 

--- a/docs/gamma/4.13/platform-management/configure-access-management.md
+++ b/docs/gamma/4.13/platform-management/configure-access-management.md
@@ -15,13 +15,10 @@ The Access Management settings page allows you to connect the Gamma console to y
 
 1. From the Gamma console sidebar, select **Platform Management**, then navigate to **Access Management**.
 2. In the **Connection details** section, provide your AM instance credentials:
-   <!-- Source: AmConfigPanel.tsx L50-L60, gravitee-gamma-module-platform @ d1bb5f8af7 -->
    * **Base URL**: The base URL of your AM management API.
    * **Access Token**: An administrative access token.
 3. Select **Verify Connection** to authenticate with your AM instance.
-   <!-- Source: AmConfigPanel.tsx L80-L90, gravitee-gamma-module-platform @ d1bb5f8af7 -->
 4. Once verified, select your **Environment** from the dropdown list.
-   <!-- Source: AmConnectionServiceImpl.java, fc993610d0 — environment_id now persisted -->
 5. Select your **Domain** from the available domains in the chosen environment.
 6. Select **Save** to apply the configuration.
 

--- a/docs/gamma/4.13/platform-management/configure-openapi-viewer.md
+++ b/docs/gamma/4.13/platform-management/configure-openapi-viewer.md
@@ -29,4 +29,3 @@ To configure the default OpenAPI viewer for your environment:
 
 The selected viewer will automatically be used to render all OpenAPI documentation pages in both the console and the Developer Portal.
 
-<!-- Source: OpenapiViewerPage.tsx — gravitee-gamma-module-aim -->

--- a/docs/gamma/4.13/platform-management/get-started/get-started-for-existing-users/activate-gamma-with-docker-compose.md
+++ b/docs/gamma/4.13/platform-management/get-started/get-started-for-existing-users/activate-gamma-with-docker-compose.md
@@ -3,7 +3,6 @@ hidden: false
 noIndex: false
 ---
 # Activate Gamma with Docker Compose
-<!-- GAP-STRUCTURAL: Missing procedural content source -->
 
 Gravitee Gamma is Gravitee's next-generation unified control plane. It brings API Management, Event Management, Agent Management, Authorization Management, and Platform Management together in a single console, so you manage your APIs, Kafka streams, AI agents and MCP servers, and authorization policies from one place.
 

--- a/docs/gamma/4.13/platform-management/get-started/get-started-for-existing-users/activate-gamma-with-kubernetes-helm.md
+++ b/docs/gamma/4.13/platform-management/get-started/get-started-for-existing-users/activate-gamma-with-kubernetes-helm.md
@@ -3,7 +3,6 @@ hidden: false
 noIndex: false
 ---
 # Activate Gamma with Kubernetes (Helm)
-<!-- GAP-STRUCTURAL: Missing procedural content source -->
 
 Gravitee Gamma is Gravitee's next-generation unified control plane. It brings API Management, Event Management, Agent Management, Authorization Management, and Platform Management together in a single console, so you manage your APIs, Kafka streams, AI agents and MCP servers, and authorization policies from one place.
 

--- a/docs/gamma/4.13/platform-management/install/hybrid-installation-guides/docker/README.md
+++ b/docs/gamma/4.13/platform-management/install/hybrid-installation-guides/docker/README.md
@@ -17,4 +17,3 @@ A hybrid Docker deployment runs the data plane only. The following table lists t
 
 <table><thead><tr><th>Component</th><th>Container name</th><th>Published port</th></tr></thead><tbody><tr><td>API Gateway</td><td><code>gio_gamma_hybrid_gateway</code></td><td><code>8082</code></td></tr><tr><td>Redis (rate limiting)</td><td><code>gio_gamma_hybrid_redis</code></td><td><code>6379</code></td></tr></tbody></table>
 
-<!-- TODO: Add a Gamma hybrid Docker architecture diagram -->

--- a/docs/gamma/4.13/platform-management/install/hybrid-installation-guides/docker/docker-cli.md
+++ b/docs/gamma/4.13/platform-management/install/hybrid-installation-guides/docker/docker-cli.md
@@ -3,7 +3,6 @@ hidden: false
 noIndex: false
 ---
 # Run a hybrid Gamma Gateway with Docker CLI
-<!-- GAP-STRUCTURAL: Missing procedural content source -->
 
 {% hint style="warning" %}
 This installation guide is for development and quick-start purposes only. Don't use it for production environments. For best practices for production environments, contact your Technical Account Manager.

--- a/docs/gamma/4.13/platform-management/install/hybrid-installation-guides/docker/docker-compose.md
+++ b/docs/gamma/4.13/platform-management/install/hybrid-installation-guides/docker/docker-compose.md
@@ -3,7 +3,6 @@ hidden: false
 noIndex: false
 ---
 # Run a hybrid Gamma Gateway with Docker Compose
-<!-- GAP-STRUCTURAL: Missing procedural content source -->
 
 {% hint style="warning" %}
 This installation guide is for development and quick-start purposes only. Don't use it for production environments. For best practices for production environments, contact your Technical Account Manager.

--- a/docs/gamma/4.13/platform-management/install/hybrid-installation-guides/kubernetes/aws-eks.md
+++ b/docs/gamma/4.13/platform-management/install/hybrid-installation-guides/kubernetes/aws-eks.md
@@ -3,7 +3,6 @@ hidden: false
 noIndex: false
 ---
 # Install a hybrid Gamma Gateway on AWS EKS
-<!-- GAP-STRUCTURAL: Missing procedural content source -->
 
 {% hint style="warning" %}
 This installation guide is for development and quick-start purposes only. Don't use it for production environments. For best practices for production environments, contact your Technical Account Manager.

--- a/docs/gamma/4.13/platform-management/install/hybrid-installation-guides/kubernetes/azure-aks.md
+++ b/docs/gamma/4.13/platform-management/install/hybrid-installation-guides/kubernetes/azure-aks.md
@@ -3,7 +3,6 @@ hidden: false
 noIndex: false
 ---
 # Install a hybrid Gamma Gateway on Azure AKS
-<!-- GAP-STRUCTURAL: Missing procedural content source -->
 
 {% hint style="warning" %}
 This installation guide is for development and quick-start purposes only. Don't use it for production environments. For best practices for production environments, contact your Technical Account Manager.

--- a/docs/gamma/4.13/platform-management/install/hybrid-installation-guides/kubernetes/openshift.md
+++ b/docs/gamma/4.13/platform-management/install/hybrid-installation-guides/kubernetes/openshift.md
@@ -3,7 +3,6 @@ hidden: false
 noIndex: false
 ---
 # Install a hybrid Gamma Gateway on OpenShift
-<!-- GAP-STRUCTURAL: Missing procedural content source -->
 
 {% hint style="warning" %}
 This installation guide is for development and quick-start purposes only. Don't use it for production environments. For best practices for production environments, contact your Technical Account Manager.

--- a/docs/gamma/4.13/platform-management/install/hybrid-installation-guides/kubernetes/vanilla-kubernetes.md
+++ b/docs/gamma/4.13/platform-management/install/hybrid-installation-guides/kubernetes/vanilla-kubernetes.md
@@ -3,7 +3,6 @@ hidden: false
 noIndex: false
 ---
 # Install a hybrid Gamma Gateway on Vanilla Kubernetes
-<!-- GAP-STRUCTURAL: Missing procedural content source -->
 
 {% hint style="warning" %}
 This installation guide is for development and quick-start purposes only. Don't use it for production environments. For best practices for production environments, contact your Technical Account Manager.

--- a/docs/gamma/4.13/platform-management/install/self-hosted-installation-guides/docker/README.md
+++ b/docs/gamma/4.13/platform-management/install/self-hosted-installation-guides/docker/README.md
@@ -17,4 +17,3 @@ Both Docker methods run the same set of containers. The following table lists th
 
 <table><thead><tr><th>Component</th><th>Container name</th><th>Published port</th></tr></thead><tbody><tr><td>API Gateway</td><td><code>gamma_gateway</code></td><td><code>8082</code></td></tr><tr><td>Management API (Gamma enabled)</td><td><code>gamma_management_api</code></td><td><code>8083</code></td></tr><tr><td>APIM Console</td><td><code>gamma_apim_console</code></td><td><code>8084</code></td></tr><tr><td>Developer Portal</td><td><code>gamma_portal</code></td><td><code>8085</code></td></tr><tr><td>Gamma console</td><td><code>gamma_console</code></td><td><code>8086</code></td></tr><tr><td>MongoDB</td><td><code>gamma_mongodb</code></td><td>n/a</td></tr><tr><td>Elasticsearch</td><td><code>gamma_elasticsearch</code></td><td>n/a</td></tr></tbody></table>
 
-<!-- TODO: Add a Gamma self-hosted Docker architecture diagram -->

--- a/docs/gamma/4.13/platform-management/install/self-hosted-installation-guides/kubernetes/aws-eks.md
+++ b/docs/gamma/4.13/platform-management/install/self-hosted-installation-guides/kubernetes/aws-eks.md
@@ -3,7 +3,6 @@ hidden: false
 noIndex: false
 ---
 # Install Gamma on AWS EKS
-<!-- GAP-STRUCTURAL: Missing procedural content source -->
 
 {% hint style="warning" %}
 This installation guide is for development and quick-start purposes only. Don't use it for production environments. For best practices for production environments, contact your Technical Account Manager.

--- a/docs/gamma/4.13/platform-management/install/self-hosted-installation-guides/kubernetes/azure-aks.md
+++ b/docs/gamma/4.13/platform-management/install/self-hosted-installation-guides/kubernetes/azure-aks.md
@@ -3,7 +3,6 @@ hidden: false
 noIndex: false
 ---
 # Install Gamma on Azure AKS
-<!-- GAP-STRUCTURAL: Missing procedural content source -->
 
 {% hint style="warning" %}
 This installation guide is for development and quick-start purposes only. Don't use it for production environments. For best practices for production environments, contact your Technical Account Manager.

--- a/docs/gamma/4.13/platform-management/install/self-hosted-installation-guides/kubernetes/openshift.md
+++ b/docs/gamma/4.13/platform-management/install/self-hosted-installation-guides/kubernetes/openshift.md
@@ -3,7 +3,6 @@ hidden: false
 noIndex: false
 ---
 # Install Gamma on OpenShift
-<!-- GAP-STRUCTURAL: Missing procedural content source -->
 
 {% hint style="warning" %}
 This installation guide is for development and quick-start purposes only. Don't use it for production environments. For best practices for production environments, contact your Technical Account Manager.

--- a/docs/gamma/4.13/platform-management/manage-applications.md
+++ b/docs/gamma/4.13/platform-management/manage-applications.md
@@ -57,7 +57,6 @@ Select an application from the list to view its detail page, which includes:
 * **User Permissions** — Manage direct members, configure group access, and transfer application ownership.
 * **Notifications** — Configure email and webhook notifications for application events.
 * **Subscriptions** — Active subscriptions to API plans. View subscription status, manage API keys, and see subscription history.
-<!-- Source: ApplicationUserPermissionsPage.tsx L1-L100, ApplicationNotificationSettingsPage.tsx L1-L100, gravitee-gamma-module-platform @ d1bb5f8af7 -->
 
 ## Next steps
 


### PR DESCRIPTION
## Summary

Removes internal authoring comments that were committed into the published gamma docs (4.12 and 4.13). These are HTML comments — invisible on the rendered site — but they sit in the public repository and leak internal detail that shouldn't be there.

**218 comments removed across 156 files**, in four categories:

- **Source annotations (102)** — internal source-file paths, repository names, commit hashes, and class names used to trace where a doc claim came from.
- **Structural-gap markers (78)** — internal "missing procedural content source" process notes.
- **Gap notes (34)** — detailed internal backlog notes, some referencing internal demo recordings and a contributor by name, plus engineering-process detail.
- **Authoring TODOs (4)** — reminders to add diagrams.

## Scope / safety

- Comment lines only — **pure deletion, 0 lines added**, and every removed line was verified to match one of the four comment patterns. No rendered content, headings, steps, or prose were touched.
- All target markers confirmed removed (0 remaining); the contributor name that appeared in the gap notes no longer appears anywhere in the gamma docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
