### PR TITLE
docs(gamma): correct AI Catalog link text on Authorization Management get started

### DIFF
--- a/docs/gamma/4.12/authorization-management/get-started/README.md
+++ b/docs/gamma/4.12/authorization-management/get-started/README.md
@@ -1,4 +1,5 @@
 ---
+description: Lists the Authorization Management get-started guides, covering the product overview, your first user, your first imported resource, and your first policy.
 hidden: false
 noIndex: false
 ---
@@ -7,5 +8,5 @@ noIndex: false
 
 * [Authorization Management overview](authorization-management-overview.md)
 * [Create your first user](create-your-first-user.md)
-* [Import your first resource from Agent catalog](import-your-first-resource-from-agent-catalog.md)
+* [Import your first resource from the AI Catalog](import-your-first-resource-from-agent-catalog.md)
 * [Create your first policy](create-your-first-policy.md)

--- a/docs/gamma/4.13/authorization-management/get-started/README.md
+++ b/docs/gamma/4.13/authorization-management/get-started/README.md
@@ -1,4 +1,5 @@
 ---
+description: Lists the Authorization Management get-started guides, covering the product overview, your first user, your first imported resource, and your first policy.
 hidden: false
 noIndex: false
 ---
@@ -7,5 +8,5 @@ noIndex: false
 
 * [Authorization Management overview](authorization-management-overview.md)
 * [Create your first user](create-your-first-user.md)
-* [Import your first resource from Agent catalog](import-your-first-resource-from-agent-catalog.md)
+* [Import your first resource from the AI Catalog](import-your-first-resource-from-agent-catalog.md)
 * [Create your first policy](create-your-first-policy.md)


### PR DESCRIPTION
Doc Verification Pipeline run on `docs/gamma/4.12/authorization-management/get-started/README.md`.

- **Code cross-check:** `gravitee-gamma-plugins` profile — `gravitee-gamma-module-authz`, `gravitee-gamma-module-aim`.
- **Live check:** local Gamma console (`localhost:8086`), Authorization Management → **Policy Structure → Entities → Resources**, driven read-only with `gravitee-browser-agent`. Nothing was created, modified, or deleted.

## Step 4 verdict table

| # | Claim | Code truth | Live truth | Verdict |
|---|---|---|---|---|
| 1 | Page heading is **Get started** | n/a (docs nav page) | n/a | No change |
| 2 | Link **Authorization Management overview** → `authorization-management-overview.md` | Module is named `Authorization Management` (the module source) | Sidebar module switcher reads **Authorization Management** | Confirmed |
| 3 | Link **Create your first user** → `create-your-first-user.md` | Target page H1 matches | Entities → **Principals** tab offers **Add principal** | Confirmed |
| 4 | Link **Import your first resource from Agent catalog** → `import-your-first-resource-from-agent-catalog.md` | No `Agent Catalog` string anywhere in the authz UI. the module source renders the menu item **Import from AI Catalog**; the module source heads the panel **Import from AI Catalog**. Target page H1 is *Import your first resource from the AI Catalog* | Entities → Resources → **Import** dropdown shows exactly two items: **Import from AI Catalog** and **Import from file…** | **Contradicted — fixed** |
| 5 | Link **Create your first policy** → `create-your-first-policy.md` | Target page H1 matches | Policy Management group present in sidebar | Confirmed |
| 6 | The section contains these four pages, in this order | Matches `docs/gamma/4.12/SUMMARY.md` lines 129-132 | n/a | Confirmed |
| 7 | Images: page contains **zero** `<figure>` elements | n/a | n/a | No change — a link index page hits none of the screenshot triggers in `images-and-figures.md`, so no image is missing and none is stale |

## What changed

1. **Step 5 (meaning):** link text `Import your first resource from Agent catalog` → `Import your first resource from the AI Catalog`. The file name is left alone so no inbound link or redirect breaks.
2. **Step 6 (style, meaning-preserving):** added the `description` frontmatter field required by `style-guide/06-document-types-and-templates/frontmatter.md`.

No bulleted-list introduction was added: `structurer-skill.md` rule 7 governs an intro sentence that already exists, and its NO HALLUCINATION guardrail forbids writing explanatory prose that was not in the draft. Whether this page should gain an intro line and per-link explanations — the four sibling `get-started/README.md` pages under `docs/gamma/4.12/` all have them — is a writer's call, not a factual contradiction.

## 4.13

`docs/gamma/4.13/authorization-management/get-started/README.md` was byte-identical to the 4.12 file, so the identical change is applied there in this same commit. `.github/workflows/version-sync.yml` covers only `apim`/`am`/`gko`, so gamma does not auto-sync and 4.13 would otherwise go stale.

## Out of scope — flagged for the writer, not edited

1. **`SUMMARY.md` carries the same wrong label.** `docs/gamma/4.12/SUMMARY.md:131` and `docs/gamma/4.13/SUMMARY.md:131` still read `Import your first resource from Agent catalog`, so the GitBook sidebar disagrees with both the page body and the target page's own H1. Not touched here because `SUMMARY.md` is outside this run's target file and is a high-collision file in a batch run.
2. **The child page contradicts the live UI.** `import-your-first-resource-from-agent-catalog.md` step 2 says to select **Import from Context Catalog** from the **Import** dropdown. Live, that dropdown offers only **Import from AI Catalog** and **Import from file…** — `Context Catalog` appears in the authz UI only as body copy on the Entities page, never as the menu item. The same wording is repeated in the page's Prerequisites hint. Different file, so not verified or fixed in this run.
3. **File name.** `import-your-first-resource-from-agent-catalog.md` still encodes `agent-catalog`. Renaming would need a `.gitbook.yaml` redirect and coordination with `SUMMARY.md`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

