### PR TITLE
docs(gamma): verify Authorization Management overview against 4.12

### DIFF
--- a/docs/gamma/4.12/authorization-management/get-started/authorization-management-overview.md
+++ b/docs/gamma/4.12/authorization-management/get-started/authorization-management-overview.md
@@ -1,32 +1,31 @@
 ---
+description: Learn how Authorization Management enforces fine-grained, catalog-aware access control across Gamma traffic using GAPL policies.
 hidden: false
 noIndex: false
 ---
 
 # Authorization Management overview
 
-Authorization Management provides fine-grained, catalog-aware access control across all Gamma traffic types — APIs, MCP servers, AI models, agents, events, and custom resources. Policies are written in GAPL (Gravitee Authorization Policy Language), a subset of the Cedar policy language, and enforced at the wire level by Gamma's gateways.
-
-
+Authorization Management provides fine-grained, catalog-aware access control across all Gamma traffic types—APIs, MCP servers, AI models, agents, events, and custom resources. Policies are written in Gravitee Authorization Policy Language (GAPL), a subset of the Cedar policy language, and enforced at the wire level by Gamma's gateways.
 
 ## How it works
 
-Authorization Management connects three things:
+Authorization Management connects the following three things:
 
-1. **Entities** — The things you want to protect (APIs, MCP tools, AI models). Entities are registered in the Catalog or created directly in Authorization Management.
-2. **Principals** — The identities making requests (users, groups, agents). Principals can be synced from your identity provider via SCIM, synchronized from Access Management (AM), or created locally. When synchronizing users from AM, sync progress is surfaced via live toast notifications, and the principal list updates dynamically without requiring a page refresh.
-3. **Policies** — Rules that grant or deny access. Each policy declares an effect (`permit` or `forbid`), a principal, an action, a resource, and optional conditions.
+1. **Entities.** The things you want to protect, such as APIs, MCP tools, and AI models. Entities are registered in the Catalog or created directly in Authorization Management.
+2. **Principals.** The identities making requests, such as users, groups, service accounts, and agent identities. Principals can be synced from Gravitee Access Management (AM), imported from a file, or created locally. During an AM sync, progress is shown through live toast notifications, and the principal list updates dynamically without a page refresh.
+3. **Policies.** Rules that grant or deny access. Each policy declares an effect of either `permit` or `forbid`, plus a principal, an action, a resource, and optional conditions.
 
-When a request arrives at the API Gateway, AI Gateway, or Event Gateway, the Policy Decision Point (PDP) evaluates all applicable policies and returns a permit or deny decision at microsecond latency with no network hop.
+When a request arrives at the API Gateway, AI Gateway, or Event Gateway, the Policy Decision Point (PDP) evaluates all applicable policies. The PDP returns a permit or deny decision at microsecond latency with no network hop.
 
 ## Policy language: GAPL
 
-GAPL (Gravitee Authorization Policy Language) uses Cedar syntax. A policy looks like:
+GAPL uses Cedar syntax. A policy looks like:
 
 ```
 permit (
-  principal == user::"alice",
-  action == action::"invoke",
+  principal == User::"alice",
+  action == Action::"invoke",
   resource == MCPTool::"github-create-issue"
 );
 ```
@@ -39,20 +38,23 @@ GAPL supports a subset of the Cedar policy language optimized for the Gamma visu
 
 ## Policy categories
 
-Authorization Management organizes policies into service-specific categories. Each category has its own page with a policy list, KPI tiles, search, and status filter.
+Authorization Management organizes policies into service-specific categories. Each category has its own page with a policy list, KPI tiles, search, and status filter. The following table describes each policy category:
 
-| Category              | What it governs                                                                                                                  | Entity types                               |
-| --------------------- | -------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
-| **MCP Policies**      | Access to MCP servers, their tools, prompts, and resources.                                                                      | MCPServer, MCPTool, MCPPrompt, MCPResource |
-| **AI Model Policies** | Access to AI providers and specific models, with cost and token usage constraints.                                               | LLMProvider, LLMModel                      |
-| **API Policies**      | Access to API proxies, their endpoints, and data fields.                                                                         | API, Endpoint, DataField                   |
-| **Custom Policies**   | Policies for resources not routed as MCP, API, Agent, LLM, or Event — internal applications, data assets, and bespoke resources. | Custom (user-defined)                      |
+| Category              | What it governs                                                                                                                      | Entity types                               |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------ |
+| **MCP Policies**      | Access to MCP servers, their tools, prompts, and resources.                                                                          | MCPServer, MCPTool, MCPPrompt, MCPResource |
+| **AI Model Policies** | Access to AI providers and specific models, with cost and token usage constraints.                                                   | LLMProvider, Model                         |
+| **API Policies**      | Access to API proxies, their endpoints, and data fields.                                                                             | API, Endpoint, DataField                   |
+| **A2A Policies**      | Which principals can invoke each A2A agent.                                                                                          | Agent                                      |
+| **Custom Policies**   | Policies for resources not routed as MCP, API, Agent, AI Model, or Event—internal applications, data assets, and bespoke resources. | Custom (user-defined)                      |
 
 ## Condition snippets
 
