### PR TITLE
docs(gamma): whole-document style pass on 5 already-merged agent-management build pages

### DIFF
--- a/docs/gamma/4.13/agent-management/build/README.md
+++ b/docs/gamma/4.13/agent-management/build/README.md
@@ -1,23 +1,24 @@
 ---
 hidden: false
 noIndex: false
+description: Create and configure the AI Gateway components that govern LLM, MCP, and A2A traffic, along with the agent identities for the agents in your infrastructure.
 ---
 
 # Build
 
 Create and configure the AI Gateway components that govern LLM, MCP, and A2A traffic, along with agent identities for every agent that touches your infrastructure.
 
-* [**Create an MCP proxy**](create-an-mcp-proxy.md): Set up an MCP Proxy in front of an upstream MCP server to add authentication, policies, and observability to every tool invocation.
-* [**Configure your MCP proxy**](configure-your-mcp/README.md): Configure mediation, credential management, and the MCP Proxy's connection to upstream servers.
-  * [**Add policies to your MCP server**](configure-your-mcp/add-policies-to-mcp-server.md): Apply fine-grained authorization policies at the tool level.
-  * [**Apply policies to specific MCP methods**](configure-your-mcp/apply-policies-to-mcp-methods.md): Target policies at individual MCP protocol methods, such as `resources/list`, `tools/call`, or `prompts/get`.
-  * [**Apply policies to individual tool invocations**](configure-your-mcp/apply-policies-to-tool-invocations.md): Govern a specific, high-value tool invocation without constraining the rest of the server.
-* [**Create an MCP Studio**](create-an-mcp-studio.md): Compose tools, resources, prompts, and skills from multiple sources into a Composite MCP Server.
-  * [**Edit tool composition**](edit-mcp-studio-composition.md): Select and alias the tools exposed by your MCP Studio, and configure authentication to the upstream servers they come from.
-* [**Create an LLM Proxy**](create-an-llm-proxy.md): Configure an LLM Proxy to route model traffic through the AI Gateway with authentication, cost attribution, and observability.
-* [**Configure an LLM Proxy**](configure-an-llm-proxy.md): Set up guardrails, PII filtering, rate limiting, security plans, and policies.
-* [**Create an agent identity**](create-an-agent-identity.md): Register an agent as a User-embedded, Hosted delegated, or Autonomous OAuth client, identified by a client ID or a CIMD metadata document.
-* [**Configure your Access Management instance**](configure-your-access-management-instance.md): Connect the module to Gravitee Access Management, select an environment and domain, and check that the domain has the capabilities agent identities rely on.
-* [**Expose your agent with the A2A Proxy**](expose-agent-with-a2a-proxy.md): Make an agent's skills discoverable and callable across trust boundaries with per-skill authorization.
-* [**Configure your A2A Proxy**](configure-your-a2a-proxy/README.md): Manage security, access controls, and flows for your A2A Proxy using the Policy Studio.
-  * [**Add policies to your A2A Proxy**](configure-your-a2a-proxy/add-policies-to-a2a-proxy.md): Attach security, transformation, and logic policies to agent-to-agent communications.
+* [**Create an MCP proxy**](create-an-mcp-proxy.md). Set up an MCP Proxy in front of an upstream MCP server to add authentication, policies, and observability to every tool invocation.
+* [**Configure your MCP proxy**](configure-your-mcp/README.md). Configure mediation, credential management, and the MCP Proxy's connection to upstream servers.
+  * [**Add policies to your MCP server**](configure-your-mcp/add-policies-to-mcp-server.md). Apply fine-grained authorization policies at the tool level.
+  * [**Apply policies to specific MCP methods**](configure-your-mcp/apply-policies-to-mcp-methods.md). Target policies at individual MCP protocol methods, such as `resources/list`, `tools/call`, or `prompts/get`.
+  * [**Apply policies to individual tool invocations**](configure-your-mcp/apply-policies-to-tool-invocations.md). Govern a specific, high-value tool invocation without constraining the rest of the server.
+* [**Create an MCP Studio**](create-an-mcp-studio.md). Compose tools, resources, prompts, and skills from multiple sources into a Composite MCP Server.
+  * [**Edit tool composition**](edit-mcp-studio-composition.md). Select and alias the tools exposed by your MCP Studio, and configure authentication to the upstream servers they come from.
+* [**Create an LLM Proxy**](create-an-llm-proxy.md). Configure an LLM Proxy to route model traffic through the AI Gateway with authentication, cost attribution, and observability.
+* [**Configure an LLM Proxy**](configure-an-llm-proxy.md). Configure guardrails, PII filtering, rate limiting, security plans, and policies.
+* [**Create an agent identity**](create-an-agent-identity.md). Register an agent as a User-embedded, Hosted delegated, or Autonomous OAuth client, identified by a client ID or a CIMD metadata document.
+* [**Configure your Access Management instance**](configure-your-access-management-instance.md). Connect the module to Gravitee Access Management, select an environment and domain, and check that the domain has the capabilities agent identities rely on.
+* [**Expose your agent with the A2A Proxy**](expose-agent-with-a2a-proxy.md). Make an agent's skills discoverable and callable across trust boundaries with per-skill authorization.
+* [**Configure your A2A Proxy**](configure-your-a2a-proxy/README.md). Manage security, access controls, and flows for your A2A Proxy using the Policy Studio.
+  * [**Add policies to your A2A Proxy**](configure-your-a2a-proxy/add-policies-to-a2a-proxy.md). Attach security, transformation, and logic policies to agent-to-agent communications.

