### PR TITLE
docs(gamma): correct register-your-kafka-clusters against a live 4.12 console

### DIFF
--- a/docs/gamma/4.12/event-stream-management/import/register-your-kafka-clusters.md
+++ b/docs/gamma/4.12/event-stream-management/import/register-your-kafka-clusters.md
@@ -1,26 +1,25 @@
 ---
+description: How to register an existing Kafka cluster with Gamma so it can be deployed and used by Kafka Services and Virtual Clusters.
 hidden: false
 noIndex: false
 ---
+
 # Register your Kafka clusters
 
-
-Registering a Kafka cluster with Gamma makes it available to Event Stream Management. Once registered, the cluster can be governed through the Event Gateway, used as the foundation for Kafka services and virtual clusters, and monitored from the Gamma console.
+When you register a Kafka cluster with Gamma, it becomes available to Event Stream Management. Once registered and deployed, the cluster can be governed through the Event Gateway, used as the foundation for Kafka Services and Virtual Clusters, and monitored from the Gamma console.
 
 ## Why register a cluster
 
-Gamma does not host Kafka clusters — it governs them. Registration connects Gamma to your existing Kafka infrastructure so that:
+Gamma does not host Kafka clusters—it governs them. Registration connects Gamma to your existing Kafka infrastructure to enable the following:
 
 * **Kafka Services** can be created on top of the cluster, adding security plans, policies, and access controls
 * **Virtual Clusters** can be provisioned for multi-tenant isolation
-* **Explorer** can connect to browse topics, inspect messages, and manage operations
-* **Kafka APIs** from the cluster can be exposed as **Kafka API Tools** in the Catalog, bridging event streams to the AI agent layer
 
 ## Prerequisites
 
 * Access to a running Gamma console instance
 * A Kafka cluster accessible from the Gamma platform
-* Kafka cluster connection details: bootstrap server addresses, authentication credentials (if applicable), and TLS certificates (if applicable)
+* Kafka cluster connection details, including bootstrap server addresses and, where applicable, authentication credentials and TLS certificates
 
 ## Register a cluster
 
@@ -28,34 +27,34 @@ Gamma does not host Kafka clusters — it governs them. Registration connects Ga
 2. Navigate to **Clusters**.
 3. Select **Create cluster**.
 4. In the **Identity** step, provide a recognizable name and optional description for the cluster.
-5. In the **Configuration** step, enter the cluster connection details. The exact fields available are driven by the connection schema, but generally include:
+5. In the **Configuration** step, select **Add** to add an entry to the **Kafka Cluster Connections** list. Add one entry for each connection you want the cluster to expose, and complete the following fields for each entry:
 
-| Field                 | Description                                                        |
-| --------------------- | ------------------------------------------------------------------ |
-| **Bootstrap servers** | One or more Kafka broker addresses in `host:port` format.          |
-| **Authentication**    | The authentication method for connecting to the cluster.           |
-| **TLS**               | TLS/SSL configuration for encrypted connections.                   |
+| Field                 | Description                                                                                                                |
+| --------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| **Connection name**   | Required. A name that identifies this connection.                                                                            |
+| **Cross ID**          | Optional. A portable identifier for cross-environment references. Gamma generates one from the connection name if you leave this empty. |
+| **Bootstrap servers** | Required. The Kafka bootstrap server address, in `host:port` format.                                                         |
+| **Security protocol** | Required. One of `PLAINTEXT`, `SASL_PLAINTEXT`, `SASL_SSL`, or `SSL`. Defaults to `PLAINTEXT`.                                |
 
 6. Proceed to the **Review** step to confirm the configuration.
 7. Select **Create cluster**.
+8. On the cluster overview, select **Deploy**.
 
-The Registered Cluster appears in the cluster list and becomes available for Kafka Service creation and Virtual Cluster composition.
+A new cluster is created with a lifecycle state of **Undeployed** and appears in the cluster list. When you deploy it, its lifecycle state changes to **Deployed**, and it becomes available for Kafka Service creation and Virtual Cluster composition.
 
 ## Manage registered clusters
 