-Each policy category provides pre-built condition snippets you can insert into your policies:
+Each policy category provides pre-built condition snippets you can insert into your policies.
 
 ### MCP conditions
+
+The following conditions are available for MCP policies:
 
 | Condition              | GAPL snippet                                       |
 | ---------------------- | -------------------------------------------------- |
@@ -61,6 +63,8 @@ Each policy category provides pre-built condition snippets you can insert into y
 | **Corporate IP range** | `context.source.ip.in_cidr("10.0.0.0/8")`          |
 
 ### AI Model conditions
+
+The following conditions are available for AI Model policies:
 
 | Condition            | GAPL snippet                                      |
 | -------------------- | ------------------------------------------------- |
@@ -71,16 +75,39 @@ Each policy category provides pre-built condition snippets you can insert into y
 
 ### API conditions
 
+The following conditions are available for API policies:
+
 | Condition              | GAPL snippet                                          |
 | ---------------------- | ----------------------------------------------------- |
 | **Corporate IP range** | `context.source.ip.in_cidr("10.0.0.0/8")`             |
 | **Scope present**      | `context.auth.scopes.contains("orders:read")`         |
-| **Rate limit**         | `context.rate.per_minute(principal) < 100`            |
+| **Rate < 100/min**     | `context.rate.per_minute(principal) < 100`            |
 | **Tenant match**       | `context.request.header.x_tenant == principal.tenant` |
+
+### A2A conditions
+
+The following conditions are available for A2A policies:
+
+| Condition              | GAPL snippet                                       |
+| ---------------------- | -------------------------------------------------- |
+| **Business hours**     | `context.time.hour >= 9 && context.time.hour < 17` |
+| **Trusted device**     | `context.device.trusted == true`                   |
+| **Corporate IP range** | `context.source.ip.in_cidr("10.0.0.0/8")`          |
+
+### Custom conditions
+
+The following conditions are available for custom policies:
+
+| Condition              | GAPL snippet                                       |
+| ---------------------- | -------------------------------------------------- |
+| **Corporate IP range** | `context.source.ip.in_cidr("10.0.0.0/8")`          |
+| **MFA required**       | `context.auth.mfa == true`                         |
+| **Business hours**     | `context.time.hour >= 9 && context.time.hour < 17` |
+| **Owner only**         | `resource.owner == principal`                      |
 
 ## Policy lifecycle
 
-Each policy has a status:
+Each policy has one of the following statuses:
 
 | Status       | Description                                                                           |
 | ------------ | ------------------------------------------------------------------------------------- |
@@ -90,12 +117,12 @@ Each policy has a status:
 
 ## Integration with other product areas
 
-Authorization Management is not isolated — it integrates with the API Gateway, AI Gateway, and Event Gateway as a shared enforcement layer:
+Authorization Management integrates with the API Gateway, AI Gateway, and Event Gateway as a shared enforcement layer across the following product areas:
 
-* **API Management** — API proxies reference Authorization Management policies for endpoint-level access control. The API overview checklist includes an "Apply authorization" step.
-* **Agent Management** — MCP Proxies and LLM Proxies enforce authorization policies at the tool and model level. Policy entities are populated from the Catalog.
-* **Event Stream Management** — Kafka services can be governed by authorization policies targeting virtual clusters, topics, and consumer groups.
+* **API Management.** API proxies reference Authorization Management policies for endpoint-level access control.
+* **Agent Management.** MCP Proxies and LLM Proxies enforce authorization policies at the tool and model level. Policy entities are populated from the Catalog.
+* **Event Stream Management.** Kafka services can be governed by authorization policies targeting event streams, topics, and schema fields.
 
 ## Next steps
 
-* [Create authorization policies](../build/create-authorization-policies.md) — Learn how to create, edit, and deploy policies for each service category.
+* [Create authorization policies](../build/create-authorization-policies.md). Learn how to create, edit, and deploy policies for each service category.

