### PR TITLE
docs(gamma): close two gaps from the APIM subscription port in 4.12

### DIFF
--- a/docs/gamma/4.12/api-management/build/configure-your-api-proxy/establish-consumer-access.md
+++ b/docs/gamma/4.12/api-management/build/configure-your-api-proxy/establish-consumer-access.md
@@ -223,6 +223,32 @@ The same key table is available from the application, under **Applications** in 
 
 When custom API key reuse is enabled for the environment, a key value that belongs to a revoked or expired key can be assigned to a new subscription instead of being rejected as a duplicate. This lets a consumer keep a key value it has already distributed when its subscription is replaced.
 
+#### Enable reuse
+
+Reuse depends on two environment settings. Both are disabled by default, so reuse does nothing until you turn them on:
+
+| Setting                                         | Purpose                                                                                                                       |
+| ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `plan.security.apikey.allowCustom.enabled`      | Permits a key value to be supplied at all. While this is disabled, any approval that carries a **Custom API key** is rejected. |
+| `plan.security.apikey.allowCustomReuse.enabled` | Permits an inactive key value to be reactivated rather than rejected as a duplicate.                                          |
+
+The Gamma 4.12 console does not expose either setting. Read and write them through the Management API at environment scope:
+
+```bash
+curl -s -u "admin:admin" \
+  "http://localhost:8083/management/organizations/DEFAULT/environments/DEFAULT/settings"
+```
+
+To change them, send the full settings object back to the same path with `POST`, setting `plan.security.customApiKey.enabled` and `plan.security.customApiKeyReuse.enabled` to `true`. The endpoint accepts `POST` rather than `PUT`.
+
+{% hint style="info" %}
+The stored parameter keys and the settings payload use different names for the same two flags. The parameters are `allowCustom` and `allowCustomReuse`. The matching payload fields are `customApiKey` and `customApiKeyReuse`.
+{% endhint %}
+
+The **Custom API key** field appears in the **Approve Subscription** dialog for every API Key plan, whether or not these settings are enabled. When they are disabled, the field accepts input and the approval then fails.
+
+#### Reuse eligibility
+
 | Key state | Can be reused |
 | --------- | ------------- |
 | Revoked   | Yes           |

--- a/docs/gamma/4.12/api-management/build/configure-your-api-proxy/establish-consumer-access.md
+++ b/docs/gamma/4.12/api-management/build/configure-your-api-proxy/establish-consumer-access.md
@@ -257,14 +257,53 @@ Reuse depends on two environment settings. Both are disabled by default, so reus
 | `plan.security.apikey.allowCustom.enabled`      | Permits a key value to be supplied at all. While this is disabled, any approval that carries a **Custom API key** is rejected. |
 | `plan.security.apikey.allowCustomReuse.enabled` | Permits an inactive key value to be reactivated rather than rejected as a duplicate.                                          |
 
-The Gamma 4.12 console does not expose either setting. Read and write them through the Management API at environment scope:
+The Gamma 4.12 console does not expose either setting. Read and write them through the Management API at environment scope. The endpoint accepts `POST` rather than `PUT`.
+
+{% hint style="warning" %}
+`POST` replaces the entire settings object. Any setting missing from your request body is deleted from the environment and reverts to its built-in default, so posting only the two flags resets every other environment setting. Always start from the current settings, change only the two fields, and post the whole object back.
+{% endhint %}
+
+**1. Retrieve the current settings.** Save the response to a file rather than editing it by hand from the terminal:
 
 ```bash
 curl -s -u "admin:admin" \
+  "http://localhost:8083/management/organizations/DEFAULT/environments/DEFAULT/settings" \
+  -o settings.json
+```
+
+**2. Change the two fields.** Both live under `plan.security`, each as an object with an `enabled` boolean:
+
+```json
+{
+  "plan": {
+    "security": {
+      "customApiKey": { "enabled": true },
+      "customApiKeyReuse": { "enabled": true }
+    }
+  }
+}
+```
+
+The block above is an excerpt. `settings.json` holds the full settings object—`plan.security` also carries the `keyless`, `apikey`, `sharedApiKey`, `oauth2`, `jwt`, and `mtls` entries, alongside many other top-level blocks. Keep all of them.
+
+Editing in place with `jq` avoids dropping anything:
+
+```bash
+jq '.plan.security.customApiKey.enabled = true |
+    .plan.security.customApiKeyReuse.enabled = true' \
+  settings.json > settings-updated.json
+```
+
+**3. Post the complete object back** to the same path:
+
+```bash
+curl -s -u "admin:admin" -X POST \
+  -H "Content-Type: application/json" \
+  --data @settings-updated.json \
   "http://localhost:8083/management/organizations/DEFAULT/environments/DEFAULT/settings"
 ```
 