-After registration, you can view and update cluster details from the Clusters page. Select a registered cluster to open its overview and navigate its detail views to:
+After registration, you can view and update cluster details from the Clusters page. Select a registered cluster to open its overview and navigate its detail views to perform the following tasks:
 
-* View connection status and health
-* Update connection credentials or bootstrap servers
+* View the cluster's lifecycle state, type, and connection count
+* Update connection details, including bootstrap servers and security settings, from the **Configuration** view
 * Undeploy the cluster to suspend its connection
 * Delete the cluster registration
 
 {% hint style="warning" %}
-Removing a cluster registration does not affect the cluster itself — it only removes Gamma's connection to it. Any Kafka Services or Virtual Clusters built on top of the cluster will lose their underlying connection.
+Removing a cluster registration does not affect the cluster itself—it only removes Gamma's connection to it. Any Kafka Services or Virtual Clusters built on top of the cluster will lose their underlying connection.
 {% endhint %}
-
 
 ## Next steps
 
-* **Create a Kafka Service** — Build a governed Kafka Service on top of your Registered Cluster. See [Create a Kafka service with a registered cluster](../build/create-a-kafka-service-with-a-registered-cluster.md).
-* **Browse topics in Explorer** — Connect to the cluster and inspect its topics and messages.
+* **Create a Kafka Service**. Build a governed Kafka Service on top of your registered cluster. See [Create a Kafka service with a registered cluster](../build/create-a-kafka-service-with-a-registered-cluster.md).

--- a/docs/gamma/4.13/event-stream-management/import/register-your-kafka-clusters.md
+++ b/docs/gamma/4.13/event-stream-management/import/register-your-kafka-clusters.md
@@ -1,26 +1,25 @@
 ---
+description: How to register an existing Kafka cluster with Gamma so it can be deployed and used by Kafka Services and Virtual Clusters.
 hidden: false
 noIndex: false
 ---
+
 # Register your Kafka clusters
 
-
-Registering a Kafka cluster with Gamma makes it available to Event Stream Management. Once registered, the cluster can be governed through the Event Gateway, used as the foundation for Kafka services and virtual clusters, and monitored from the Gamma console.
+When you register a Kafka cluster with Gamma, it becomes available to Event Stream Management. Once registered and deployed, the cluster can be governed through the Event Gateway, used as the foundation for Kafka Services and Virtual Clusters, and monitored from the Gamma console.
 
 ## Why register a cluster
 
-Gamma does not host Kafka clusters — it governs them. Registration connects Gamma to your existing Kafka infrastructure so that:
+Gamma does not host Kafka clusters—it governs them. Registration connects Gamma to your existing Kafka infrastructure to enable the following:
 
 * **Kafka Services** can be created on top of the cluster, adding security plans, policies, and access controls
 * **Virtual Clusters** can be provisioned for multi-tenant isolation
-* **Explorer** can connect to browse topics, inspect messages, and manage operations
-* **Kafka APIs** from the cluster can be exposed as **Kafka API Tools** in the Catalog, bridging event streams to the AI agent layer
 
 ## Prerequisites
 
 * Access to a running Gamma console instance
 * A Kafka cluster accessible from the Gamma platform
-* Kafka cluster connection details: bootstrap server addresses, authentication credentials (if applicable), and TLS certificates (if applicable)
+* Kafka cluster connection details, including bootstrap server addresses and, where applicable, authentication credentials and TLS certificates
 
 ## Register a cluster
 
@@ -28,34 +27,34 @@ Gamma does not host Kafka clusters — it governs them. Registration connects Ga
 2. Navigate to **Clusters**.
 3. Select **Create cluster**.
 4. In the **Identity** step, provide a recognizable name and optional description for the cluster.
