### PR TITLE
docs(gamma): verify Create a Kafka service with a registered cluster (4.12)

### DIFF
--- a/docs/gamma/4.12/event-stream-management/build/create-a-kafka-service-with-a-registered-cluster.md
+++ b/docs/gamma/4.12/event-stream-management/build/create-a-kafka-service-with-a-registered-cluster.md
@@ -1,8 +1,10 @@
+---
+description: Create a Kafka Service in Event Stream Management and bind it to a connection on a registered Kafka cluster.
+---
+
 # Create a Kafka service with a registered cluster
 
-## Create a Kafka service with a registered cluster
-
-A Kafka Service is the client-facing endpoint managed by Gravitee. It is the Event Stream Management equivalent of an API proxy — the Kafka Service is the governance layer that enforces authentication, security plans, ACLs, and quotas before routing traffic to the backend infrastructure.
+A Kafka Service is the client-facing endpoint managed by Gravitee. It is the Event Stream Management equivalent of an API proxy. The Kafka Service is the governance layer that enforces authentication, security plans, ACLs, and quotas before routing traffic to the backend infrastructure.
 
 The backend infrastructure can be a standalone broker list, a specific connection on a registered physical cluster, or a Virtual Cluster.
 
@@ -10,75 +12,78 @@ The backend infrastructure can be a standalone broker list, a specific connectio
 For a simplified walkthrough that covers just the basics, see [Create your first Kafka service](../get-started/create-your-first-kafka-service.md).
 {% endhint %}
 
-### How Kafka services work
+## How Kafka services work
 
-When you create a Kafka Service, you define how clients connect to it (the **Listener**) and how the service reaches Kafka (the **Endpoint Binding**). The Event Gateway enforces the service's configuration at runtime — every produce and consume operation passes through the gateway, where security plans, authorization policies, and rate limits are evaluated.
+When you create a Kafka Service, you define the **Listener** that clients connect to, and the **Endpoint binding** that determines how the service reaches Kafka. The Event Gateway enforces the service's configuration at runtime. Every produce and consume operation passes through the gateway, where security plans, authorization policies, and rate limits are evaluated.
 
-A single Kafka Service can route to multiple clusters by binding to a Virtual Cluster, or multiple Kafka Services can bind to the same registered cluster to provide different governance tiers.
+A single Kafka Service can route to multiple clusters by binding to a Virtual Cluster. Alternatively, multiple Kafka Services can bind to the same registered cluster to provide different governance tiers.
 
-### Prerequisites
+## Prerequisites
 
 * Access to a running Gamma console instance
 * At least one registered Kafka cluster (see [Register your Kafka clusters](../import/register-your-kafka-clusters.md))
 
-### Create a Kafka service
+## Create a Kafka service
 
 1. From the Gamma console sidebar, select **Event Stream Management**.
 2. Navigate to **Kafka Services**.
 3. Select **Create Kafka Service**.
 
-#### 1. Identity
+The wizard has four steps. To configure the service, complete the following steps:
 