--- a/docs/gamma/4.12/authorization-management/get-started/authorization-management-overview.md
+++ b/docs/gamma/4.12/authorization-management/get-started/authorization-management-overview.md
@@ -16,7 +16,7 @@ Authorization Management connects the following three things:
 2. **Principals.** The identities making requests, such as users, groups, service accounts, and agent identities. Principals can be synced from Gravitee Access Management (AM), imported from a file, or created locally. During an AM sync, progress is shown through live toast notifications, and the principal list updates dynamically without a page refresh.
 3. **Policies.** Rules that grant or deny access. Each policy declares an effect of either `permit` or `forbid`, plus a principal, an action, a resource, and optional conditions.
 
-When a request arrives at the API Gateway, AI Gateway, or Event Gateway, the Policy Decision Point (PDP) evaluates all applicable policies. The PDP returns a permit or deny decision at microsecond latency with no network hop.
+When a request arrives at the API Gateway or AI Gateway, the Policy Decision Point (PDP) evaluates all applicable policies. The PDP returns a permit or deny decision at microsecond latency with no network hop.
 
 ## Policy language: GAPL
 
@@ -117,7 +117,7 @@ Each policy has one of the following statuses:
 
 ## Integration with other product areas
 
-Authorization Management integrates with the API Gateway, AI Gateway, and Event Gateway as a shared enforcement layer across the following product areas:
+Authorization Management integrates with the API Gateway and AI Gateway as a shared enforcement layer across the following product areas:
 
 * **API Management.** API proxies reference Authorization Management policies for endpoint-level access control.
 * **Agent Management.** MCP Proxies and LLM Proxies enforce authorization policies at the tool and model level. Policy entities are populated from the Catalog.

--- a/docs/gamma/4.12/authorization-management/get-started/authorization-management-overview.md
+++ b/docs/gamma/4.12/authorization-management/get-started/authorization-management-overview.md
@@ -6,7 +6,7 @@ noIndex: false
 
 # Authorization Management overview
 
-Authorization Management provides fine-grained, catalog-aware access control across all Gamma traffic types—APIs, MCP servers, AI models, agents, events, and custom resources. Policies are written in Gravitee Authorization Policy Language (GAPL), a subset of the Cedar policy language, and enforced at the wire level by Gamma's gateways.
+Authorization Management provides fine-grained, catalog-aware access control across all Gamma traffic types—APIs, MCP servers, AI models, agents, and custom resources. Policies are written in Gravitee Authorization Policy Language (GAPL), a subset of the Cedar policy language, and enforced at the wire level by Gamma's gateways.
 
 ## How it works
 
@@ -46,7 +46,7 @@ Authorization Management organizes policies into service-specific categories. Ea
 | **AI Model Policies** | Access to AI providers and specific models, with cost and token usage constraints.                                                   | LLMProvider, Model                         |
 | **API Policies**      | Access to API proxies, their endpoints, and data fields.                                                                             | API, Endpoint, DataField                   |
 | **A2A Policies**      | Which principals can invoke each A2A agent.                                                                                          | Agent                                      |
-| **Custom Policies**   | Policies for resources not routed as MCP, API, Agent, AI Model, or Event—internal applications, data assets, and bespoke resources. | Custom (user-defined)                      |
+| **Custom Policies**   | Policies for resources not routed as MCP, API, Agent, or AI Model—internal applications, data assets, and bespoke resources. | Custom (user-defined)                      |
 
 ## Condition snippets
 

--- a/docs/gamma/4.12/authorization-management/get-started/authorization-management-overview.md
+++ b/docs/gamma/4.12/authorization-management/get-started/authorization-management-overview.md
@@ -121,7 +121,6 @@ Authorization Management integrates with the API Gateway, AI Gateway, and Event 
 
 * **API Management.** API proxies reference Authorization Management policies for endpoint-level access control.
 * **Agent Management.** MCP Proxies and LLM Proxies enforce authorization policies at the tool and model level. Policy entities are populated from the Catalog.
-* **Agent Management.** MCP Proxies and LLM Proxies enforce authorization policies at the tool and model level. Policy entities are populated from the Catalog.
 
 ## Next steps
 

--- a/docs/gamma/4.12/authorization-management/get-started/authorization-management-overview.md
+++ b/docs/gamma/4.12/authorization-management/get-started/authorization-management-overview.md
@@ -121,7 +121,7 @@ Authorization Management integrates with the API Gateway, AI Gateway, and Event 
 
 * **API Management.** API proxies reference Authorization Management policies for endpoint-level access control.
 * **Agent Management.** MCP Proxies and LLM Proxies enforce authorization policies at the tool and model level. Policy entities are populated from the Catalog.