--- a/docs/gamma/4.13/agent-management/build/configure-an-llm-proxy.md
+++ b/docs/gamma/4.13/agent-management/build/configure-an-llm-proxy.md
@@ -1,18 +1,18 @@
 ---
 hidden: false
 noIndex: false
+description: Configure guardrails, PII filtering, rate limiting, security plans, structured output, and cost visibility for an LLM Proxy after creation.
 ---
 
 # Configure an LLM Proxy
 
-
 After creating an LLM Proxy, configure guardrails, PII filtering, rate limiting, security plans, and policies. This page covers all post-creation configuration options.
 
-## Guardrails, PII filtering, and Rate limiting
+## Guardrails, PII filtering, and rate limiting
 
 Guardrails, PII filtering, and rate limiting are implemented using standard Gravitee policies. You configure them by attaching policies with the LLM Studio.
 
-The LLM Studio operates just like the API Management policy studio, supporting request/response phases. To attach these controls:
+The LLM Studio operates like the API Management policy studio, supporting request/response phases. To attach these controls:
 
 1. Navigate to your LLM Proxy detail page and open **LLM Studio**.
 2. Click **+** on the request or response flow, and then search for and select the desired policy, such as PII Filtering, Rate Limit, or AI – Prompt Guard Rails, to add it to the flow.
