### PR TITLE
docs(gamma): verify 4.12 Platform Management overview against the live console

### DIFF
--- a/docs/gamma/4.12/platform-management/overview.md
+++ b/docs/gamma/4.12/platform-management/overview.md
@@ -1,33 +1,33 @@
 ---
 description: >-
-  Gravitee Gamma is a connectivity platform that unifies API Management, Event
-  Stream Management, Agent Management, and Authorization Management under a
-  shared catalog, authorization engine, and enforce
+  Gravitee Gamma unifies API Management, Event Stream Management, Agent
+  Management, and Authorization Management under a shared catalog, authorization
+  engine, and enforcement architecture.
 ---
 
 # Overview
 
-Gravitee Gamma lets you govern, secure, and observe enterprise traffic (APIs, event streams, and AI agent interactions) from a single platform. It provides a shared catalog, authorization engine, and enforcement architecture.
+Gravitee Gamma lets you govern, secure, and observe enterprise traffic across APIs, event streams, and AI agent interactions from a single platform. It provides a shared catalog, authorization engine, and enforcement architecture.
 
 ***
 
 ## Why Gamma Exists
 
-Modern enterprises run three distinct traffic types in isolation: REST, GraphQL, and gRPC APIs, Kafka event streams, and AI agent traffic (LLM calls, MCP tool invocations, and agent-to-agent delegations). Separate management of these traffic types results in fragmented visibility, duplicated policy configuration, and unaudited AI usage across your organization.
+Modern enterprises run three distinct traffic types in isolation: REST, GraphQL, and gRPC APIs, Kafka event streams, and AI agent traffic. Agent traffic covers LLM calls, MCP tool invocations, and agent-to-agent delegations. Separate management of these traffic types results in fragmented visibility, duplicated policy configuration, and unaudited AI usage across your organization.
 
 Gamma addresses the following core challenges:
 
-* **Unmanaged AI traffic.** Engineering teams use Claude Code, Cursor, and ChatGPT Enterprise with no central visibility into cost, model usage, or data exposure. Agents call MCP tools on upstream servers using shared API keys or unaudited credentials.
-* **Fragmented authorization.** Policies written for API gateways don't extend to AI agents or event streams, leaving different traffic types governed by different tools with no common enforcement point.
-* **Disjointed infrastructure.** REST APIs, Kafka topics, MCP servers, AI models, and agents exist in separate registries with no shared catalog. This makes it impossible to build cross-protocol policies or expose existing infrastructure to AI agents without redevelopment.
+* **Unmanaged AI traffic**. Engineering teams use Claude Code, Cursor, and ChatGPT Enterprise with no central visibility into cost, model usage, or data exposure. Agents call MCP tools on upstream servers using shared API keys or unaudited credentials.
+* **Fragmented authorization**. Policies written for API gateways don't extend to AI agents or event streams. Different traffic types are governed by different tools with no common enforcement point.
+* **Disjointed infrastructure**. REST APIs, Kafka topics, MCP servers, AI models, and agents exist in separate registries with no shared catalog. This makes it impossible to build cross-protocol policies or expose existing infrastructure to AI agents without redevelopment.
 
 ***
 
 ## How Gamma Works
 
-Gamma unifies four product lines (API Management, Event Stream Management, Agent Management, and Authorization Management) under a shared platform. All four share a common Catalog of assets and a common authorization engine that defines fine-grained policies against those cataloged assets. They also share common enforcement points (the AI Gateway, API Gateway, and Event Gateway) that evaluate the same policies at the wire level.
+Gamma unifies four product lines under a shared platform: API Management, Event Stream Management, Agent Management, and Authorization Management. All four share a common Catalog of assets and a common authorization engine that defines fine-grained policies against those cataloged assets. They also share common enforcement points—the AI Gateway, API Gateway, and Event Gateway—that evaluate the same policies at the wire level.
 
-```sh
+```
 ┌─────────────────────────────────────────────────────────────────────┐
 │                           Gravitee Gamma                            │
 │                                                                     │