-* **Event Stream Management.** Kafka services can be governed by authorization policies targeting event streams, topics, and schema fields.
+* **Agent Management.** MCP Proxies and LLM Proxies enforce authorization policies at the tool and model level. Policy entities are populated from the Catalog.
 
 ## Next steps
 

--- a/docs/gamma/4.13/authorization-management/get-started/authorization-management-overview.md
+++ b/docs/gamma/4.13/authorization-management/get-started/authorization-management-overview.md
@@ -1,32 +1,31 @@
 ---
+description: Learn how Authorization Management enforces fine-grained, catalog-aware access control across Gamma traffic using GAPL policies.
 hidden: false
 noIndex: false
 ---
 
 # Authorization Management overview
 
-Authorization Management provides fine-grained, catalog-aware access control across all Gamma traffic types — APIs, MCP servers, AI models, agents, events, and custom resources. Policies are written in GAPL (Gravitee Authorization Policy Language), a subset of the Cedar policy language, and enforced at the wire level by Gamma's gateways.
-
-
+Authorization Management provides fine-grained, catalog-aware access control across all Gamma traffic types—APIs, MCP servers, AI models, agents, events, and custom resources. Policies are written in Gravitee Authorization Policy Language (GAPL), a subset of the Cedar policy language, and enforced at the wire level by Gamma's gateways.
 
 ## How it works
 
-Authorization Management connects three things:
+Authorization Management connects the following three things:
 
-1. **Entities** — The things you want to protect (APIs, MCP tools, AI models). Entities are registered in the Catalog or created directly in Authorization Management.
-2. **Principals** — The identities making requests (users, groups, agents). Principals can be synced from your identity provider via SCIM, synchronized from Access Management (AM), or created locally. When synchronizing users from AM, sync progress is surfaced via live toast notifications, and the principal list updates dynamically without requiring a page refresh.
-3. **Policies** — Rules that grant or deny access. Each policy declares an effect (`permit` or `forbid`), a principal, an action, a resource, and optional conditions.
+1. **Entities.** The things you want to protect, such as APIs, MCP tools, and AI models. Entities are registered in the Catalog or created directly in Authorization Management.
+2. **Principals.** The identities making requests, such as users, groups, service accounts, and agent identities. Principals can be synced from Gravitee Access Management (AM), imported from a file, or created locally. During an AM sync, progress is shown through live toast notifications, and the principal list updates dynamically without a page refresh.
+3. **Policies.** Rules that grant or deny access. Each policy declares an effect of either `permit` or `forbid`, plus a principal, an action, a resource, and optional conditions.
 
-When a request arrives at the API Gateway, AI Gateway, or Event Gateway, the Policy Decision Point (PDP) evaluates all applicable policies and returns a permit or deny decision at microsecond latency with no network hop.
+When a request arrives at the API Gateway, AI Gateway, or Event Gateway, the Policy Decision Point (PDP) evaluates all applicable policies. The PDP returns a permit or deny decision at microsecond latency with no network hop.
 
 ## Policy language: GAPL
 
-GAPL (Gravitee Authorization Policy Language) uses Cedar syntax. A policy looks like:
+GAPL uses Cedar syntax. A policy looks like:
 
 ```
 permit (
-  principal == user::"alice",
-  action == action::"invoke",
+  principal == User::"alice",
+  action == Action::"invoke",
   resource == MCPTool::"github-create-issue"
 );
 ```
@@ -39,20 +38,23 @@ GAPL supports a subset of the Cedar policy language optimized for the Gamma visu
 
 ## Policy categories
 
-Authorization Management organizes policies into service-specific categories. Each category has its own page with a policy list, KPI tiles, search, and status filter.
+Authorization Management organizes policies into service-specific categories. Each category has its own page with a policy list, KPI tiles, search, and status filter. The following table describes each policy category:
 
