### PR TITLE
docs(gamma): verify ESM Get started landing page against the 4.12 console

### DIFF
--- a/docs/gamma/4.12/event-stream-management/get-started/README.md
+++ b/docs/gamma/4.12/event-stream-management/get-started/README.md
@@ -1,12 +1,14 @@
 ---
+description: Introductory pages for Event Stream Management in Gamma, covering the product overview and the quickstarts for clusters, Kafka services, and Virtual Clusters.
 hidden: false
 noIndex: false
 ---
 
 # Get started
-New to Event Stream Management in Gamma? Start here.
 
-* [**Event Stream Management overview**](event-stream-management-overview.md) — What Event Stream Management does and how it fits into the Gamma platform.
-* [**Register your first cluster**](register-your-first-cluster.md) — Connect Gamma to a Kafka cluster — the foundation for services and virtual clusters.
-* [**Create your first Kafka service**](create-your-first-kafka-service.md) — Set up a Kafka service in the Gamma console.
-* [**Create your first virtual cluster**](create-your-first-virtual-cluster.md) — Provision a virtual cluster on top of your Kafka infrastructure.
+New to Event Stream Management in Gamma? Start with the following pages:
+
+* [**Event Stream Management overview**](event-stream-management-overview.md). This page explains what Event Stream Management does and how it fits into the Gamma platform.
+* [**Register your first cluster**](register-your-first-cluster.md). This quickstart shows you how to register a Kafka cluster with Gamma, the foundation for Kafka Services and Virtual Clusters.
+* [**Create your first Kafka service**](create-your-first-kafka-service.md). This quickstart shows you how to set up a Kafka service in the Gamma console.
+* [**Create your first Virtual Cluster**](create-your-first-virtual-cluster.md). This quickstart shows you how to provision a Virtual Cluster on top of your Kafka infrastructure.

--- a/docs/gamma/4.13/event-stream-management/get-started/README.md
+++ b/docs/gamma/4.13/event-stream-management/get-started/README.md
@@ -1,12 +1,14 @@
 ---
+description: Introductory pages for Event Stream Management in Gamma, covering the product overview and the quickstarts for clusters, Kafka services, and Virtual Clusters.
 hidden: false
 noIndex: false
 ---
 
 # Get started
-New to Event Stream Management in Gamma? Start here.
 
-* [**Event Stream Management overview**](event-stream-management-overview.md) — What Event Stream Management does and how it fits into the Gamma platform.
-* [**Register your first cluster**](register-your-first-cluster.md) — Connect Gamma to a Kafka cluster — the foundation for services and virtual clusters.
-* [**Create your first Kafka service**](create-your-first-kafka-service.md) — Set up a Kafka service in the Gamma console.
-* [**Create your first virtual cluster**](create-your-first-virtual-cluster.md) — Provision a virtual cluster on top of your Kafka infrastructure.
+New to Event Stream Management in Gamma? Start with the following pages:
+
+* [**Event Stream Management overview**](event-stream-management-overview.md). This page explains what Event Stream Management does and how it fits into the Gamma platform.
+* [**Register your first cluster**](register-your-first-cluster.md). This quickstart shows you how to register a Kafka cluster with Gamma, the foundation for Kafka Services and Virtual Clusters.
+* [**Create your first Kafka service**](create-your-first-kafka-service.md). This quickstart shows you how to set up a Kafka service in the Gamma console.
+* [**Create your first Virtual Cluster**](create-your-first-virtual-cluster.md). This quickstart shows you how to provision a Virtual Cluster on top of your Kafka infrastructure.


### PR DESCRIPTION
## Summary

Ran the Doc Verification Pipeline on the Event Stream Management **Get started** landing page. Every link target, link title, and description was checked against the running 4.12 Gamma console and confirmed against the Event Stream Management module source for 4.12.

The page is a landing page, not a procedure, and it carries no images. No screenshot triggers apply, so nothing was added or removed.

## Verdict table

| Claim | Code truth | Live truth | Verdict |
| --- | --- | --- | --- |
| Links to `event-stream-management-overview.md`, titled "Event Stream Management overview" | n/a | n/a | Correct. Link text matches the target page title and the `SUMMARY.md` entry. |
| Overview description: "What Event Stream Management does and how it fits into the Gamma platform" | n/a | n/a | Correct. Matches the two top-level sections of the overview page. |
| Links to `register-your-first-cluster.md`, titled "Register your first cluster" | n/a | n/a | Correct. |
| Cluster description: "Connect Gamma to a Kafka cluster" | Confirmed the module models a cluster as a reusable multi-connection registration, with connections added to it separately | The console's Clusters page describes the action as registering a cluster, then adding connections to it | **Fixed.** Reworded to registering a cluster with Gamma. |
| Cluster description: "the foundation for services and virtual clusters" | Confirmed | The Clusters page states a registered cluster is the foundation for Kafka Services and Virtual Clusters | Correct in substance. **Terminology fixed** to the names the console uses. |
| Links to `create-your-first-kafka-service.md`, titled "Create your first Kafka service" | n/a | n/a | Correct. Link text matches the target page title and the `SUMMARY.md` entry. |
| Kafka service description: "Set up a Kafka service in the Gamma console" | Confirmed | The console has a Kafka Services section with a Create Kafka Service action | Correct. |
| Link text "Create your first virtual cluster" | n/a | n/a | **Fixed.** The target page is titled "Create your first Virtual Cluster" and `SUMMARY.md` lists it that way, so the link text was inconsistent with the page a reader lands on. |
| Virtual Cluster description: "Provision a virtual cluster on top of your Kafka infrastructure" | Confirmed | The console's Virtual Clusters page describes federating registered Kafka clusters behind a single managed endpoint | Correct in substance. **Terminology aligned** with the console's entity name. |
| Four child pages, in this order | n/a | n/a | Correct. Order matches `SUMMARY.md`. |
| Product area is called "Event Stream Management" in the console | Confirmed | The console's Event Stream Management area is titled exactly that | Correct. |
| Page has no images | n/a | n/a | Correct as-is. No image trigger applies to a landing page. |

## What changed

Meaning-level (evidence-backed):

* Link text is now **Create your first Virtual Cluster**, matching the page it links to.
* The cluster item now describes registering a Kafka cluster with Gamma rather than connecting Gamma to one.
* "services and virtual clusters" is now "Kafka Services and Virtual Clusters".

Style pass (form only):

* Added the required `description` frontmatter field.
* List item explanations now follow the separator rule: the term ends with a period, and the explanation is a complete sentence of its own. Bold link text is retained.
* The list introduction now contains "following" and ends with a colon.
* Added the missing blank line after the H1.

## Versions

4.12 and 4.13 were byte-identical before this change, so the identical patch is applied to both in this PR. `version-sync.yml` does not cover `docs/gamma`.

## Notes for the writer

Nothing out of scope was found. The other Gamma "Get started" landing pages (Agent Management, API Management, Edge Management, Authorization Management) use the same em dash list separator and also lack a `description` field, so they will need the same treatment if the convention is applied across the set.