-To change them, send the full settings object back to the same path with `POST`, setting `plan.security.customApiKey.enabled` and `plan.security.customApiKeyReuse.enabled` to `true`. The endpoint accepts `POST` rather than `PUT`.
+A successful call returns `200` with the saved settings. Re-run the `GET` to confirm both flags are `true`.
 
 {% hint style="info" %}
 The stored parameter keys and the settings payload use different names for the same two flags. The parameters are `allowCustom` and `allowCustomReuse`. The matching payload fields are `customApiKey` and `customApiKeyReuse`.

--- a/docs/gamma/4.12/api-management/build/configure-your-api-proxy/establish-consumer-access.md
+++ b/docs/gamma/4.12/api-management/build/configure-your-api-proxy/establish-consumer-access.md
@@ -146,6 +146,31 @@ When a plan uses manual validation, every subscription request lands in **Pendin
 4. Select **Approve**. The status changes to **Accepted**, the processed and starting timestamps are stamped, and for API Key plans the key is issued.
 5. To deny the request instead, select **Reject**, enter a **Reason**, and select **Reject**. The reason is mandatory—the confirmation button stays disabled until you enter one.
 
+### Be notified of subscription events
+
+The **Consumers** page does not announce a new request, so if you rely on manual validation, configure notifications to learn when one arrives. Notifications are configured per API proxy:
+
+1. Open the API proxy.
+2. In the API detail sidebar, under **General**, open **Notifications**.
+3. Add a notification, choose a channel, and then select the events to send.
+
+Three channels are available: **Console**, **Email**, and **Webhook**.
+
+The subscription events correspond to the statuses and actions described above:
+
+| Event                        | Corresponds to                                                       |
+| ---------------------------- | ---------------------------------------------------------------------- |
+| **New Subscription**         | A consumer requests a subscription. Enable this one for manual validation. |
+| **Subscription Accepted**    | The **Approve** action.                                              |
+| **Subscription Rejected**    | The **Reject** action.                                               |
+| **Subscription Paused**      | The **Pause** action.                                                |
+| **Subscription Resumed**     | The **Resume** action.                                               |
+| **Subscription Closed**      | The **Close subscription** action.                                   |
+| **Subscription Transferred** | The **Transfer** action.                                             |
+| **Subscription Failed**      | The consumer status changing to **Failure**.                         |
+
+Three further events cover API key changes: **API-Key Renewed**, **API-Key Revoked**, and **API-Key Expired**.
+
 ### Transfer a subscription to another plan
 
 A transfer moves an accepted subscription onto a different plan without closing it or re-issuing credentials. This is useful when a consumer moves from a trial tier to a paid tier that enforces different rate limits or quotas.


### PR DESCRIPTION
Follow-up to #2082, which ported four APIM subscription pages into Gamma. This PR closes two topics that did not survive that port, both found by running the Doc Verification Pipeline against a running Gamma `4.12.11` environment and `origin/4.12.x`.

## 1. How to enable custom API key reuse

The **Reuse a custom API key** section said reuse applies "when custom API key reuse is enabled for the environment" without naming the setting or saying how to change it, so a reader could not act on it.

| Claim | Code truth (`origin/4.12.x`) | Live truth (4.12.11) | Verdict |
|---|---|---|---|
| "reuse is enabled for the environment" | `plan.security.apikey.allowCustomReuse.enabled`, read at environment scope in `GenerateApiKeyDomainService` | `false` | Unactionable — **fixed** |
| Reuse is on by default | Default `Boolean.FALSE` in `Key.java` | `false` | Undocumented — **added** |
| Enabled from the console | No `security-plan-types` feature on `4.12.x`. Platform module ships `access-management`, `applications`, `dictionaries`, `metadata`, `shared` | Route renders an empty page. Sidebar offers only Applications, Metadata, Access Management | **No UI in 4.12** — documented as API-only |
| Custom keys need `allowCustom` | Enforced independently by `ApiSubscriptionsResource` and the API-product equivalents. Defaults to `false` | `false` | Second prerequisite — **added** |
| `allowCustom` gates reuse in the backend | `canReuse` checks only inactivity and the reuse flag | — | Console cascade only, not backend logic. Not documented as a dependency |
| Revoked/Expired reusable, Paused/Active not | `isInactive` is `revoked \|\| expired` | — | **Confirmed** — existing table already correct, unchanged |
| Write path | `savePortalSettings` posts to the v1 `/settings` path | `POST` returned 200 and both flags flipped. `PUT` returned 405, `Allow: HEAD,POST,GET,OPTIONS` | **Confirmed** — documented as POST |
| `POST` is a full-object replace | `ConfigServiceImpl.saveConfigByReference` writes every `@ParameterKey` field on the deserialized entity. `PlanSecurity` fields have no initializers, so anything absent from the body arrives `null`, and `ParameterServiceImpl.save` **deletes** the parameter when the value is `null` | — | Destructive if partial — **documented after review** |

The live environment was restored to its original values after the write was confirmed.

### Addressed from review

@aqibmohammadkhan pointed out that the new section introduces a `POST` while dropping the caveat APIM's [console settings page](https://github.com/gravitee-io/gravitee-platform-docs/blob/main/docs/apim/4.12/configure-and-manage-the-platform/manage-organizations-and-environments/apim-console.md) carries — "You must provide the complete JSON body shown below to update the configuration. Otherwise, default values are stored" — so a reader who posts just the two flags resets the environment.

