### PR TITLE
docs(gamma): verify shadow AI monitoring page for 4.12 and 4.13

### DIFF
--- a/docs/gamma/4.12/edge-management/observe/monitor-shadow-ai-traffic.md
+++ b/docs/gamma/4.12/edge-management/observe/monitor-shadow-ai-traffic.md
@@ -1,8 +1,9 @@
 ---
+description: Use the Gamma console to review AI service requests that occur outside governed channels.
 hidden: true
 noIndex: true
 ---
 
 # Monitor your shadow AI traffic
 
-Use the Gamma console to gain visibility into AI service requests that are occurring outside of governed channels. Shadow AI monitoring surfaces ungoverned usage so you can assess risk and decide which traffic to bring under policy control via the Edge Daemon.
+Use the Gamma console to gain visibility into AI service requests that occur outside governed channels. Shadow AI monitoring surfaces ungoverned usage so you can assess risk and decide which traffic to bring under policy control through the Edge Daemon.

--- a/docs/gamma/4.13/edge-management/observe/monitor-shadow-ai-traffic.md
+++ b/docs/gamma/4.13/edge-management/observe/monitor-shadow-ai-traffic.md
@@ -1,8 +1,9 @@
 ---
+description: Use the Gamma console to review AI service requests that occur outside governed channels.
 hidden: true
 noIndex: true
 ---
 
 # Monitor your shadow AI traffic
 
-Use the Gamma console to gain visibility into AI service requests that are occurring outside of governed channels. Shadow AI monitoring surfaces ungoverned usage so you can assess risk and decide which traffic to bring under policy control via the Edge Daemon.
+Use the Gamma console to gain visibility into AI service requests that occur outside governed channels. Shadow AI monitoring surfaces ungoverned usage so you can assess risk and decide which traffic to bring under policy control through the Edge Daemon.


### PR DESCRIPTION
Doc Verification Pipeline run on `docs/gamma/4.12/edge-management/observe/monitor-shadow-ai-traffic.md`.

Verified against the live 4.12 Gamma console (`gamma-ui:4.12.11`, local Docker) and against the 4.12 Edge Management module as deployed in that environment. Every factual statement on the page held up, so this PR carries **no factual corrections** — only style-guide conformance.

## Verdict table

| Claim | Code truth | Live truth | Verdict |
|---|---|---|---|
| The Gamma console gives visibility into AI service requests occurring outside governed channels | Confirmed. The 4.12 Edge Management module ships a dedicated shadow AI view, and detections are queried from analytics filtered to shadow AI traffic. | Confirmed. **Edge Management** is a top-level application card on the console home page; its sidebar contains **Shadow AI**, which renders a **Shadow AI** page described as reviewing direct AI provider traffic observed on managed devices that did not pass through the Gateway. | Accurate |
| "Shadow AI monitoring" is a real, named capability | Confirmed. The console's Edge configuration screen carries a **Shadow AI monitoring** section, described as detecting direct connections to AI providers that bypass the gateway, with configurable monitored domains and a report interval. | Confirmed. **Configuration** appears in the Edge Management sidebar in 4.12. | Accurate |
| The page surfaces ungoverned usage so you can assess risk | Confirmed. The view aggregates detections into **Total detections**, **Affected devices**, and **Top provider**, plus a table of **Device**, **Provider**, **Process**, and **Detections**. | Confirmed. All three summary tiles and the four-column table render live, with a **Refresh** control and a time-range selector offering **Last 24 hours**, **Last 7 days**, and **Last 30 days**. Empty state reads "No shadow AI detections found for this time range." | Accurate |
| Traffic can be brought under policy control through the Edge Daemon | Confirmed. The Edge Daemon reports shadow AI detections to the Edge reactor, and the console's Edge configuration screen defines the interception domains and routes that place that traffic under policy. | Confirmed. The Edge Management sidebar exposes **Configuration**, **Proxied Traffic**, and **Devices** alongside **Shadow AI**. | Accurate |
| Images on the page | n/a | n/a | The page carries no `<figure>`. Nothing stale, nothing to replace. |

## What changed

Style-guide conformance only — no meaning-level edits:

- Added the required `description` frontmatter field (`style-guide/06-document-types-and-templates/frontmatter.md`).
- Replaced "via" with "through" — the grammarian rules disallow "via".
- Tightened "requests that are occurring outside of governed channels" to "requests that occur outside governed channels".

## Both versions patched

`docs/gamma/4.12/...` and `docs/gamma/4.13/...` were byte-identical before this change, so the same patch is applied to both in this PR and they remain identical.

## Notes for the writer — not fixed here

- **The page is a two-sentence stub.** It has no procedure, no navigation path, and no screenshot, even though the shadow AI view is a real screen a reader has to find. The `Observe` section's sibling page, `monitor-proxied-traffic.md`, is a stub in exactly the same shape. Fleshing these out into real tasks is a content decision, outside this pipeline's scope.
- **A cross-page navigation inconsistency exists in 4.12 and 4.13.** `agent-management/observe/monitor-ai-gateway-from-devices.md` tells the reader to reach Edge Management through **Agent Management**, then **Observe**. In the live 4.12 console, Edge Management is its own top-level application, reached from the console home page, and it has no **Observe** sub-item. `edge-management/get-started/edge-management-overview.md` describes it correctly. That page was not in scope for this run and was left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