@@ -57,13 +57,13 @@ Gamma unifies four product lines (API Management, Event Stream Management, Agent
 
 Gamma includes the following components:
 
-* **API Gateway.** Enforces runtime policy on every API request: authentication, rate limiting, content transformation, and routing between consumers and backend services.
-* **AI Gateway.** The unified runtime for LLM, MCP, and A2A traffic. It consists of three proxies (LLM Proxy, MCP Proxy, and A2A Proxy) that share an authentication chain, policy chain, observability chain, and Authorization Management integration.
-* **Event Gateway.** Enforces runtime policy on every Kafka event interaction: authentication, authorization, rate limiting, and protocol mediation.
-* **Gamma Console.** The Control Plane where all product lines are configured, observed, and managed across API Management, Event Stream Management, Agent Management, Authorization Management, and Platform Management.
-* **Catalog.** The authoritative registry of every asset an agent or consumer can use: AI models, MCP servers, tools (MCP, API, and Kafka API tools), prompts, resources, skills, and agents. Policy is authored against cataloged entities.
-* **Policy Decision Point (PDP).** Evaluates all applicable Gravitee Authorization Policy Language (GAPL) policies at microsecond latency with no network hop, running inside every gateway.
-* **Edge Daemon.** A lightweight process installed on employee devices using MDM that observes outgoing AI traffic, enforces local pre-egress policies, and forwards requests to the AI Gateway.
+* **API Gateway**. This gateway enforces runtime policy on every API request: authentication, rate limiting, content transformation, and routing between consumers and backend services.
+* **AI Gateway**. This gateway is the unified runtime for LLM, MCP, and A2A traffic. It consists of three proxies—the LLM Proxy, MCP Proxy, and A2A Proxy—that share an authentication chain, policy chain, observability chain, and Authorization Management integration.
+* **Event Gateway**. This gateway enforces runtime policy on every Kafka event interaction: authentication, authorization, rate limiting, and protocol mediation.
+* **Gamma Console**. This is the Control Plane where all product lines are configured, observed, and managed across API Management, Event Stream Management, Agent Management, Authorization Management, Edge Management, and Platform Management.
+* **Catalog**. This is the authoritative registry of every asset an agent or consumer can use: AI models, MCP servers, prompts, MCP resources, tools, knowledge and data sources, skills, and agents. Tools cover MCP, API, event, workflow, code, and knowledge tools. Policy is authored against cataloged entities.
+* **Policy Decision Point (PDP)**. The PDP evaluates all applicable Gravitee Authorization Policy Language (GAPL) policies at microsecond latency with no network hop, and it runs inside every gateway.
+* **Edge Daemon**. This is a lightweight process installed on employee devices using MDM. It observes outgoing AI traffic, enforces local pre-egress policies, and forwards requests to the AI Gateway.
 
 ***
 
@@ -71,37 +71,43 @@ Gamma includes the following components:
 
 ### API Management
 
-API Management governs REST, GraphQL, and gRPC traffic through API proxies, the core artifact that mediates between consumers and backend services. The API Gateway enforces runtime policy on every request while the Gamma console provides the Control Plane to design, secure, publish, and observe APIs. Creation wizards offer both a from-scratch four-step flow (API Details, Configure Proxy, Secure, and Review & Deploy) and quick-start templates for common patterns.
+API Management governs REST, GraphQL, gRPC, and WebSocket traffic through API proxies, the core artifact that mediates between consumers and backend services. The API Gateway enforces runtime policy on every request while the Gamma console provides the Control Plane to design, secure, publish, and observe APIs.
+
+API creation offers the following starting points:
+
+* **Start from scratch**. This option runs the full four-step wizard: API Details, Configure Proxy, Secure, and Review & Deploy.
+* **Quick-start templates**. These presets arrive with security and plans already filled in.
+* **Import API**. This option creates the API from a Gravitee definition, an OpenAPI specification, or a WSDL document.
 
 See [API Management overview](../api-management/get-started/api-management-overview.md).
 
 ### Security & Authentication
 
-Every API proxy accepts one or more security plans that define how consumers authenticate. Supported plan types include Keyless, API Key, JWT, OAuth2, and mTLS. Plans move through a defined lifecycle (Staging, Published, Deprecated, and Closed) and support rate limiting, quotas, and resource filtering at the plan level. For AI traffic, the AI Gateway supports OAuth authorization discovery and credential mediation for MCP servers, and token-based rate limiting for LLM Proxies.
+Every API proxy accepts one or more security plans that define how consumers authenticate. Supported plan types include Keyless, API Key, JWT, OAuth2, and mTLS. Plans move through a defined lifecycle of Staging, Published, Deprecated, and Closed. Plans also support rate limiting, quotas, and resource filtering at the plan level. For AI traffic, the AI Gateway supports OAuth authorization discovery and credential mediation for MCP servers, and token-based rate limiting for LLM Proxies.
 
 See [Secure your API proxy](../api-management/build/secure-your-api-proxy.md).
 
 ### Event Stream Management
 
-Event Stream Management governs Kafka clusters, event-driven data flows, and streaming infrastructure. Key capabilities include Kafka cluster registration, Kafka Service creation (the event-stream equivalent of an API proxy), and Virtual Clusters for multi-tenant isolation on shared infrastructure. An integrated Explorer lets you create topics, inspect messages, and manage connections. Kafka APIs contributed to the Catalog can be exposed as Kafka API Tools in Agent Management, bridging event streams to the AI agent layer without redevelopment.
+Event Stream Management governs Kafka clusters, event-driven data flows, and streaming infrastructure. Key capabilities include Kafka cluster registration, Kafka Service creation, and Virtual Clusters for multi-tenant isolation on shared infrastructure. A Kafka Service is the event-stream equivalent of an API proxy. Event sources contributed to the Catalog can be exposed as event tools in Agent Management, which bridges event streams to the AI agent layer without redevelopment.
 
 See [Event Stream Management overview](../event-stream-management/get-started/event-stream-management-overview.md).
 
 ### Agent Management & AI Governance
 
-Agent Management governs every protocol in the agentic stack. The **LLM Proxy** handles traffic to LLM providers (Anthropic, OpenAI, AWS Bedrock, Gemini Enterprise Agent Platform (formerly Vertex AI), and Azure) with guardrails, PII filtering, and token-based rate limiting. The **MCP Proxy** governs tool invocations in two modes: Proxy mode for transparent governance of upstream MCP servers, and Studio mode for composing Composite MCP Servers. The **A2A Proxy** governs agent-to-agent delegations with skill discovery, per-skill authorization, and agent identity verification. Every interaction emits an OpenTelemetry span with agent identity, tool name, inputs, outputs, latency, policy decision, cost, and timestamp.
+Agent Management governs every protocol in the agentic stack. The **LLM Proxy** handles traffic to LLM providers with guardrails, PII filtering, and token-based rate limiting. Supported providers are OpenAI, Gemini, Anthropic, Bedrock, and Vertex AI. The **MCP Proxy** governs tool invocations in two modes: Proxy mode for transparent governance of upstream MCP servers, and Studio mode for composing catalog assets into an MCP Studio. The **A2A Proxy** governs agent-to-agent delegations with skill discovery, per-skill authorization, and agent identity verification. Every interaction emits an OpenTelemetry span with agent identity, tool name, inputs, outputs, latency, policy decision, cost, and timestamp.
 
 See [Agent Management overview](../agent-management/get-started/ai-management-overview.md).
 
 ### Authorization Management
 
-Authorization Management provides fine-grained, catalog-aware access control across all Gamma traffic types through policies written in Gravitee Authorization Policy Language (GAPL), a subset of the Cedar policy language. Policies declare an effect (`permit` or `forbid`), a principal, an action, a resource, and optional conditions for time-of-day restrictions, IP range checks, token budgets, and custom attribute matching. Policy categories cover MCP Policies, AI Model Policies, API Policies, and Custom Policies. Principals can be synchronized from identity providers using SCIM or from Gravitee Access Management.
+Authorization Management provides fine-grained, catalog-aware access control across all Gamma traffic types. Policies are written in Gravitee Authorization Policy Language (GAPL), a subset of the Cedar policy language. A policy declares an effect of `permit` or `forbid`, a principal, an action, a resource, and optional conditions for time-of-day restrictions, IP range checks, token budgets, and custom attribute matching. Policy Management covers MCPs, AI Models, APIs, A2A Agents, and Custom Policies. Principals can be synchronized from Gravitee Access Management or imported from a file.
 
 See [Authorization Management overview](../authorization-management/get-started/authorization-management-overview.md).
 
 ### Edge Management
 
-Edge Management provides visibility and control over AI traffic on employee devices. The Edge Daemon, distributed using MDM solutions (Kandji, Jamf, and Intune), supports two routing modes. Interception mode is the default and provides transparent DNS-level redirect of AI provider traffic. Proxy mode requires explicit per-tool base URL configuration. The daemon detects shadow AI usage regardless of whether traffic is routed through it. It enforces local pre-egress policies and forwards requests to the AI Gateway for enterprise-wide policy enforcement. The Edge Management dashboard surfaces fleet status, metrics filterable by device and model, and shadow AI usage reports.
+Edge Management provides visibility and control over AI traffic on employee devices. The Edge Daemon, distributed to managed devices as a Kandji Custom App, supports two routing modes. Interception mode is the default and provides transparent DNS-level redirect of AI provider traffic. Proxy mode requires explicit per-tool base URL configuration. The daemon detects shadow AI usage regardless of whether traffic is routed through it. It enforces local pre-egress policies and forwards requests to the AI Gateway for enterprise-wide policy enforcement. The Edge Management dashboard surfaces fleet status, metrics filterable by device and model, and shadow AI usage reports.
 
 See [Edge Management overview](../edge-management/get-started/edge-management-overview.md).
 
@@ -111,28 +117,29 @@ See [Edge Management overview](../edge-management/get-started/edge-management-ov
 
 Gamma supports the following protocols and standards:
 
-| Protocol                                                | Support | Notes                                                                |
-| ------------------------------------------------------- | ------- | -------------------------------------------------------------------- |
-| REST / HTTP                                             | Full    | API proxies with context path or virtual host routing                |
-| GraphQL                                                 | Full    | Governed through API Management                                      |
-| gRPC                                                    | Full    | Governed through API Management                                      |
-| Kafka (native)                                          | Full    | Through the Event Gateway (Kafka Services and Virtual Clusters)      |
-| MCP (JSON-RPC 2.0)                                      | Full    | Through the MCP Proxy in Proxy mode or Studio mode                   |
-| A2A                                                     | Full    | Through the A2A Proxy with `/.well-known/agent.json` skill discovery |
-| LLM APIs (OpenAI, Anthropic, Bedrock, Gemini Enterprise Agent Platform (formerly Vertex AI), Azure) | Full    | Through the LLM Proxy with provider-specific routing                 |
+| Protocol    | Support | Notes                                                                                                    |
+| ----------- | ------- | -------------------------------------------------------------------------------------------------------- |
+| REST / HTTP | Full    | API proxies with context path or virtual host routing                                                    |
+| GraphQL     | Full    | Governed through API Management                                                                          |
+| gRPC        | Full    | Governed through API Management                                                                          |
+| WebSocket   | Full    | Governed through API Management                                                                          |
+| Kafka       | Full    | Native Kafka protocol through the Event Gateway, using Kafka Services and Virtual Clusters               |
+| MCP         | Full    | JSON-RPC 2.0 through the MCP Proxy in Proxy mode or Studio mode                                          |
+| A2A         | Full    | Through the A2A Proxy with `/.well-known/agent-card.json` skill discovery                                |
+| LLM APIs    | Full    | Through the LLM Proxy with provider-specific routing for OpenAI, Gemini, Anthropic, Bedrock, and Vertex AI |
 
 ***
 
 ## Next steps
 
-If you are new to Gravitee Gamma, complete the following steps:
+If you're new to Gravitee Gamma, complete the following steps:
 
-1. [**Create your first API**](../api-management/get-started/create-your-first-api.md): Create an API proxy and enforce a security plan in under five minutes.
-2. [**Create your first MCP server**](../agent-management/get-started/create-your-first-mcp-server.md): Set up an MCP proxy in front of an upstream MCP server and verify tool invocations.
-3. [**Create your first Kafka service**](../event-stream-management/get-started/create-your-first-kafka-service.md): Register a Kafka cluster and create a governed Kafka service.
+1. [**Create your first API**](../api-management/get-started/create-your-first-api.md). Create an API proxy and enforce a security plan in under five minutes.
+2. [**Create your first MCP server**](../agent-management/get-started/create-your-first-mcp-server.md). Configure an MCP proxy in front of an upstream MCP server and verify tool invocations.
+3. [**Create your first Kafka service**](../event-stream-management/get-started/create-your-first-kafka-service.md). Register a Kafka cluster and create a governed Kafka service.
 
-If you are evaluating Gravitee Gamma for your organization, consult the following resources:
+If you're evaluating Gravitee Gamma for your organization, consult the following resources:
 
-* [**Authorization Management overview**](../authorization-management/get-started/authorization-management-overview.md)**.** Understand GAPL policies and how the shared policy engine governs all traffic types.
-* [**Agent Management overview**](../agent-management/get-started/ai-management-overview.md)**.** Understand how the AI Gateway, Catalog, and Agent Identity work together to govern AI agent traffic.
-* [**Event Stream Management overview**](../event-stream-management/get-started/event-stream-management-overview.md)**.** Understand how Kafka infrastructure is governed and exposed to agents through the Catalog.
+* [**Authorization Management overview**](../authorization-management/get-started/authorization-management-overview.md). Understand GAPL policies and how the shared policy engine governs all traffic types.
+* [**Agent Management overview**](../agent-management/get-started/ai-management-overview.md). Understand how the AI Gateway, Catalog, and Agent Identity work together to govern AI agent traffic.
+* [**Event Stream Management overview**](../event-stream-management/get-started/event-stream-management-overview.md). Understand how Kafka infrastructure is governed and exposed to agents through the Catalog.

--- a/docs/gamma/4.13/platform-management/overview.md
+++ b/docs/gamma/4.13/platform-management/overview.md
@@ -1,33 +1,33 @@
 ---
 description: >-
-  Gravitee Gamma is a connectivity platform that unifies API Management, Event
-  Stream Management, Agent Management, and Authorization Management under a
-  shared catalog, authorization engine, and enforce
+  Gravitee Gamma unifies API Management, Event Stream Management, Agent
+  Management, and Authorization Management under a shared catalog, authorization
+  engine, and enforcement architecture.
 ---
 
 # Overview
 
-Gravitee Gamma lets you govern, secure, and observe enterprise traffic (APIs, event streams, and AI agent interactions) from a single platform. It provides a shared catalog, authorization engine, and enforcement architecture.
+Gravitee Gamma lets you govern, secure, and observe enterprise traffic across APIs, event streams, and AI agent interactions from a single platform. It provides a shared catalog, authorization engine, and enforcement architecture.
 
 ***
 
 ## Why Gamma Exists
 
-Modern enterprises run three distinct traffic types in isolation: REST, GraphQL, and gRPC APIs, Kafka event streams, and AI agent traffic (LLM calls, MCP tool invocations, and agent-to-agent delegations). Separate management of these traffic types results in fragmented visibility, duplicated policy configuration, and unaudited AI usage across your organization.
+Modern enterprises run three distinct traffic types in isolation: REST, GraphQL, and gRPC APIs, Kafka event streams, and AI agent traffic. Agent traffic covers LLM calls, MCP tool invocations, and agent-to-agent delegations. Separate management of these traffic types results in fragmented visibility, duplicated policy configuration, and unaudited AI usage across your organization.
 
 Gamma addresses the following core challenges:
 
-* **Unmanaged AI traffic.** Engineering teams use Claude Code, Cursor, and ChatGPT Enterprise with no central visibility into cost, model usage, or data exposure. Agents call MCP tools on upstream servers using shared API keys or unaudited credentials.
-* **Fragmented authorization.** Policies written for API gateways don't extend to AI agents or event streams, leaving different traffic types governed by different tools with no common enforcement point.
-* **Disjointed infrastructure.** REST APIs, Kafka topics, MCP servers, AI models, and agents exist in separate registries with no shared catalog. This makes it impossible to build cross-protocol policies or expose existing infrastructure to AI agents without redevelopment.
+* **Unmanaged AI traffic**. Engineering teams use Claude Code, Cursor, and ChatGPT Enterprise with no central visibility into cost, model usage, or data exposure. Agents call MCP tools on upstream servers using shared API keys or unaudited credentials.
+* **Fragmented authorization**. Policies written for API gateways don't extend to AI agents or event streams. Different traffic types are governed by different tools with no common enforcement point.
+* **Disjointed infrastructure**. REST APIs, Kafka topics, MCP servers, AI models, and agents exist in separate registries with no shared catalog. This makes it impossible to build cross-protocol policies or expose existing infrastructure to AI agents without redevelopment.
 
 ***
 
 ## How Gamma Works
 
-Gamma unifies four product lines (API Management, Event Stream Management, Agent Management, and Authorization Management) under a shared platform. All four share a common Catalog of assets and a common authorization engine that defines fine-grained policies against those cataloged assets. They also share common enforcement points (the AI Gateway, API Gateway, and Event Gateway) that evaluate the same policies at the wire level.
+Gamma unifies four product lines under a shared platform: API Management, Event Stream Management, Agent Management, and Authorization Management. All four share a common Catalog of assets and a common authorization engine that defines fine-grained policies against those cataloged assets. They also share common enforcement points—the AI Gateway, API Gateway, and Event Gateway—that evaluate the same policies at the wire level.
 
-```sh
+```
 ┌─────────────────────────────────────────────────────────────────────┐
 │                           Gravitee Gamma                            │
 │                                                                     │
@@ -57,13 +57,13 @@ Gamma unifies four product lines (API Management, Event Stream Management, Agent
 
 Gamma includes the following components:
 
-* **API Gateway.** Enforces runtime policy on every API request: authentication, rate limiting, content transformation, and routing between consumers and backend services.
-* **AI Gateway.** The unified runtime for LLM, MCP, and A2A traffic. It consists of three proxies (LLM Proxy, MCP Proxy, and A2A Proxy) that share an authentication chain, policy chain, observability chain, and Authorization Management integration.
-* **Event Gateway.** Enforces runtime policy on every Kafka event interaction: authentication, authorization, rate limiting, and protocol mediation.
-* **Gamma Console.** The Control Plane where all product lines are configured, observed, and managed across API Management, Event Stream Management, Agent Management, Authorization Management, and Platform Management.
-* **Catalog.** The authoritative registry of every asset an agent or consumer can use: AI models, MCP servers, tools (MCP, API, and Kafka API tools), prompts, resources, skills, and agents. Policy is authored against cataloged entities.
-* **Policy Decision Point (PDP).** Evaluates all applicable Gravitee Authorization Policy Language (GAPL) policies at microsecond latency with no network hop, running inside every gateway.
-* **Edge Daemon.** A lightweight process installed on employee devices using MDM that observes outgoing AI traffic, enforces local pre-egress policies, and forwards requests to the AI Gateway.
+* **API Gateway**. This gateway enforces runtime policy on every API request: authentication, rate limiting, content transformation, and routing between consumers and backend services.
+* **AI Gateway**. This gateway is the unified runtime for LLM, MCP, and A2A traffic. It consists of three proxies—the LLM Proxy, MCP Proxy, and A2A Proxy—that share an authentication chain, policy chain, observability chain, and Authorization Management integration.
+* **Event Gateway**. This gateway enforces runtime policy on every Kafka event interaction: authentication, authorization, rate limiting, and protocol mediation.
+* **Gamma Console**. This is the Control Plane where all product lines are configured, observed, and managed across API Management, Event Stream Management, Agent Management, Authorization Management, Edge Management, and Platform Management.
+* **Catalog**. This is the authoritative registry of every asset an agent or consumer can use: AI models, MCP servers, prompts, MCP resources, tools, knowledge and data sources, skills, and agents. Tools cover MCP, API, event, workflow, code, and knowledge tools. Policy is authored against cataloged entities.
+* **Policy Decision Point (PDP)**. The PDP evaluates all applicable Gravitee Authorization Policy Language (GAPL) policies at microsecond latency with no network hop, and it runs inside every gateway.
+* **Edge Daemon**. This is a lightweight process installed on employee devices using MDM. It observes outgoing AI traffic, enforces local pre-egress policies, and forwards requests to the AI Gateway.
 
 ***
 
@@ -71,37 +71,43 @@ Gamma includes the following components:
 
 ### API Management
 
-API Management governs REST, GraphQL, and gRPC traffic through API proxies, the core artifact that mediates between consumers and backend services. The API Gateway enforces runtime policy on every request while the Gamma console provides the Control Plane to design, secure, publish, and observe APIs. Creation wizards offer both a from-scratch four-step flow (API Details, Configure Proxy, Secure, and Review & Deploy) and quick-start templates for common patterns.
+API Management governs REST, GraphQL, gRPC, and WebSocket traffic through API proxies, the core artifact that mediates between consumers and backend services. The API Gateway enforces runtime policy on every request while the Gamma console provides the Control Plane to design, secure, publish, and observe APIs.
+
+API creation offers the following starting points:
+
+* **Start from scratch**. This option runs the full four-step wizard: API Details, Configure Proxy, Secure, and Review & Deploy.
+* **Quick-start templates**. These presets arrive with security and plans already filled in.
+* **Import API**. This option creates the API from a Gravitee definition, an OpenAPI specification, or a WSDL document.
 
 See [API Management overview](../api-management/get-started/api-management-overview.md).
 
 ### Security & Authentication
 
-Every API proxy accepts one or more security plans that define how consumers authenticate. Supported plan types include Keyless, API Key, JWT, OAuth2, and mTLS. Plans move through a defined lifecycle (Staging, Published, Deprecated, and Closed) and support rate limiting, quotas, and resource filtering at the plan level. For AI traffic, the AI Gateway supports OAuth authorization discovery and credential mediation for MCP servers, and token-based rate limiting for LLM Proxies.
+Every API proxy accepts one or more security plans that define how consumers authenticate. Supported plan types include Keyless, API Key, JWT, OAuth2, and mTLS. Plans move through a defined lifecycle of Staging, Published, Deprecated, and Closed. Plans also support rate limiting, quotas, and resource filtering at the plan level. For AI traffic, the AI Gateway supports OAuth authorization discovery and credential mediation for MCP servers, and token-based rate limiting for LLM Proxies.
 
 See [Secure your API proxy](../api-management/build/secure-your-api-proxy.md).
 
 ### Event Stream Management
 
-Event Stream Management governs Kafka clusters, event-driven data flows, and streaming infrastructure. Key capabilities include Kafka cluster registration, Kafka Service creation (the event-stream equivalent of an API proxy), and Virtual Clusters for multi-tenant isolation on shared infrastructure. An integrated Explorer lets you create topics, inspect messages, and manage connections. Kafka APIs contributed to the Catalog can be exposed as Kafka API Tools in Agent Management, bridging event streams to the AI agent layer without redevelopment.
+Event Stream Management governs Kafka clusters, event-driven data flows, and streaming infrastructure. Key capabilities include Kafka cluster registration, Kafka Service creation, and Virtual Clusters for multi-tenant isolation on shared infrastructure. A Kafka Service is the event-stream equivalent of an API proxy. Event sources contributed to the Catalog can be exposed as event tools in Agent Management, which bridges event streams to the AI agent layer without redevelopment.
 
 See [Event Stream Management overview](../event-stream-management/get-started/event-stream-management-overview.md).
 
 ### Agent Management & AI Governance
 
-Agent Management governs every protocol in the agentic stack. The **LLM Proxy** handles traffic to LLM providers (Anthropic, OpenAI, AWS Bedrock, Gemini Enterprise Agent Platform (formerly Vertex AI), and Azure) with guardrails, PII filtering, and token-based rate limiting. The **MCP Proxy** governs tool invocations in two modes: Proxy mode for transparent governance of upstream MCP servers, and Studio mode for composing Composite MCP Servers. The **A2A Proxy** governs agent-to-agent delegations with skill discovery, per-skill authorization, and agent identity verification. Every interaction emits an OpenTelemetry span with agent identity, tool name, inputs, outputs, latency, policy decision, cost, and timestamp.
+Agent Management governs every protocol in the agentic stack. The **LLM Proxy** handles traffic to LLM providers with guardrails, PII filtering, and token-based rate limiting. Supported providers are OpenAI, Gemini, Anthropic, Bedrock, and Vertex AI. The **MCP Proxy** governs tool invocations in two modes: Proxy mode for transparent governance of upstream MCP servers, and Studio mode for composing catalog assets into an MCP Studio. The **A2A Proxy** governs agent-to-agent delegations with skill discovery, per-skill authorization, and agent identity verification. Every interaction emits an OpenTelemetry span with agent identity, tool name, inputs, outputs, latency, policy decision, cost, and timestamp.
 
 See [Agent Management overview](../agent-management/get-started/ai-management-overview.md).
 
 ### Authorization Management
 
-Authorization Management provides fine-grained, catalog-aware access control across all Gamma traffic types through policies written in Gravitee Authorization Policy Language (GAPL), a subset of the Cedar policy language. Policies declare an effect (`permit` or `forbid`), a principal, an action, a resource, and optional conditions for time-of-day restrictions, IP range checks, token budgets, and custom attribute matching. Policy categories cover MCP Policies, AI Model Policies, API Policies, and Custom Policies. Principals can be synchronized from identity providers using SCIM or from Gravitee Access Management.
+Authorization Management provides fine-grained, catalog-aware access control across all Gamma traffic types. Policies are written in Gravitee Authorization Policy Language (GAPL), a subset of the Cedar policy language. A policy declares an effect of `permit` or `forbid`, a principal, an action, a resource, and optional conditions for time-of-day restrictions, IP range checks, token budgets, and custom attribute matching. Policy Management covers MCPs, AI Models, APIs, A2A Agents, and Custom Policies. Principals can be synchronized from Gravitee Access Management or imported from a file.
 
 See [Authorization Management overview](../authorization-management/get-started/authorization-management-overview.md).
 
 ### Edge Management
 
-Edge Management provides visibility and control over AI traffic on employee devices. The Edge Daemon, distributed using MDM solutions (Kandji, Jamf, and Intune), supports two routing modes. Interception mode is the default and provides transparent DNS-level redirect of AI provider traffic. Proxy mode requires explicit per-tool base URL configuration. The daemon detects shadow AI usage regardless of whether traffic is routed through it. It enforces local pre-egress policies and forwards requests to the AI Gateway for enterprise-wide policy enforcement. The Edge Management dashboard surfaces fleet status, metrics filterable by device and model, and shadow AI usage reports.
+Edge Management provides visibility and control over AI traffic on employee devices. The Edge Daemon, distributed to managed devices as a Kandji Custom App, supports two routing modes. Interception mode is the default and provides transparent DNS-level redirect of AI provider traffic. Proxy mode requires explicit per-tool base URL configuration. The daemon detects shadow AI usage regardless of whether traffic is routed through it. It enforces local pre-egress policies and forwards requests to the AI Gateway for enterprise-wide policy enforcement. The Edge Management dashboard surfaces fleet status, metrics filterable by device and model, and shadow AI usage reports.
 
 See [Edge Management overview](../edge-management/get-started/edge-management-overview.md).
 
@@ -111,28 +117,29 @@ See [Edge Management overview](../edge-management/get-started/edge-management-ov
 
 Gamma supports the following protocols and standards:
 
-| Protocol                                                | Support | Notes                                                                |
-| ------------------------------------------------------- | ------- | -------------------------------------------------------------------- |
-| REST / HTTP                                             | Full    | API proxies with context path or virtual host routing                |
-| GraphQL                                                 | Full    | Governed through API Management                                      |
-| gRPC                                                    | Full    | Governed through API Management                                      |
-| Kafka (native)                                          | Full    | Through the Event Gateway (Kafka Services and Virtual Clusters)      |
-| MCP (JSON-RPC 2.0)                                      | Full    | Through the MCP Proxy in Proxy mode or Studio mode                   |
-| A2A                                                     | Full    | Through the A2A Proxy with `/.well-known/agent.json` skill discovery |
-| LLM APIs (OpenAI, Anthropic, Bedrock, Gemini Enterprise Agent Platform (formerly Vertex AI), Azure) | Full    | Through the LLM Proxy with provider-specific routing                 |
+| Protocol    | Support | Notes                                                                                                    |
+| ----------- | ------- | -------------------------------------------------------------------------------------------------------- |
+| REST / HTTP | Full    | API proxies with context path or virtual host routing                                                    |
+| GraphQL     | Full    | Governed through API Management                                                                          |
+| gRPC        | Full    | Governed through API Management                                                                          |
+| WebSocket   | Full    | Governed through API Management                                                                          |
+| Kafka       | Full    | Native Kafka protocol through the Event Gateway, using Kafka Services and Virtual Clusters               |
+| MCP         | Full    | JSON-RPC 2.0 through the MCP Proxy in Proxy mode or Studio mode                                          |
+| A2A         | Full    | Through the A2A Proxy with `/.well-known/agent-card.json` skill discovery                                |
+| LLM APIs    | Full    | Through the LLM Proxy with provider-specific routing for OpenAI, Gemini, Anthropic, Bedrock, and Vertex AI |
 
 ***
 
 ## Next steps
 
-If you are new to Gravitee Gamma, complete the following steps:
+If you're new to Gravitee Gamma, complete the following steps:
 
-1. [**Create your first API**](../api-management/get-started/create-your-first-api.md): Create an API proxy and enforce a security plan in under five minutes.
-2. [**Create your first MCP server**](../agent-management/get-started/create-your-first-mcp-server.md): Set up an MCP proxy in front of an upstream MCP server and verify tool invocations.
-3. [**Create your first Kafka service**](../event-stream-management/get-started/create-your-first-kafka-service.md): Register a Kafka cluster and create a governed Kafka service.
+1. [**Create your first API**](../api-management/get-started/create-your-first-api.md). Create an API proxy and enforce a security plan in under five minutes.
+2. [**Create your first MCP server**](../agent-management/get-started/create-your-first-mcp-server.md). Configure an MCP proxy in front of an upstream MCP server and verify tool invocations.
+3. [**Create your first Kafka service**](../event-stream-management/get-started/create-your-first-kafka-service.md). Register a Kafka cluster and create a governed Kafka service.
 
-If you are evaluating Gravitee Gamma for your organization, consult the following resources:
+If you're evaluating Gravitee Gamma for your organization, consult the following resources:
 
-* [**Authorization Management overview**](../authorization-management/get-started/authorization-management-overview.md)**.** Understand GAPL policies and how the shared policy engine governs all traffic types.
-* [**Agent Management overview**](../agent-management/get-started/ai-management-overview.md)**.** Understand how the AI Gateway, Catalog, and Agent Identity work together to govern AI agent traffic.
-* [**Event Stream Management overview**](../event-stream-management/get-started/event-stream-management-overview.md)**.** Understand how Kafka infrastructure is governed and exposed to agents through the Catalog.
+* [**Authorization Management overview**](../authorization-management/get-started/authorization-management-overview.md). Understand GAPL policies and how the shared policy engine governs all traffic types.
+* [**Agent Management overview**](../agent-management/get-started/ai-management-overview.md). Understand how the AI Gateway, Catalog, and Agent Identity work together to govern AI agent traffic.
+* [**Event Stream Management overview**](../event-stream-management/get-started/event-stream-management-overview.md). Understand how Kafka infrastructure is governed and exposed to agents through the Catalog.


### PR DESCRIPTION
Doc Verification Pipeline run on `docs/gamma/4.12/platform-management/overview.md`.

**Environment:** local Gamma console at `http://localhost:8086`, `graviteeio/gamma-ui:4.12.11` + `apim-management-api:4.12.11` (confirmed via `docker ps`), driven with `gravitee-browser-agent`. Read-only: nothing was created, modified, or deleted in the console — wizards were opened and cancelled.

**Code cross-check:** `gravitee-gamma-plugins` RAG profile (`gravitee-gamma-module-aim`, `-authz`, `-esm`, `gravitee-reactor-edge`). Where the repos (on `main`) and the deployed 4.12 artifacts disagreed, the **deployed 4.12 module bundles** inside `gamma_management_api` were treated as authoritative.

## Step 4 verdict table

| # | Claim | Code truth | Live truth (4.12.11) | Verdict |
|---|---|---|---|---|
| 1 | Gamma unifies four product lines: API Management, ESM, Agent Management, Authorization Management | Four module repos exist, plus edge | Product switcher lists 6 areas (adds Edge Management, Platform Management) | Framing — **flagged for writer**, not edited |
| 2 | Gamma Console covers APIM, ESM, Agent Mgmt, AuthZ, Platform Mgmt | — | Switcher: Edge Management, Agent Management, API Management, Event Stream Management, Platform Management, Authorization Management | **Contradicted** — added Edge Management |
| 3 | Catalog holds AI models, MCP servers, tools (MCP, API, **Kafka API** tools), prompts, resources, skills, agents | AIM 4.12 `ROUTE_KEYS` include `knowledge`; no Kafka tool type | Catalog nav: AI Models, MCP Servers, Prompts, MCP Resources, Tools, **Knowledge & Data**, Skills, Agents. Create tool offers Knowledge & Data capability, Workflow, Code, API, Event | **Contradicted** — added knowledge/data, replaced "Kafka API tools" with the live tool set |
| 4 | AI Gateway = LLM Proxy + MCP Proxy + A2A Proxy | Confirmed | Secure nav: LLM Proxies, MCP Proxies, A2A Proxies | **Confirmed** |
| 5 | API Management governs REST, GraphQL, gRPC | — | APIM quick start: "any HTTP, GraphQL, gRPC, or WebSocket service"; Protocols: REST, GraphQL, gRPC, **WebSocket** | **Contradicted (incomplete)** — added WebSocket |
| 6 | Creation wizard: from-scratch four-step flow + quick-start templates | — | `/apim/apis/new` offers **three**: Start from scratch, Quick-start templates, **Import API** | **Contradicted (incomplete)** — added Import API |
| 7 | Four-step names: API Details, Configure Proxy, Secure, Review & Deploy | — | Stepper reads exactly those four | **Confirmed** |
| 8 | Plan types: Keyless, API Key, JWT, OAuth2, mTLS | — | Create plan menu: API Key, JWT, OAuth2, mTLS, Keyless | **Confirmed** |
| 9 | Plan lifecycle: Staging, Published, Deprecated, Closed | — | Plans page status filters: Staging, Published, Deprecated, Closed | **Confirmed** |
| 10 | ESM: cluster registration, Kafka Service creation, Virtual Clusters | ESM 1.0.0 `ROUTE_KEYS` = overview, clusters, virtual-clusters, kafka-apis | ESM nav: Dashboard, Clusters, Kafka Services, Virtual Clusters | **Confirmed** |
| 11 | "An integrated Explorer lets you create topics, inspect messages, manage connections" | Deployed esm 1.0.0 has **no** `kafka-explorer` route; repo `main` keeps the nav entry hidden until release | No Explorer in nav; `/esm/kafka-explorer`, `/esm/explorer`, `/esm/topics` all 404 | **Contradicted** — sentence removed |
| 12 | Kafka APIs exposed as "Kafka API Tools" | No such type | Create tool offers **Event tool** ("select one or more event sources…") | **Contradicted** — "event tools" |
| 13 | LLM providers: Anthropic, OpenAI, AWS Bedrock, Vertex AI, **Azure** | `LlmRequestFormat` = OPEN_AI, GEMINI, ANTHROPIC, BEDROCK, VERTEX_AI | Provider dropdown: OpenAI, Gemini, Anthropic, Bedrock, Vertex AI. No Azure | **Contradicted** — Azure removed, Gemini added |
| 14 | MCP Proxy modes: Proxy mode, Studio mode | `McpProxyMode` = PROXY, STUDIO | Create MCP Proxy: "Proxy mode" / "Studio mode" | **Confirmed** |
| 15 | Studio mode composes "Composite MCP Servers" | Core type is `McpStudio*` | UI says "compose assets from the catalog… unified MCP entrypoint"; artifact is an MCP Studio | **Contradicted** — "an MCP Studio" |
| 16 | GAPL = Cedar subset; effect `permit`/`forbid`, principal, action, resource, conditions | AuthZ tests and policy editor use exactly this shape; Cedar referenced as the engine | Quick Start describes PEP/PDP runtime and GAPL engine | **Confirmed** |
| 17 | Policy categories: MCP, AI Model, API, Custom | AuthZ `ROUTE_KEYS` add `a2a` | Policy Management nav: MCPs, AI Models, APIs, **A2A Agents**, Custom Policies | **Contradicted (incomplete)** — added A2A Agents |
| 18 | Principals synchronized using **SCIM** or from Gravitee Access Management | "scim" appears only as a free-text `source` value in one test; no SCIM implementation | Import menu offers **Sync from Gravitee Access Management** and **Import from file…** only | **Contradicted** — SCIM replaced with file import |
| 19 | Edge Daemon distributed using MDM (**Kandji, Jamf, Intune**) | — | Edge 1.1.0 bundle mentions only **Kandji** ("deploy… to managed devices via Kandji", "Kandji Custom App") | **Contradicted** — narrowed to Kandji |
| 20 | Edge routing modes: Interception (default) vs Proxy | Daemon heartbeat carries `"mode": "interception"` | Console exposes interception DNS domains + routes; Proxy mode is daemon-side | **Not determined** — left unchanged |
| 21 | Edge dashboard: fleet status, metrics by device/model, shadow AI reports | Edge `ROUTE_KEYS` = quick-start, edge-configuration, shadow-ai, proxied-traffic, devices | Nav matches (Devices, Proxied Traffic, Shadow AI); environment unconfigured, so contents not observable | **Not determined** — left unchanged |
| 22 | A2A skill discovery at `/.well-known/agent.json` | `AgentCardFetchDomainService`: `/.well-known/agent-card.json` primary, `agent.json` legacy fallback | Deployed AIM 1.2.0 bundle references only `agent-card.json` | **Contradicted** — updated to `agent-card.json` |
| 23 | PDP evaluates GAPL at microsecond latency, no network hop, inside every gateway | PEP + PDP ship as gateway plugins; PDP polls compiled bundles | AuthZ Quick Start shows Gateway/PEP + PDP Runtime | **Not determined** (latency unverifiable) — left unchanged |
| 24 | OpenTelemetry span fields per interaction | Tracing enabled in AIM observability config | Tracing nav exists; no traffic to inspect | **Not determined** — left unchanged |
| 25 | AI Gateway OAuth discovery, credential mediation, token rate limiting | — | Requires configured proxies to observe | **Not determined** — left unchanged |
| 26 | **Images** | — | Page contains no `<figure>` elements | **N/A** — nothing to verify, nothing captured |

## Step 5 edits (evidence-driven)

Rows 2, 3, 5, 6, 11, 12, 13, 15, 17, 18, 19, 22 above.

## Step 6 style pass

Whole-document Docs Editor pass: fixed the truncated frontmatter description, removed non-acronym parentheses, converted bold-term list items to the `**Term**. Sentence.` form, replaced the `` ```sh `` fence on the ASCII diagram with a plain fence, split over-long sentences, turned the API creation options into a bulleted list, and normalised the Next steps link punctuation. Every hunk was diffed against the pre-pass file and confirmed meaning-preserving.

## Flagged for the writer (not edited)

- **"Four product lines"** framing. The console presents six areas; Edge Management is a peer product tile with its own section on this page. Worth deciding whether the page should say four, five, or six.
- **"Why Gamma Exists"** still says "REST, GraphQL, and gRPC APIs" for the industry framing while the API Management section now also lists WebSocket.
- The ASCII diagram labels Platform Management as **"(Apps/Resources)"**. The 4.12 Platform Management nav is Applications, Metadata, and Access Management; `manage-resources.md` itself notes the Resources tab is "Coming soon".
- The 4.12 console states the **Edge Daemon is macOS-only** (Apple Silicon and Intel) and that it intercepts Claude Code traffic through the Anthropic API. The page doesn't mention platform support at all.
- **No images on this page.** Nothing here meets an images-and-figures trigger in a way the pipeline should act on, but "the reader arrives somewhere new" arguably applies to the console home; that's a writer's call, and the pipeline does not add screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