-| Category              | What it governs                                                                                                                  | Entity types                               |
-| --------------------- | -------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
-| **MCP Policies**      | Access to MCP servers, their tools, prompts, and resources.                                                                      | MCPServer, MCPTool, MCPPrompt, MCPResource |
-| **AI Model Policies** | Access to AI providers and specific models, with cost and token usage constraints.                                               | LLMProvider, LLMModel                      |
-| **API Policies**      | Access to API proxies, their endpoints, and data fields.                                                                         | API, Endpoint, DataField                   |
-| **Custom Policies**   | Policies for resources not routed as MCP, API, Agent, LLM, or Event — internal applications, data assets, and bespoke resources. | Custom (user-defined)                      |
+| Category              | What it governs                                                                                                                      | Entity types                               |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------ |
+| **MCP Policies**      | Access to MCP servers, their tools, prompts, and resources.                                                                          | MCPServer, MCPTool, MCPPrompt, MCPResource |
+| **AI Model Policies** | Access to AI providers and specific models, with cost and token usage constraints.                                                   | LLMProvider, Model                         |
+| **API Policies**      | Access to API proxies, their endpoints, and data fields.                                                                             | API, Endpoint, DataField                   |
+| **A2A Policies**      | Which principals can invoke each A2A agent.                                                                                          | Agent                                      |
+| **Custom Policies**   | Policies for resources not routed as MCP, API, Agent, AI Model, or Event—internal applications, data assets, and bespoke resources. | Custom (user-defined)                      |
 
 ## Condition snippets
 
-Each policy category provides pre-built condition snippets you can insert into your policies:
+Each policy category provides pre-built condition snippets you can insert into your policies.
 
 ### MCP conditions
+
+The following conditions are available for MCP policies:
 
 | Condition              | GAPL snippet                                       |
 | ---------------------- | -------------------------------------------------- |
@@ -61,6 +63,8 @@ Each policy category provides pre-built condition snippets you can insert into y
 | **Corporate IP range** | `context.source.ip.in_cidr("10.0.0.0/8")`          |
 
 ### AI Model conditions
+
+The following conditions are available for AI Model policies:
 
 | Condition            | GAPL snippet                                      |
 | -------------------- | ------------------------------------------------- |
@@ -71,16 +75,39 @@ Each policy category provides pre-built condition snippets you can insert into y
 
 ### API conditions
 
+The following conditions are available for API policies:
+
 | Condition              | GAPL snippet                                          |
 | ---------------------- | ----------------------------------------------------- |
 | **Corporate IP range** | `context.source.ip.in_cidr("10.0.0.0/8")`             |
 | **Scope present**      | `context.auth.scopes.contains("orders:read")`         |
-| **Rate limit**         | `context.rate.per_minute(principal) < 100`            |
+| **Rate < 100/min**     | `context.rate.per_minute(principal) < 100`            |
 | **Tenant match**       | `context.request.header.x_tenant == principal.tenant` |
+
+### A2A conditions
+
+The following conditions are available for A2A policies:
+
+| Condition              | GAPL snippet                                       |
+| ---------------------- | -------------------------------------------------- |
+| **Business hours**     | `context.time.hour >= 9 && context.time.hour < 17` |
+| **Trusted device**     | `context.device.trusted == true`                   |
+| **Corporate IP range** | `context.source.ip.in_cidr("10.0.0.0/8")`          |
+
+### Custom conditions
+
+The following conditions are available for custom policies:
+
+| Condition              | GAPL snippet                                       |
+| ---------------------- | -------------------------------------------------- |
+| **Corporate IP range** | `context.source.ip.in_cidr("10.0.0.0/8")`          |
+| **MFA required**       | `context.auth.mfa == true`                         |
+| **Business hours**     | `context.time.hour >= 9 && context.time.hour < 17` |
+| **Owner only**         | `resource.owner == principal`                      |
 
 ## Policy lifecycle
 
-Each policy has a status:
+Each policy has one of the following statuses:
 
 | Status       | Description                                                                           |
 | ------------ | ------------------------------------------------------------------------------------- |
@@ -90,12 +117,12 @@ Each policy has a status:
 
 ## Integration with other product areas
 
-Authorization Management is not isolated — it integrates with the API Gateway, AI Gateway, and Event Gateway as a shared enforcement layer:
+Authorization Management integrates with the API Gateway, AI Gateway, and Event Gateway as a shared enforcement layer across the following product areas:
 
-* **API Management** — API proxies reference Authorization Management policies for endpoint-level access control. The API overview checklist includes an "Apply authorization" step.
-* **Agent Management** — MCP Proxies and LLM Proxies enforce authorization policies at the tool and model level. Policy entities are populated from the Catalog.
-* **Event Stream Management** — Kafka services can be governed by authorization policies targeting virtual clusters, topics, and consumer groups.
+* **API Management.** API proxies reference Authorization Management policies for endpoint-level access control.
+* **Agent Management.** MCP Proxies and LLM Proxies enforce authorization policies at the tool and model level. Policy entities are populated from the Catalog.
+* **Event Stream Management.** Kafka services can be governed by authorization policies targeting event streams, topics, and schema fields.
 
 ## Next steps
 
