### PR TITLE
docs(gamma): correct tool-invocation policy procedure for MCP proxies

### DIFF
--- a/docs/gamma/4.13/agent-management/build/configure-your-mcp/apply-policies-to-tool-invocations.md
+++ b/docs/gamma/4.13/agent-management/build/configure-your-mcp/apply-policies-to-tool-invocations.md
@@ -14,8 +14,8 @@ To apply policies to a specific tool invocation:
 1. In the Gamma console, navigate to **Agent Management**.
 2. Select your MCP proxy from the proxy list.
 3. In the sidebar, select **Policy Studio**.
-4. Create a new flow or select an existing one.
-5. In the flow configuration, define a selector for the target tool.
-6. Open the policy palette and drag your chosen policies onto the flow.
-7. Click **Save** to persist your changes.
+4. Under **MCP Method Flows**, select **Add MCP method flow**.
+5. Enter a **Flow name**, and then select the **`tools/call`** MCP method. To scope the flow to a single tool, add a **Condition** that matches the tool name, for example `{#context.attributes['mcp_tool_name'] == 'database_query'}`. Select **Create**.
+6. In the flow's **Request** or **Response** phase, select **Browse all**, or a category such as **+ Security**, to open the **Add Policy** catalog. Search for and select the policy you want to apply.
+7. Select **Save** to persist your changes.
 


### PR DESCRIPTION
## Summary

Verified the **Apply policies to individual tool invocations** page (`docs/gamma/4.13/agent-management/build/configure-your-mcp/apply-policies-to-tool-invocations.md`) against the 4.13 GA product and corrected two steps that did not match the actual Policy Studio UI for MCP Proxies.

The procedure previously described a "selector for the target tool" and a drag-and-drop "policy palette." Neither exists in the product. In Policy Studio, a proxy has **Common Flows** and **MCP Method Flows**; you target a specific tool by creating an MCP method flow on `tools/call` and adding a **Condition** on the tool name, and you add policies through the **Add Policy** catalog by searching and selecting them.

## What changed

- **Step 4-5:** Create an **MCP method flow**, select the `tools/call` method, and add a **Condition** such as `{#context.attributes['mcp_tool_name'] == 'database_query'}` to scope the flow to one tool. Replaces the non-existent "define a selector for the target tool."
- **Step 6:** Add policies from the **Add Policy** catalog (choose the **Request** or **Response** phase, then search and select a policy). Replaces the non-existent drag-and-drop "policy palette."

Navigation and the **Save** action were confirmed accurate and left unchanged.

## Verification table

| Claim | Verdict | Notes |
|-------|---------|-------|
| Navigate to **Agent Management** | Confirmed | Module title matches |
| Select MCP proxy from the proxy list | Confirmed | MCP Proxies list |
| Sidebar to **Policy Studio** | Confirmed | Under the **Design** section |
| "Create a new flow or select an existing one" | Corrected | Flows are **Common Flows** or **MCP Method Flows** |
| "Define a selector for the target tool" | Fixed | No such selector; scope a `tools/call` flow with a **Condition** on `mcp_tool_name` |
| "Open the policy palette and drag policies onto the flow" | Fixed | Policies are added from the **Add Policy** catalog by search and select, not drag-and-drop |
| Click **Save** | Confirmed | **Save** button present |

Rate limit and role-based access control policies referenced in the introduction are both present in the policy catalog, so the introduction is accurate and unchanged.