-5. In the **Configuration** step, enter the cluster connection details. The exact fields available are driven by the connection schema, but generally include:
+5. In the **Configuration** step, select **Add** to add an entry to the **Kafka Cluster Connections** list. Add one entry for each connection you want the cluster to expose, and complete the following fields for each entry:
 
-| Field                 | Description                                                        |
-| --------------------- | ------------------------------------------------------------------ |
-| **Bootstrap servers** | One or more Kafka broker addresses in `host:port` format.          |
-| **Authentication**    | The authentication method for connecting to the cluster.           |
-| **TLS**               | TLS/SSL configuration for encrypted connections.                   |
+| Field                 | Description                                                                                                                |
+| --------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| **Connection name**   | Required. A name that identifies this connection.                                                                            |
+| **Cross ID**          | Optional. A portable identifier for cross-environment references. Gamma generates one from the connection name if you leave this empty. |
+| **Bootstrap servers** | Required. The Kafka bootstrap server address, in `host:port` format.                                                         |
+| **Security protocol** | Required. One of `PLAINTEXT`, `SASL_PLAINTEXT`, `SASL_SSL`, or `SSL`. Defaults to `PLAINTEXT`.                                |
 
 6. Proceed to the **Review** step to confirm the configuration.
 7. Select **Create cluster**.
+8. On the cluster overview, select **Deploy**.
 
-The Registered Cluster appears in the cluster list and becomes available for Kafka Service creation and Virtual Cluster composition.
+A new cluster is created with a lifecycle state of **Undeployed** and appears in the cluster list. When you deploy it, its lifecycle state changes to **Deployed**, and it becomes available for Kafka Service creation and Virtual Cluster composition.
 
 ## Manage registered clusters
 
-After registration, you can view and update cluster details from the Clusters page. Select a registered cluster to open its overview and navigate its detail views to:
+After registration, you can view and update cluster details from the Clusters page. Select a registered cluster to open its overview and navigate its detail views to perform the following tasks:
 
-* View connection status and health
-* Update connection credentials or bootstrap servers
+* View the cluster's lifecycle state, type, and connection count
+* Update connection details, including bootstrap servers and security settings, from the **Configuration** view
 * Undeploy the cluster to suspend its connection
 * Delete the cluster registration
 
 {% hint style="warning" %}
-Removing a cluster registration does not affect the cluster itself — it only removes Gamma's connection to it. Any Kafka Services or Virtual Clusters built on top of the cluster will lose their underlying connection.
+Removing a cluster registration does not affect the cluster itself—it only removes Gamma's connection to it. Any Kafka Services or Virtual Clusters built on top of the cluster will lose their underlying connection.
 {% endhint %}
-
 
 ## Next steps
 
-* **Create a Kafka Service** — Build a governed Kafka Service on top of your Registered Cluster. See [Create a Kafka service with a registered cluster](../build/create-a-kafka-service-with-a-registered-cluster.md).
-* **Browse topics in Explorer** — Connect to the cluster and inspect its topics and messages.
+* **Create a Kafka Service**. Build a governed Kafka Service on top of your registered cluster. See [Create a Kafka service with a registered cluster](../build/create-a-kafka-service-with-a-registered-cluster.md).


### PR DESCRIPTION
Verifies `event-stream-management/import/register-your-kafka-clusters.md` against a live 4.12 Gamma console, following the page's own procedure end to end and actually registering a cluster.

4.12 and 4.13 were byte-identical before this change, so both are patched here.

## Verdict table