-* [Create authorization policies](../build/create-authorization-policies.md) — Learn how to create, edit, and deploy policies for each service category.
+* [Create authorization policies](../build/create-authorization-policies.md). Learn how to create, edit, and deploy policies for each service category.

--- a/docs/gamma/4.13/authorization-management/get-started/authorization-management-overview.md
+++ b/docs/gamma/4.13/authorization-management/get-started/authorization-management-overview.md
@@ -16,7 +16,7 @@ Authorization Management connects the following three things:
 2. **Principals.** The identities making requests, such as users, groups, service accounts, and agent identities. Principals can be synced from Gravitee Access Management (AM), imported from a file, or created locally. During an AM sync, progress is shown through live toast notifications, and the principal list updates dynamically without a page refresh.
 3. **Policies.** Rules that grant or deny access. Each policy declares an effect of either `permit` or `forbid`, plus a principal, an action, a resource, and optional conditions.
 
-When a request arrives at the API Gateway, AI Gateway, or Event Gateway, the Policy Decision Point (PDP) evaluates all applicable policies. The PDP returns a permit or deny decision at microsecond latency with no network hop.
+When a request arrives at the API Gateway or AI Gateway, the Policy Decision Point (PDP) evaluates all applicable policies. The PDP returns a permit or deny decision at microsecond latency with no network hop.
 
 ## Policy language: GAPL
 
@@ -117,7 +117,7 @@ Each policy has one of the following statuses:
 
 ## Integration with other product areas
 
-Authorization Management integrates with the API Gateway, AI Gateway, and Event Gateway as a shared enforcement layer across the following product areas:
+Authorization Management integrates with the API Gateway and AI Gateway as a shared enforcement layer across the following product areas:
 
 * **API Management.** API proxies reference Authorization Management policies for endpoint-level access control.
 * **Agent Management.** MCP Proxies and LLM Proxies enforce authorization policies at the tool and model level. Policy entities are populated from the Catalog.

--- a/docs/gamma/4.13/authorization-management/get-started/authorization-management-overview.md
+++ b/docs/gamma/4.13/authorization-management/get-started/authorization-management-overview.md
@@ -6,7 +6,7 @@ noIndex: false
 
 # Authorization Management overview
 
-Authorization Management provides fine-grained, catalog-aware access control across all Gamma traffic types—APIs, MCP servers, AI models, agents, events, and custom resources. Policies are written in Gravitee Authorization Policy Language (GAPL), a subset of the Cedar policy language, and enforced at the wire level by Gamma's gateways.
+Authorization Management provides fine-grained, catalog-aware access control across all Gamma traffic types—APIs, MCP servers, AI models, agents, and custom resources. Policies are written in Gravitee Authorization Policy Language (GAPL), a subset of the Cedar policy language, and enforced at the wire level by Gamma's gateways.
 
 ## How it works
 
@@ -46,7 +46,7 @@ Authorization Management organizes policies into service-specific categories. Ea
 | **AI Model Policies** | Access to AI providers and specific models, with cost and token usage constraints.                                                   | LLMProvider, Model                         |
 | **API Policies**      | Access to API proxies, their endpoints, and data fields.                                                                             | API, Endpoint, DataField                   |
 | **A2A Policies**      | Which principals can invoke each A2A agent.                                                                                          | Agent                                      |
-| **Custom Policies**   | Policies for resources not routed as MCP, API, Agent, AI Model, or Event—internal applications, data assets, and bespoke resources. | Custom (user-defined)                      |
+| **Custom Policies**   | Policies for resources not routed as MCP, API, Agent, or AI Model—internal applications, data assets, and bespoke resources. | Custom (user-defined)                      |
 
 ## Condition snippets
 

--- a/docs/gamma/4.13/authorization-management/get-started/authorization-management-overview.md
+++ b/docs/gamma/4.13/authorization-management/get-started/authorization-management-overview.md
@@ -121,7 +121,6 @@ Authorization Management integrates with the API Gateway, AI Gateway, and Event 
 
 * **API Management.** API proxies reference Authorization Management policies for endpoint-level access control.
 * **Agent Management.** MCP Proxies and LLM Proxies enforce authorization policies at the tool and model level. Policy entities are populated from the Catalog.
-* **Event Stream Management.** Kafka services can be governed by authorization policies targeting event streams, topics, and schema fields.
 
 ## Next steps
 


### PR DESCRIPTION
## What this verifies