-| Field           | Description                                                                          |
-| --------------- | ------------------------------------------------------------------------------------ |
-| **Name**        | A human-readable name that identifies this Kafka Service in the console and Catalog. |
-| **Version**     | The version of this service (e.g., 1.0).                                             |
-| **Description** | Optional. A description of the service's purpose.                                    |
+1. [Identity](#identity)
+2. [Listener](#listener)
+3. [Endpoint](#endpoint)
+4. [Review and create](#review-and-create)
 
-#### 2. Listener
+### Identity
 
-The listener defines the entrypoint that Kafka clients will connect to.
+| Field           | Description                                                                                          |
+| --------------- | ---------------------------------------------------------------------------------------------------- |
+| **Name**        | A human-readable name that identifies this Kafka Service in the Kafka Service list and detail views. |
+| **Version**     | The version of this service, for example 1.0.                                                        |
+| **Description** | Optional. A description of the service's purpose.                                                    |
 
-| Field           | Description                                                                                                                                                                                                                                                                                        |
-| --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Host prefix** | A single DNS label (lowercase letters, digits, and hyphens; max 63 characters). The Event Gateway appends its configured domain, and clients connect on the gateway's SNI port — for example `orders.<gateway-domain>:<sni-port>`. The port is a gateway-level setting and is not configured here. |
+### Listener
 
-#### 3. Endpoint
+The listener defines the entrypoint that Kafka clients connect to.
+
+| Field           | Description                                                                                                                                                                                                                                                    |
+| --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Host prefix** | A single DNS label of lowercase letters, digits, and hyphens, up to 63 characters. The Event Gateway appends its configured domain, and clients connect on the gateway's SNI port, for example `orders.<gateway-domain>:<sni-port>`. The port is a gateway-level setting and is not configured here. |
+
+### Endpoint
 
 The endpoint binding determines how the Kafka Service reaches Kafka. Choose one of the following modes:
 
-* **Standalone**: Manually provide a comma-separated list of `host:port` bootstrap servers.
-* **Managed cluster**: Select a registered Kafka cluster and one of its configured connections.
-* **Virtual Cluster**: Select a Virtual Cluster to route traffic through a unified namespace or Kafka Mesh.
+* **Standalone**. Manually provide a comma-separated list of `host:port` bootstrap servers.
+* **Managed cluster**. Select a registered Kafka cluster and one of its configured connections.
+* **Virtual Cluster**. Select a Virtual Cluster to route traffic through a unified namespace or Kafka Mesh.
 
-#### 4. Review and create
+### Review and create
 
 1. Review the service identity, listener, and endpoint binding.
 2. Select **Create Kafka Service**.
 
 The console creates the Kafka Service and redirects you to its overview page.
 
-### Configure Plans and Policies
+## Configure Plans and Policies
 
 After creating the Kafka Service, you must configure a **Plan** to allow clients to consume from or produce to the service.
 
 The following security plan types are available:
 
-* **Keyless (Public)**
-* **API Key**
+* **Keyless**
+* **API key**
 * **OAuth2**
 * **JWT**
 * **mTLS**
 
-Plans support **Subscription validation** (Auto or Manual) and advanced **Port-based routing** (Bootstrap port, broker range start, broker range end) for gateways running in port routing mode without SNI.
+Every plan also carries a **Subscription validation** mode, set to either `AUTO` or `MANUAL`.
 
 Once a plan is established, you can apply **Policies** to enforce quotas, message filtering, or access controls.
 
-### Expose as a Kafka API Tool
+## Next steps
 
-Once a Kafka Service is running, you can expose its topics as **Kafka API Tools** in the Catalog, bridging your event infrastructure to the AI agent layer. Kafka API Tools become available as building blocks in MCP Studio alongside other tools, resources, and prompts.
-
-### Next steps
-
-* **Provision a Virtual Cluster** — Add multi-tenant isolation on top of your Kafka Service. See [Establish a virtual cluster](establish-a-virtual-cluster.md).
-* **Create topics** — Set up Kafka topics for producing and consuming messages.
+* **Provision a Virtual Cluster**. Add multi-tenant isolation on top of your Kafka Service. See [Establish a virtual cluster](establish-a-virtual-cluster.md).
+* **Create topics**. Create Kafka topics for producing and consuming messages.


### PR DESCRIPTION
Doc Verification Pipeline run on `docs/gamma/4.12/event-stream-management/build/create-a-kafka-service-with-a-registered-cluster.md`.

The page was verified against a local Gamma 4.12 console by actually walking the procedure: a Kafka Service was created and bound to a connection on a registered, deployed Kafka cluster, then the Plans surface was inspected for every security type. Claims with a code-level counterpart were cross-checked against the Event Stream Management module shipped in 4.12.

## Environment limitation

**There is no Kafka broker in this stack.** The registered cluster's connection was declared but never dialed. Anything requiring a real Kafka handshake — broker reachability, connection health, produce and consume, topic listing — is **not determined** here and was left untouched. The procedure itself completes fully without a broker, since a Kafka Service can be created, bound, and inspected without the backend answering.

## Step 4 verdict table

| # | Claim | Code truth | Live truth | Verdict |
|---|---|---|---|---|
| 1 | Sidebar **Event Stream Management**, then **Kafka Services** | n/a | Matches | OK |
| 2 | **Create Kafka Service** button | Confirmed | Matches | OK |
| 3 | Wizard has four steps: Identity, Listener, Endpoint, Review | Confirmed | Matches; step chips read 1 Identity, 2 Listener, 3 Endpoint, 4 Review | OK |
| 4 | Identity fields: Name, Version, Description (optional) | n/a | Matches | OK |
| 5 | Name "identifies this Kafka Service in the console and Catalog" | No Catalog surface for Kafka Services | Field help reads "Shown in the Kafka Service list and detail views" | **Fixed** |
| 6 | Version, for example 1.0 | n/a | Matches; placeholder is `1.0` | OK |
| 7 | Host prefix is a single DNS label, lowercase letters, digits and hyphens, max 63 characters | Confirmed by the field's validation pattern | Matches | OK |
| 8 | Gateway appends its domain, clients connect on the SNI port, port not configured here | Confirmed | Matches; the Listener step has exactly one field and no port input | OK |
| 9 | Endpoint modes: Standalone, Managed cluster, Virtual Cluster | Confirmed, exact labels | Matches | OK |
| 10 | Standalone takes a comma-separated `host:port` bootstrap server list | Confirmed | Matches. Standalone also exposes a **Security protocol** selector the page doesn't mention | OK (see notes) |
| 11 | Managed cluster: pick a registered cluster and one of its connections | Confirmed, both are required | Matches; bound to a registered cluster and its connection successfully | OK |
| 12 | Virtual Cluster mode | Confirmed | Option present, not exercised | OK |
| 13 | Step 4 reviews the service and offers **Create Kafka Service** | n/a | Matches; panel is titled "Review & create" | OK |
| 14 | The console creates the service and redirects to its overview page | n/a | Matches; redirected to the overview with a "Kafka Service created" toast | OK |
| 15 | A plan is required before clients can consume or produce | n/a | Matches; the empty state and the setup checklist both say so | OK |
| 16 | Security plan types: Keyless (Public), API Key, OAuth2, JWT, mTLS | Five types confirmed; labels are Keyless, API key, OAuth2, JWT, mTLS | Matches, but the label is **Keyless**, not "Keyless (Public)" | **Fixed** |
| 17 | Subscription validation, Auto or Manual | Values are `AUTO` and `MANUAL` | Matches; the control renders them uppercase | **Fixed** (wording) |
| 18 | Plans support Port-based routing: Bootstrap port, broker range start, broker range end | Not offered by the plan form | Contradicted. All five plan forms show only Name, Security type, security settings, Subscription validation, and Description | **Fixed** (removed) |
| 19 | Policies enforce quotas, message filtering, access controls | Policy Studio present | Policy Studio present on the service, not exercised | OK |
| 20 | "Expose as a Kafka API Tool" — topics exposed as Kafka API Tools in the Catalog and MCP Studio | No such capability anywhere in 4.12 | Contradicted. The Kafka Service navigation has no such entry, and no module in the 4.12 console offers it | **Fixed** (section removed) |
| 21 | The Event Gateway evaluates plans and policies on every produce and consume | n/a | **Not determined** — no Kafka broker in this stack | Left as written |
| 22 | Images | n/a | The page carries **zero** `<figure>` elements | See notes |
| 23 | Relative links resolve | All three targets exist | n/a | OK |

## What changed

Meaning-level fixes, all backed by rows 5, 16, 17, 18, and 20:

- Name field description now matches what the console actually says.
- `Keyless (Public)` to `Keyless`, and `API Key` to `API key`.
- The port-routing sentence was removed; Subscription validation is retained with its real `AUTO` and `MANUAL` values.
- The "Expose as a Kafka API Tool" section was removed.

Style pass over the whole page, form-only:

- Added the required `description:` frontmatter.
- Removed the duplicated page title (`#` then an identical `##`).
- Promoted the heading hierarchy so sections sit at `##` and wizard steps at `###`, matching the rest of the Gamma docs.
- Added a procedure overview with anchor links to the four wizard steps.
- Replaced `e.g.` with plain English, removed explanatory parentheses, split two over-long sentences, and switched bulleted term/explanation separators from colons and em dashes to periods.

No images were added, removed, or replaced — the page has none.

## Notes for the writer, not edited in

- **Images.** The page has no screenshots at all. Creating a Kafka Service is a task where the reader arrives somewhere new (a four-step wizard) and makes an on-screen choice (the three binding-mode cards), so a single screenshot on the first wizard step would be justified under the image triggers. Adding one is a writer's call, so nothing was captured.
- **Standalone binding security.** The Standalone mode also exposes a **Security protocol** selector, defaulting to `PLAINTEXT`. The page describes Standalone as bootstrap servers only. This is an omission rather than a contradiction, so it wasn't edited in.
- **`create-your-first-kafka-service.md`** (a different page) also says "Keyless (Public)" and carries the same Identity table wording about the Catalog. It's out of scope for this PR and needs the same correction.
- **4.13 was not patched.** `docs/gamma/4.13/.../create-a-kafka-service-with-a-registered-cluster.md` already differed from 4.12 before this change: it carries `hidden`/`noIndex` frontmatter and a `<--- to be published --->` marker, and already uses the `##`/`###` heading hierarchy. Per the divergence convention it was left alone, but it still contains all five factual errors corrected here and should get a follow-up.

## Not verifiable here

Runtime behavior. No Kafka broker runs in this stack, so nothing that needs a real handshake was claimed either way.