| # | Claim | Code truth | Live truth | Verdict |
|---|---|---|---|---|
| 1 | Sidebar item **Event Stream Management** | Confirmed | Confirmed | OK |
| 2 | Sub-item **Clusters** | Confirmed | Confirmed. ESM has four areas: Dashboard, Clusters, Kafka Services, Virtual Clusters | OK |
| 3 | Button **Create cluster** | Confirmed | Confirmed | OK |
| 4 | Step 1 **Identity**, name plus optional description | Confirmed | Confirmed. Name required, description optional | OK |
| 5 | Step 2 **Configuration** has Bootstrap servers / Authentication / TLS | Contradicted | Contradicted. The step is a repeatable **Kafka Cluster Connections** list; you select **Add** per connection. Fields per entry: **Connection name** (required), **Cross ID** (optional), **Bootstrap servers** (required), **Security protocol** (required, default `PLAINTEXT`, options `PLAINTEXT` / `SASL_PLAINTEXT` / `SASL_SSL` / `SSL`). No field is labelled "Authentication" or "TLS" | **Fix** |
| 6 | Step 3 **Review** | Confirmed | Confirmed. Step label **Review**, heading **Review & create** | OK |
| 7 | Final button reads **Create cluster** | Confirmed | Confirmed | OK |
| 8 | **Explorer** browses topics and inspects messages | Not present in 4.12 | Contradicted. No Explorer area anywhere in the 4.12 ESM console | **Fix** |
| 9 | Kafka APIs exposed as **Kafka API Tools** in the Catalog | No counterpart in 4.12 | Not observed anywhere in the console | **Fix** |
| 10 | Cluster "becomes available for Kafka Service creation and Virtual Cluster composition" on creation | Contradicted | Contradicted. A new cluster is created **Undeployed**. Binding a Kafka Service to it prompts "Deploy a Kafka cluster first", and Virtual Cluster composition offers only already-deployed clusters | **Fix** |
| 11 | Manage: "View connection status and health" | Partly contradicted | Partly contradicted. The overview reports type, lifecycle state, connection count, version, and deployment time. The list's **Status** column is the deployment lifecycle state. There is no connection-health view | **Fix** |
| 12 | Manage: update connection credentials or bootstrap servers | Confirmed | Confirmed on the **Configuration** view, with **Save changes** / **Discard** | OK |
| 13 | Manage: **Undeploy** to suspend the connection | Confirmed | Confirmed. The action reads **Deploy** while undeployed and **Undeploy** once deployed | OK |
| 14 | Manage: delete the registration | Confirmed | Confirmed. **Delete cluster** | OK |
| 15 | Next steps: "Browse topics in Explorer" | Not present in 4.12 | Contradicted, same as claim 8 | **Fix** |
| — | Images | n/a | The page carries no `<figure>` elements | n/a |

## What changed

- **Configuration step rewritten** to the connections-list shape and the real field names, with the security-protocol options and default.
- **Deploy step added**, and the closing sentence corrected: a cluster is created **Undeployed** and only becomes usable by Kafka Services and Virtual Clusters once deployed.
- **Explorer bullets removed** from "Why register a cluster" and "Next steps".
- **"Kafka API Tools in the Catalog" bullet removed.**
- **Management bullets corrected** to what the detail views actually offer.
- Added the required `description:` frontmatter, and ran the style pass over the whole page: em-dash spacing, gerund openings, parenthetical asides, list and table introductions, and the term/explanation separator in the "Next steps" bullet.

## Notes for the writer, not edits

- **"Next steps" is now a single bullet.** A pointer to the Virtual Cluster pages would balance it, but adding one is a content decision rather than a verified correction, so it is left alone.
- **The page has no screenshots.** The reader arrives somewhere new at step 1 and works through a multi-step wizard, so one screenshot would be justified under the image triggers. The pipeline does not add images that a page does not already have, so this is flagged rather than fixed.
- **Bootstrap servers accepts a single address per connection** in the field's own guidance, and multiple brokers are expressed as multiple connection entries. Whether the field also accepts a comma-separated list was not tested.

## Verification method

Registered a real cluster in a live 4.12 console and walked the full wizard, then deployed it and exercised the management views. Cross-checked the UI-visible strings and the cluster-binding behavior against the 4.12 console build.

The environment for this run has no Kafka broker, so the connection was declared but never dialled. Nothing on the page about broker reachability or connection health is asserted from this run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