`docs/gamma/4.12/authorization-management/get-started/authorization-management-overview.md`, run through the Doc Verification Pipeline.

Evidence sources:
- **Code:** the *deployed* 4.12 bundles read out of the running container (`docker exec gamma_management_api …`), not the checked-out repos. `gravitee-gamma-module-authz` **1.2.0**, `gravitee-gamma-module-apim` **4.12.11**, `gravitee-gamma-module-aim` **1.2.0**. This matters — the authz repo's `main` is already on 1.3.0 and disagrees with 4.12.
- **Live:** Gamma console on `localhost:8086`, images `gamma-ui:4.12.11` / `apim-management-api:4.12.11`. Read-only throughout; nothing was created, modified, or deleted.

The page contains no `<figure>` elements, so there are no image rows in the verdict table.

## Step 4 verdict table

| # | Claim | Code truth (authz 1.2.0 / apim 4.12.11 deployed bundles) | Live truth (localhost:8086, Gamma 4.12.11) | Verdict |
|---|---|---|---|---|
| 1 | Policies written in GAPL, a subset of Cedar | Parser rejects `unless`: "'unless' clauses are not supported by the GAPL visual editor" | Not exercised (read-only) | Confirmed |
| 2 | Entities registered in the Catalog or created directly | Resources sheet "Import from AI Catalog"; `onAdd` adds locally | Entities page: "Resource entities are imported from the Context Catalog"; **Import** + **Add principal** | Confirmed |
| 3 | Principals are "users, groups, agents" | Principal entity types: `User`, `Group`, `ServiceAccount`, `AgentIdentity` | Entities page: "Principals (users, groups, service accounts, agent identities)" | **Contradicted** — omits service accounts |
| 4 | Principals can be synced from your IdP **via SCIM** | No `SCIM` string anywhere in the authz bundle | Principals **Import** dropdown has exactly two items: "Sync from Gravitee Access Management", "Import from file…" | **Contradicted** — no SCIM |
| 5 | Principals synchronized from Access Management (AM) | `Sync from Gravitee Access Management` menu item | Present in Import dropdown | Confirmed |
| 6 | AM sync surfaces live toast notifications | `toast.info("Syncing entities from Gravitee Access Management…")`, `toast.success("Sync finished, synced N entities")` | Not triggered (read-only, AM not connected) | Confirmed (code) |
| 7 | Principal list updates without a page refresh | `refetchInterval: 2500` on the PRINCIPAL entity query while a sync is pending | Not triggered (read-only) | Confirmed (code) |
| 8 | Policy declares effect (`permit`/`forbid`), principal, action, resource, optional conditions | Statement model `{effect, principals, actions, resources, condition}`; forbid-wins | Guide text: "built from permit and forbid statements" | Confirmed |
| 9 | PDP evaluates and returns permit/deny | `Policy Decision Point` referenced 4× | PDP Gateways page: "Each gateway runs a Policy Decision Point identified by its target PDP id" | Confirmed |
| 10 | Microsecond latency, no network hop | Not determinable from the UI bundle | Not observable | Not determined — left unchanged |
| 11 | GAPL example uses `user::"alice"`, `action::"invoke"` | The editor's own compiled output uses capitalised namespaces: `principal == User::"user-0000"`, `action == Action::"call_tool"`; registry types are `User` / `Action` | Not exercised (read-only) | **Contradicted** — namespace casing |
| 12 | `MCPTool::` is a valid resource namespace | `MCPTool` present in the entity-type registry | — | Confirmed |
| 13 | `unless` clauses are not available in the GAPL editor | Parser fails with "'unless' clauses are not supported by the GAPL visual editor" | Not exercised | Confirmed |
| 14 | Policy categories are **four**: MCP, AI Model, API, Custom | `AuthzPolicyType` = MCP, AGENT, MODEL, API, CUSTOM; nav routes = mcps, models, apis, **a2a**, custom-policies; config title "A2A Policies" | Sidebar → Policy Management: MCPs, AI Models, APIs, **A2A Agents**, Custom Policies. `/authz/a2a` renders "A2A Policies" | **Contradicted** — A2A Policies missing |
| 15 | MCP Policies entity types: MCPServer, MCPTool, MCPPrompt, MCPResource | `resourceGroups` keys exactly those four | Page title "MCP Policies" | Confirmed |
| 16 | AI Model Policies entity types: LLMProvider, **LLMModel** | `resourceGroups` keys are `LLMProvider` and `Model`; `LLMModel` occurs 0 times | Page title "AI Model Policies" | **Contradicted** — `LLMModel` → `Model` |
| 17 | API Policies entity types: API, Endpoint, DataField | `resourceGroups` keys exactly those three | Page title "API Policies" | Confirmed |
| 18 | Custom Policies govern what is not routed as MCP, API, Agent, **LLM**, or Event | Product wording: "not already routed as an MCP, API, Agent, **AI Model** or Event" | Same string rendered on `/authz/custom-policies` | **Contradicted** — term "LLM" |
| 19 | Each category page has a policy list, KPI tiles, search, status filter | Search input + status `Select` (All statuses / Draft / Deployed / Disabled) | `/authz/mcps`: KPI tiles Policies / Deployed / Draft / Unique targets, search box, "All statuses" filter, policy table | Confirmed |
| 20 | MCP conditions: Business hours, Trusted device, Corporate IP range (3 snippets, exact text) | `conditionSnippets` match verbatim | Not exercised (would need the create wizard) | Confirmed |
| 21 | AI Model conditions: Token budget, Cost ceiling, PII filter on, Model size small (exact text) | `conditionSnippets` match verbatim | Not exercised | Confirmed |
| 22 | API condition labelled **Rate limit** | Label is `Rate < 100/min` (snippet text is correct) | Not exercised | **Contradicted** — label |
| 23 | API conditions: Corporate IP range, Scope present, Tenant match (exact text) | Match verbatim | Not exercised | Confirmed |
| 24 | "Each policy category provides pre-built condition snippets" — 3 of 5 documented | A2A and Custom both ship `conditionSnippets` | A2A and Custom pages both exist | **Contradicted** — enumeration incomplete |
| 25 | Policy statuses: Draft, Deployed, Disabled | Enum `DRAFT`, `DEPLOYED`, `DISABLED` | Status filter offers exactly Draft / Deployed / Disabled | Confirmed |
| 26 | API Management: API proxies reference authz policies for endpoint-level access control | API Policies category description matches | `/authz/apis` renders that description | Confirmed |
| 27 | The API overview checklist includes an **"Apply authorization"** step | apim 4.12.11 checklist items are `endpoint-security`, `security-policies`, `alerts`, `team-access`; "Apply authorization" occurs 0 times | API overview shows **0/4**: Configure backend security on your endpoint group / Apply security policies / Set up alerts / Invite teammates and assign roles | **Contradicted** — no such step |
| 28 | Agent Management: MCP/LLM Proxies enforce authz at tool and model level; entities from Catalog | aim 1.2.0: "Turn on FGA to enforce per-tool authorization using Gravitee Authorization policies"; "Enable fine-grained authorization in one click to control access to each tool" | Not exercised (read-only) | Confirmed |
| 29 | ESM: Kafka services governed by policies targeting **virtual clusters**, topics, and **consumer groups** | authz event-family entity types are `EventStream`, `Topic`, `SchemaField`; `VirtualCluster` / `ConsumerGroup` occur 0 times | No Events policy page in the 4.12 nav | **Contradicted** — entity types |
| 30 | Frontmatter has a `description:` field | House convention 1 + `style-guide/06-.../frontmatter.md` marks it required | — | **Missing** — added |
| — | Images / `<figure>` elements | Page contains none | — | N/A — no image rows |