@@ -51,6 +51,6 @@ This data is visualized in the **LLM — Overview** dashboard, which tracks `LLM
 
 ## Next steps
 
-* [Create an LLM Proxy](create-an-llm-proxy.md): Create a new LLM Proxy if you haven't already.
-* [Publish your LLM Proxy](../publish/publish-your-llm-proxy.md): Make the LLM Proxy discoverable.
-* [Monitor AI Gateway usage from employee systems](../observe/monitor-ai-gateway-from-devices.md): View AI traffic from employee devices.
+* [Create an LLM Proxy](create-an-llm-proxy.md). Create a new LLM Proxy if you haven't already.
+* [Publish your LLM Proxy](../publish/publish-your-llm-proxy.md). Make the LLM Proxy discoverable.
+* [Monitor AI Gateway usage from employee systems](../observe/monitor-ai-gateway-from-devices.md). View AI traffic from employee devices.

--- a/docs/gamma/4.13/agent-management/build/configure-your-a2a-proxy/README.md
+++ b/docs/gamma/4.13/agent-management/build/configure-your-a2a-proxy/README.md
@@ -1,25 +1,26 @@
 ---
 hidden: false
 noIndex: false
+description: Configure an A2A Proxy's behavior, security, and observability using the Policy Studio and the sidebar navigation in the Gamma console.
 ---
 
 # Configure your A2A Proxy
 
 After creating an Agent-to-Agent (A2A) Proxy, you can configure its behavior, manage security, and establish access controls using the Policy Studio.
 
-The Gamma console provides a visual builder for applying policies and managing flows on your A2A Proxy.
+The Gamma console provides a visual builder to apply policies and manage flows on your A2A Proxy.
 
-* **[Add policies to your A2A Proxy](add-policies-to-a2a-proxy.md)**: Learn how to use the Policy Studio to attach security, transformation, and logic policies to your A2A communications.
+* **[Add policies to your A2A Proxy](add-policies-to-a2a-proxy.md)**. Learn how to use the Policy Studio to attach security, transformation, and logic policies to your A2A communications.
 
-## A2A Proxy Navigation
+## A2A Proxy navigation
 
-When you open an A2A Proxy from the dashboard, you can configure it using the sidebar navigation groups:
+When you open an A2A Proxy from the dashboard, you can configure it using the following sidebar navigation groups:
 
-* **General**: 
-  * **Overview**: View proxy status and deployment history.
-  * **General**: Manage the proxy's name, description, and status.
-  * **Endpoint**: Configure the target URL of the upstream agent.
-  * **API Properties**: Manage dynamic properties that can be evaluated at runtime.
+* **General**:
+  * **Overview**. View proxy status and deployment history.
+  * **General**. Manage the proxy's name, description, and status.
+  * **Endpoint**. Configure the target URL of the upstream agent.
+  * **API Properties**. Manage dynamic properties that can be evaluated at runtime.
 * **Design**:
-  * **Policy Studio**: Design your flows and apply policies to agent-to-agent communication.
-* **Observability**: Monitor the proxy with **Dashboard**, **Logs**, and **Tracing**.
+  * **Policy Studio**. Design your flows and apply policies to agent-to-agent communication.
+* **Observability**. Monitor the proxy with **Dashboard**, **Logs**, and **Tracing**.

--- a/docs/gamma/4.13/agent-management/build/configure-your-mcp/apply-policies-to-mcp-methods.md
+++ b/docs/gamma/4.13/agent-management/build/configure-your-mcp/apply-policies-to-mcp-methods.md
@@ -6,7 +6,7 @@ noIndex: false
 
 # Apply policies to specific MCP methods
 
-When exposing an MCP Proxy, you can apply policies at different levels of granularity. By default, policies attached to a **Common flow** are executed on every interaction with the MCP server, regardless of the method or tool. You can also target specific MCP protocol methods, such as `resources/list`, `tools/call`, or `prompts/get`, by creating an **MCP method flow**.
+When you expose an MCP Proxy, you can apply policies at different levels of granularity. By default, policies attached to a **Common flow** are executed on every interaction with the MCP server, regardless of the method or tool. You can also target specific MCP protocol methods, such as `resources/list`, `tools/call`, or `prompts/get`, by creating an **MCP method flow**.
 
 ## Configure method-specific policies
 
@@ -17,9 +17,9 @@ To apply policies to a specific MCP method, complete the following steps:
 3. In the proxy sidebar, under **Design**, select **Policy Studio**.
 4. Under **MCP method flows**, select **Add MCP method flow**.
 5. In the **Create a new MCP method flow** panel, complete the following fields:
-   - **Flow name.** Enter a name for the flow.
-   - **MCP methods.** Select one or more MCP methods to target, such as `tools/call`, `resources/list`, or `prompts/get`.
-   - **Condition.** Enter an optional Expression Language condition that must evaluate to true for the flow to run.
+    - **Flow name.** Enter a name for the flow.
+    - **MCP methods.** Select one or more MCP methods to target, such as `tools/call`, `resources/list`, or `prompts/get`.
+    - **Condition.** Enter an optional Expression Language condition that must evaluate to true for the flow to run.
 6. Select **Create**.
-7. In the **Request phase** or **Response phase**, select **Browse all...** or a suggested category button to open the **Add Policy** catalog, choose a policy, and add it to the phase.
+7. In the **Request phase** or **Response phase**, select **Browse all...** or a suggested category button to open the **Add Policy** catalog. Choose a policy, and then add it to the phase.
 8. Select **Save** to persist your changes.

--- a/docs/gamma/4.13/agent-management/build/configure-your-mcp/apply-policies-to-tool-invocations.md
+++ b/docs/gamma/4.13/agent-management/build/configure-your-mcp/apply-policies-to-tool-invocations.md
@@ -1,11 +1,12 @@
 ---
 hidden: false
 noIndex: false
+description: Apply policies to individual tool invocations in an MCP Proxy by creating an MCP method flow on tools/call with a condition that matches the tool name.
 ---
 
 # Apply policies to individual tool invocations
 
-In addition to targeting specific MCP methods, you can apply policies directly to individual tool invocations within an MCP Proxy. This enables fine-grained governance, such as applying rate limits or role-based access control to a specific, high-value tool (like `database_query` or `execute_script`) while leaving other tools unconstrained.
+In addition to targeting specific MCP methods, you can apply policies directly to individual tool invocations within an MCP Proxy. This enables fine-grained governance, such as applying rate limits or role-based access control to a specific, high-value tool—for example, `database_query` or `execute_script`—while leaving other tools unconstrained.
 
 ## Configure tool-specific policies
 


### PR DESCRIPTION
## Summary

Applies the new whole-document Step 6 style pass (structure/grammar/terminology) to five Agent Management **Build** pages whose content verification already merged to `main`. Because those PRs are closed, this brings them up to the whole-document style standard in one place.

Pages:
- `build/README.md`
- `build/configure-an-llm-proxy.md`
- `build/configure-your-a2a-proxy/README.md`
- `build/configure-your-mcp/apply-policies-to-mcp-methods.md`
- `build/configure-your-mcp/apply-policies-to-tool-invocations.md`

## Form-only — no meaning changed

Every change is stylistic: added frontmatter descriptions, colon→period list-item explanations, sentence-case headings, 4-space list indentation, parentheses→commas/em-dashes, and minor grammar (active voice, present tense). Each file's diff was reviewed hunk-by-hunk to confirm no technical meaning changed:

- All child-page links, targets, and ordering in `README.md` preserved exactly.
- A2A Proxy sidebar items preserved (Overview, General, Endpoint, API Properties; Policy Studio; Dashboard, Logs, Tracing).
- MCP method-flow fields, the `resources/list`/`tools/call`/`prompts/get` examples, the Expression Language literals, and the Add Policy catalog flow preserved.
- LLM Proxy terms, plan types, policy names, and the LLM — Overview dashboard preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)