### PR TITLE
docs(apim): note that hosted sending domains are verified on request (4.13)

### DIFF
--- a/docs/apim/4.13/.version-overrides
+++ b/docs/apim/4.13/.version-overrides
@@ -9,3 +9,4 @@ release-information/release-notes/apim-4.12.md
 release-information/changelog/apim-4.12.x.md
 terraform/changelog.md
 terraform/release-notes.md
+configure-and-manage-the-platform/manage-organizations-and-environments/branded-senders.md

--- a/docs/apim/4.13/configure-and-manage-the-platform/manage-organizations-and-environments/branded-senders.md
+++ b/docs/apim/4.13/configure-and-manage-the-platform/manage-organizations-and-environments/branded-senders.md
@@ -19,7 +19,7 @@ A rule changes only the sender address and the subject prefix. The body of each 
 Branded senders can be configured at two scopes, **Organization** and **Environment**, and for self-hosted installations in `gravitee.yml`.
 
 {% hint style="info" %}
-On Gravitee-hosted installations, a sending domain is verified **on demand**: it is configured manually for your account rather than self-service. To have a domain verified, [contact Gravitee](/gravitee-cloud/community-and-support/enterprise-support). You're given DNS records to publish, and branded senders works for that domain once verification completes.
+On Gravitee-hosted installations, a sending domain is verified **on demand**: it is configured manually for your account rather than self-service. To have a domain verified, [contact Gravitee](/gravitee-cloud/community-and-support/enterprise-support). You are provided with the DNS records to publish, and then branded senders works for that domain once verification completes.
 {% endhint %}
 
 ## Prerequisites

--- a/docs/apim/4.13/configure-and-manage-the-platform/manage-organizations-and-environments/branded-senders.md
+++ b/docs/apim/4.13/configure-and-manage-the-platform/manage-organizations-and-environments/branded-senders.md
@@ -18,6 +18,10 @@ A rule changes only the sender address and the subject prefix. The body of each 
 
 Branded senders can be configured at two scopes, **Organization** and **Environment**, and for self-hosted installations in `gravitee.yml`.
 
+{% hint style="info" %}
+On Gravitee-hosted installations, a sending domain is verified **on demand**: it is configured manually for your account rather than self-service. To have a domain verified, [contact Gravitee](/gravitee-cloud/community-and-support/enterprise-support). You're given DNS records to publish, and branded senders works for that domain once verification completes.
+{% endhint %}
+
 ## Prerequisites
 
 - The SMTP email service must be **enabled** at the Organization or Environment level. Branded sender controls are disabled while email is off.
@@ -41,7 +45,7 @@ They refuse it in one of two ways, and the difference matters:
 Because of the second case, a successful send isn't evidence that a branded rule works. Send a branded notification to yourself and confirm that it **arrives** before you apply a rule to real recipients.
 {% endhint %}
 
-If your relay restricts senders, ask your email provider what's needed to send as an additional domain. Providers usually require you to prove that you control the domain first.
+If your relay restricts senders, ask your email provider what's needed to send as an additional domain. Providers usually require you to prove that you control the domain first. On Gravitee-hosted installations, that's handled by [contacting Gravitee](/gravitee-cloud/community-and-support/enterprise-support), as described in the Overview.
 
 ### Authorize the Relay in Your DNS
 


### PR DESCRIPTION
Adds an info callout to the 4.13 Branded Senders page explaining that on Gravitee-hosted installations a sending domain is verified on request rather than self-service, with a link to enterprise support.

## Why

Branded senders only works once the sending domain is authorized on the relay that sends the mail. The page currently tells readers to "ask your email provider what's needed to send as an additional domain" — accurate for self-hosted, but on Gravitee-hosted installations the email provider is Gravitee, and there is no self-service path today.

Without this, a hosted customer can configure a branded sender rule, save it successfully, and have the notifications never arrive, with nothing on the page explaining why or what to do about it.

The wording and link target follow the existing pattern on
[Establish private networks with AWS](https://documentation.gravitee.io/gravitee-cloud/guides/establish-private-networks-with-aws), which documents another capability provisioned manually rather than self-service.