## Notes for the writer

- **`docs/gamma/4.13/…` was byte-identical to the 4.12 file before this change**, so the identical change is applied there in this same commit. `.github/workflows/version-sync.yml` covers only apim/am/gko, so gamma does not auto-sync and 4.13 would otherwise go stale.
- **Row 10 — "microsecond latency with no network hop"** is not determinable from the UI bundle and not observable in the console. Left exactly as written.
- **Row 24** was treated as a contradiction because the section's own introduction says *"Each policy category provides pre-built condition snippets"* and then covered three of five. The two added tables are transcribed verbatim from the deployed `conditionSnippets` config.
- **Out of scope, flagged not fixed:** the 4.12 authz nav has no Events policy category, yet the Custom Policies description (product copy, rendered live) says custom policies cover what is *"not already routed as an MCP, API, Agent, AI Model or Event"*. Event-family entity types (`EventStream`, `Topic`, `SchemaField`) exist in the entity registry with no matching policy page. That's a product question, not a doc fix.
- Vale reports **0 errors**. The 5 remaining `docs.Spelling` warnings are entity-type identifiers (`MCPServer`, `MCPTool`, `MCPPrompt`, `MCPResource`, `LLMProvider`) that are verified product terms missing from `vale/styles/config/vocabularies/docs/accept.txt` — pre-existing, and this change removes one of them (`LLMModel`).
