### PR TITLE
docs(apim): add 4.13 release notes template page

### DIFF
--- a/docs/apim/4.13/SUMMARY.md
+++ b/docs/apim/4.13/SUMMARY.md
@@ -558,6 +558,7 @@
 * [Expose APIM as an MCP Server](expose-apim-as-an-mcp-server.md)
 * [Release Information](release-information/README.md)
   * [Release Notes](release-information/release-notes/README.md)
+    * [APIM 4.13](release-information/release-notes/apim-4.13.md)
     * [APIM 4.12](release-information/release-notes/apim-4.12.md)
     * [APIM 4.11](https://documentation.gravitee.io/apim/4.11/release-information/release-notes/apim-4.11)
     * [APIM 4.10](https://documentation.gravitee.io/apim/4.10/release-information/release-notes/apim-4.10)

--- a/docs/apim/4.13/release-information/release-notes/apim-4.13.md
+++ b/docs/apim/4.13/release-information/release-notes/apim-4.13.md
@@ -1,0 +1,65 @@
+# APIM 4.13
+
+<!--
+TEMPLATE NOTES (delete before publishing)
+
+Structure follows the APIM 4.11 and 4.12 release notes:
+
+- Highlights: one bullet per notable change, written as a single sentence that names
+  the feature and what it lets a user do. Order roughly by impact.
+- Breaking Changes and deprecations: only include this section if there are any.
+  Use `#### **Title**` followed by prose paragraphs (not bullets), and link to the
+  Breaking changes and deprecations page for details.
+- New Features: one `#### **Feature name**` per feature, followed by 3-5 bullets
+  covering what it does, how it is configured (property names, permissions, UI
+  location), what it applies to, and any limits or prerequisites.
+- Improvements: same shape as New Features, for enhancements to existing behavior.
+
+Use bold in the `####` headings. Reference configuration keys, permissions, and
+property names in backticks. Use relative links for in-space pages and absolute
+documentation.gravitee.io links for other versions.
+-->
+
+<!--
+Include this hint only if the release has Java version constraints, following the
+APIM 4.12 example.
+
+{% hint style="warning" %}
+**Important: Java Version Requirements**
+
+APIM 4.13 ...
+{% endhint %}
+-->
+
+## Highlights
+
+<!-- One sentence per notable change. Example:
+* Feature name provides <capability> for <audience>, enabling <outcome>.
+-->
+
+* &#x20;
+
+## Breaking Changes and deprecations&#x20;
+
+<!-- Delete this section if the release introduces none. -->
+
+#### **Title of the breaking change**
+
+Describe what changed, who is affected, and the action required before or after upgrading. Link to [Breaking changes and deprecations](../breaking-changes-and-deprecations.md) for the full list.
+
+## New Features
+
+#### **Feature name**
+
+* What the feature does and which problem it solves.
+* How it is enabled or configured, including configuration keys such as `example.property.enabled`, required permissions, or Console location.
+* Which API types, deployment modes, or components it applies to.
+* Prerequisites, limits, or known constraints.
+
+## Improvements
+
+#### **Improvement name**
+
+* What changed relative to previous behavior.
+* Any configuration, permission, or upgrade action required.
+* Scope of the change (API types, plugins, or versions affected).


### PR DESCRIPTION
## Summary

Adds an empty `apim-4.13.md` release notes page to the APIM 4.13 space, pre-structured to match the 4.11 and 4.12 release notes so it can be filled in as 4.13 features land.

## Changes

- `docs/apim/4.13/release-information/release-notes/apim-4.13.md` — new page with the standard sections: **Highlights**, **Breaking Changes and deprecations**, **New Features**, **Improvements**. Authoring guidance is in HTML comments (invisible in GitBook) covering heading style, bullet shape, the optional Java version hint used in 4.12, and link conventions.
- `docs/apim/4.13/SUMMARY.md` — lists **APIM 4.13** above APIM 4.12 under Release Information → Release Notes.

## Notes

Placeholder headings and comments are intended to be replaced/deleted as real 4.13 content is written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)