Confirmed against `origin/4.12.x`, where the mechanism is stricter than "defaults are stored": an omitted parameter is deleted from the environment rather than overwritten, and then falls back to its built-in default. The trace is the new table row above.

`establish-consumer-access.md` now carries:

* A `warning` hint stating that `POST` replaces the whole object and that absent settings are deleted and revert to default.
* A numbered `GET`-to-file → edit → `POST`-the-whole-file sequence, with the `200` response and a re-`GET` confirmation step.
* The nested `plan.security` shape spelled out as JSON, explicitly labelled an excerpt, naming the siblings (`keyless`, `apikey`, `sharedApiKey`, `oauth2`, `jwt`, `mtls`) that must be kept.
* A `jq` one-liner as the safe edit path, so nothing is dropped by hand.

The caveat is written inline rather than linked: Gamma pages cross-reference APIM only through absolute `documentation.gravitee.io` URLs, and the published URL for that page was not verified.

The nested shape was checked against `portalSettings.ts` on both `4.12.x` and `master`, so it holds for the 4.13 pass too. `docs/gamma/4.13` has no **Enable reuse** section, so there is nothing to mirror and this PR stays 4.12-only.

## 2. Subscription notifications

APIM's `manage-subscriptions.md` points publishers at Notifications so they learn a request is waiting. The Gamma docs did not mention notifications anywhere, leaving the manual-validation flow with no answer to how an owner finds out a request has arrived.

Verified live: `GET` on the environment's `apis/hooks` path returns a **SUBSCRIPTION** category of eight hooks (`SUBSCRIPTION_NEW`, `ACCEPTED`, `CLOSED`, `PAUSED`, `RESUMED`, `REJECTED`, `TRANSFERRED`, `FAILED`) and an **API KEY** category of three (`APIKEY_EXPIRED`, `APIKEY_RENEWED`, `APIKEY_REVOKED`). The channel enum is `CONSOLE`, `EMAIL`, `WEBHOOK`. Notifications sit under **General** in the API proxy detail sidebar, per `API_PROXY_NAV_GROUPS`.

Each event is mapped to the status or action already documented on the page rather than to a delivery-timing claim, which was not verified. Scoped to API proxies, which is what the nav group confirms — API products were not verified and are not mentioned.

## Audit of the rest

The full claim-by-claim pass over the four APIM pages found everything else either already ported or genuinely inapplicable:

| APIM content | Outcome |
|---|---|
| `client_id` required for OAuth2/JWT plans | Already ported. Matches `SubscriptionServiceImpl`, which throws `"A client_id is required to subscribe to an OAuth2 or JWT plan."` |
| Client certificate required for mTLS plans | Already ported |
| Keyless plans need no subscription | Already ported |
| Subscription reference model, `referenceType` / `referenceId` | Already ported, in `api-product-configuration-reference.md` |
| Gateway resolves product subscriptions | Already ported, in `manage-product-apis.md` |
| Renew, revoke, expire, and the two-hour renew window | Already ported |
| Transfer procedure and constraints | Already ported, in more detail than the APIM original |
| Reuse eligibility, validation and audit behavior | Already ported |
| Subscription list columns — created, processed, started, ended | **Not portable.** Gamma's Consumers table exposes `createdAt`, not APIM's four timestamps. Porting the APIM column list would have been wrong |
| Federation and provider-managed access info | **N/A.** Gamma has no federation |
| Push plans | **N/A.** `PlanSecurityType` has no `PUSH` member and the plan wizard never offers it |

## Left open

- **Developer Portal subscription management** — the portal view, the Subscription Update (`U`) permission, the portal key table, revoke and renew from the portal. Gamma ships a `gamma_portal` container but the docs have no Developer Portal section at all. Whether Gamma documents its portal is a docs-scope decision, not a PR-level one.
- **API searchability when subscribing** — APIM says an API must be public, or the consumer a member, to be found. Both Gamma subscription paths are operator-side rather than consumer-side, so the caveat may not transfer as written. Not verified either way, so not written.
- **4.13** — the Security Plan Types page exists on `master`, so the toggles are expected in 4.13 and the API-only instructions here would be wrong there. No `4.13.x` branch and no 4.13 environment exists to verify against, so 4.13 is untouched and needs its own pass.

## For the writer

Out of scope here, flagged rather than edited:

- The Security Plan Types page on `master` carries a **Push plans** toggle backed by `plan.security.push.enabled`, but Gamma's `PlanSecurityType` has no `PUSH` member. It appears inherited from APIM's shared portal settings model.
- `SubscriptionServiceImpl` in 4.12.x throws twelve distinct subscribe-blocking exceptions, including plan-already-subscribed, another mTLS plan already subscribed by the same application, shared-API-key incompatibility, restricted plans via excluded groups, and general-conditions acceptance. The page documents only some. This is new content rather than a port, since APIM does not document them either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
