### PR TITLE
docs(gamma): verify and correct the A2A Proxy exposure guide (4.12 + 4.13)

### DIFF
--- a/docs/gamma/4.12/agent-management/build/expose-agent-with-a2a-proxy.md
+++ b/docs/gamma/4.12/agent-management/build/expose-agent-with-a2a-proxy.md
@@ -1,9 +1,9 @@
 ---
+hidden: false
+noIndex: false
 description: >-
   Expose an upstream agent behind the AI Gateway with an Agent-to-Agent (A2A)
   Proxy so that other agents can discover and call it.
-hidden: false
-noIndex: false
 ---
 
 # Expose your agent with the A2A Proxy
@@ -14,21 +14,34 @@ The Agent-to-Agent (A2A) Proxy makes an upstream agent reachable by other agents
 
 When you expose an agent through the A2A Proxy, the proxy provides the following:
 
-* **Agent card discovery**. The proxy serves the upstream agent's `/.well-known/agent-card.json` descriptor, the A2A standard for advertising agent capabilities. It rewrites the URLs that the descriptor advertises so that callers reach the agent through the gateway instead of directly. The gateway handles the legacy `/.well-known/agent.json` path and the extended agent card endpoint the same way.
-* **Client authentication**. Every caller authenticates against a plan on the proxy, using either an API key or a client certificate. The upstream agent is never exposed directly to the network.
-* **Wire-level governance**. Every invocation passes through the AI Gateway with full observability, authentication, and policy enforcement. This is the same governance applied to MCP and LLM traffic.
+* **Agent card discovery**. The proxy serves the upstream agent's `/.well-known/agent-card.json` descriptor, the A2A standard for advertising agent capabilities. It rewrites the agent's endpoint URL in the descriptor so that callers reach the agent through the gateway instead of directly. Other URLs in the card, such as `documentationUrl`, pass through unchanged. The gateway handles the legacy `/.well-known/agent.json` path and the extended agent card endpoint the same way.
+* **Client authentication**. The wizard secures the proxy with a default plan that uses either an API key or a client certificate. Every caller authenticates against a plan before the gateway forwards the request, so clients reach the agent through the gateway rather than calling it directly.
+* **Wire-level governance**. Every invocation passes through the AI Gateway with full observability and policy enforcement. This is the same governance applied to MCP and LLM traffic.
 
 ## Create an A2A Proxy
 
 1. From the Gamma console sidebar, select **Agent Management**.
 2. Under **Secure**, select **A2A Proxies**.
 3. To launch the wizard, select **Create A2A proxy**.
-4. **Step 1: Define**: Provide a name and the **Context path** where clients reach the proxy on the gateway. A description is optional.
+4. **Step 1: Define**: Provide a name and the **Context path** where clients reach the proxy on the gateway. The wizard derives the context path from the name, so you can accept the suggested value or replace it. A description is optional.
 5. **Step 2: Secure**: Choose how clients authenticate to the gateway, either **API Key** or **mTLS**. A default plan is created and published with the proxy.
 6. **Step 3: Connect**: Enter the **Target URL** of the upstream agent, and then choose how the gateway authenticates to it at runtime. **Static credential** injects a credential into a request header on every call, and **No upstream auth** calls the upstream without credentials.
 7. **Step 4: Review**: Confirm the summary, and then select **Create A2A proxy**.
 
-The A2A Proxy is created and starts running. Its **Overview** page shows the gateway URL that clients call and the upstream agent URL that the proxy forwards to.
+The A2A Proxy is created and starts running. Its **Overview** page shows the configured gateway URL and the upstream agent URL that the proxy forwards to.
+
+## Give a client access
+
+The proxy rejects unauthenticated requests, including requests for the agent card. To let a client call a proxy secured with an API key, complete the following steps:
+
+1. In the APIM console, create an application, or open an existing one.
+2. Subscribe the application to the proxy's default plan.
+3. Approve the subscription. The default plan uses manual validation, so subscriptions start as pending.
+4. Copy the API key from the subscription.
+
+Clients send the key in the `Authorization` header as `Bearer <api-key>`. The `X-Gravitee-Api-Key` header is not accepted.
+
+If you secured the proxy with mTLS instead, configure the trusted certificate authorities and the certificate validation rules in the gateway-level TLS settings.
 
 ## The `/.well-known/agent-card.json` descriptor
 
@@ -38,9 +51,10 @@ Clients fetch the agent card from the gateway at the following address:
 https://<your-gateway-host>/<context-path>/.well-known/agent-card.json
 ```
 
-The proxy returns the upstream agent's own card with its advertised URLs rewritten to the gateway address. A client that discovers the agent this way sends every subsequent request through the proxy. The contents of the descriptor, including its declared skills, come from the upstream agent.
+The proxy returns the upstream agent's own card with its advertised endpoint URL rewritten to the gateway address. A client that discovers the agent this way sends every subsequent request through the proxy. The contents of the descriptor, including its declared skills, come from the upstream agent.
 
 ## Next steps
 
-* **[Create an agent identity](create-an-agent-identity.md)**. Agent identities are managed separately, under **Catalog** in Agent Management.
+* **[Create an agent identity](create-an-agent-identity.md)**. Agent identities are managed under **Agent Identity**, in the **Catalog** section of Agent Management.
 * **[Add policies to your A2A Proxy](configure-your-a2a-proxy/add-policies-to-a2a-proxy.md)**. Use the Policy Studio to apply security, transformation, and traffic policies to agent traffic.
+* **[Author an authorization policy](../../authorization-management/configure/create-update-delete-policies.md)**. In Authorization Management, select **A2A Agents** to grant or restrict which principals can invoke an agent. Policies target an agent from the Catalog, so import the agent there first.

--- a/docs/gamma/4.12/agent-management/build/expose-agent-with-a2a-proxy.md
+++ b/docs/gamma/4.12/agent-management/build/expose-agent-with-a2a-proxy.md
@@ -1,69 +1,46 @@
 ---
+description: >-
+  Expose an upstream agent behind the AI Gateway with an Agent-to-Agent (A2A)
+  Proxy so that other agents can discover and call it.
 hidden: false
 noIndex: false
 ---
 
 # Expose your agent with the A2A Proxy
 
-The A2A (Agent-to-Agent) Proxy makes an agent's skills discoverable and callable by other agents — across trust boundaries, providers, and organizations. It implements the A2A protocol by serving a `/.well-known/agent.json` descriptor that advertises the agent's skills, and then governs every invocation through the AI Gateway.
+The Agent-to-Agent (A2A) Proxy makes an upstream agent reachable by other agents across trust boundaries, providers, and organizations. It implements the A2A protocol by serving the agent's `/.well-known/agent-card.json` descriptor through the gateway. The AI Gateway then governs every invocation.
 
 ## What the A2A Proxy does
 
-When you expose an agent through the A2A Proxy:
+When you expose an agent through the A2A Proxy, the proxy provides the following:
 
-1. **Skill discovery** — The proxy serves `/.well-known/agent.json`, the A2A standard for advertising agent capabilities. Other agents or systems can discover what this agent can do by reading the descriptor.
-2. **Per-skill authorization** — The proxy publishes each discovered skill to Authorization Management as a cataloged entity. This means you can write fine-grained authorization policies at the skill level: _"Agent X can invoke the `analyze-contract` skill but not the `execute-payment` skill."_
-3. **Wire-level governance** — Every skill invocation passes through the AI Gateway with full observability, authentication, and policy enforcement — the same governance applied to MCP and LLM traffic.
-
-## How skill publishing works
-
-When an agent is exposed through the A2A Proxy:
-
-1. The proxy reads the agent's declared skills (from the Catalog or the agent's A2A descriptor)
-2. Each skill is published to Authorization Management as a cataloged entity with metadata (skill name, description, input/output schemas)
-3. Authorization policies can reference individual skills as resources
-4. When another agent invokes a skill, the AI Gateway evaluates the applicable policies before forwarding the invocation
-
-This is structurally different from tool-level authorization on MCP Proxies — skills represent higher-level capabilities that may span multiple tool invocations.
+* **Agent card discovery**. The proxy serves the upstream agent's `/.well-known/agent-card.json` descriptor, the A2A standard for advertising agent capabilities. It rewrites the URLs that the descriptor advertises so that callers reach the agent through the gateway instead of directly. The gateway handles the legacy `/.well-known/agent.json` path and the extended agent card endpoint the same way.
+* **Client authentication**. Every caller authenticates against a plan on the proxy, using either an API key or a client certificate. The upstream agent is never exposed directly to the network.
+* **Wire-level governance**. Every invocation passes through the AI Gateway with full observability, authentication, and policy enforcement. This is the same governance applied to MCP and LLM traffic.
 
 ## Create an A2A Proxy
 
 1. From the Gamma console sidebar, select **Agent Management**.
-2. Navigate to **Build** and select **A2A Proxies**.
-3. Select **Create A2A proxy** to launch the wizard.
-4. **Step 1: Define**: Provide a name and optional description for your proxy.
-5. **Step 2: Connect**: Enter the target A2A endpoint URL. The gateway will resolve its configuration by fetching `/.well-known/agent-card.json`.
-6. **Step 3: Secure**: Attach security plans to control who can access the proxy.
-7. **Step 4: Review**: Confirm the settings and select **Create A2A proxy**.
+2. Under **Secure**, select **A2A Proxies**.
+3. To launch the wizard, select **Create A2A proxy**.
+4. **Step 1: Define**: Provide a name and the **Context path** where clients reach the proxy on the gateway. A description is optional.
+5. **Step 2: Secure**: Choose how clients authenticate to the gateway, either **API Key** or **mTLS**. A default plan is created and published with the proxy.
+6. **Step 3: Connect**: Enter the **Target URL** of the upstream agent, and then choose how the gateway authenticates to it at runtime. **Static credential** injects a credential into a request header on every call, and **No upstream auth** calls the upstream without credentials.
+7. **Step 4: Review**: Confirm the summary, and then select **Create A2A proxy**.
 
-The A2A Proxy is created and begins serving the `/.well-known/agent-card.json` descriptor. Other agents and systems can now discover and invoke this agent's skills through the AI Gateway.
+The A2A Proxy is created and starts running. Its **Overview** page shows the gateway URL that clients call and the upstream agent URL that the proxy forwards to.
 
 ## The `/.well-known/agent-card.json` descriptor
 
-The A2A Proxy generates and serves an agent card descriptor at:
+Clients fetch the agent card from the gateway at the following address:
 
 ```
 https://<your-gateway-host>/<context-path>/.well-known/agent-card.json
 ```
 
-This descriptor includes standard capabilities and inline skills. For example:
-
-```json
-{
-  "agentType": "AUTONOMOUS",
-  "capabilities": {
-    "mcp": true
-  },
-  "skills": [
-    {
-      "name": "analyze-contract",
-      "description": "Analyzes a PDF contract for compliance."
-    }
-  ]
-}
-```
+The proxy returns the upstream agent's own card with its advertised URLs rewritten to the gateway address. A client that discovers the agent this way sends every subsequent request through the proxy. The contents of the descriptor, including its declared skills, come from the upstream agent.
 
 ## Next steps
 
-* [Create an agent identity](create-an-agent-identity.md) — An agent must have an identity before it can be exposed through the A2A Proxy.
-* [Add policies to your MCP server](configure-your-mcp/add-policies-to-mcp-server.md) — The policy model for skill-level authorization follows the same pattern as tool-level authorization.
+* **[Create an agent identity](create-an-agent-identity.md)**. Agent identities are managed separately, under **Catalog** in Agent Management.
+* **[Add policies to your A2A Proxy](configure-your-a2a-proxy/add-policies-to-a2a-proxy.md)**. Use the Policy Studio to apply security, transformation, and traffic policies to agent traffic.

--- a/docs/gamma/4.13/agent-management/build/expose-agent-with-a2a-proxy.md
+++ b/docs/gamma/4.13/agent-management/build/expose-agent-with-a2a-proxy.md
@@ -1,9 +1,9 @@
 ---
+hidden: false
+noIndex: false
 description: >-
   Expose an upstream agent behind the AI Gateway with an Agent-to-Agent (A2A)
   Proxy so that other agents can discover and call it.
-hidden: false
-noIndex: false
 ---
 
 # Expose your agent with the A2A Proxy
@@ -14,21 +14,34 @@ The Agent-to-Agent (A2A) Proxy makes an upstream agent reachable by other agents
 
 When you expose an agent through the A2A Proxy, the proxy provides the following:
 
-* **Agent card discovery**. The proxy serves the upstream agent's `/.well-known/agent-card.json` descriptor, the A2A standard for advertising agent capabilities. It rewrites the URLs that the descriptor advertises so that callers reach the agent through the gateway instead of directly. The gateway handles the legacy `/.well-known/agent.json` path and the extended agent card endpoint the same way.
-* **Client authentication**. Every caller authenticates against a plan on the proxy, using either an API key or a client certificate. The upstream agent is never exposed directly to the network.
-* **Wire-level governance**. Every invocation passes through the AI Gateway with full observability, authentication, and policy enforcement. This is the same governance applied to MCP and LLM traffic.
+* **Agent card discovery**. The proxy serves the upstream agent's `/.well-known/agent-card.json` descriptor, the A2A standard for advertising agent capabilities. It rewrites the agent's endpoint URL in the descriptor so that callers reach the agent through the gateway instead of directly. Other URLs in the card, such as `documentationUrl`, pass through unchanged. The gateway handles the legacy `/.well-known/agent.json` path and the extended agent card endpoint the same way.
+* **Client authentication**. The wizard secures the proxy with a default plan that uses either an API key or a client certificate. Every caller authenticates against a plan before the gateway forwards the request, so clients reach the agent through the gateway rather than calling it directly.
+* **Wire-level governance**. Every invocation passes through the AI Gateway with full observability and policy enforcement. This is the same governance applied to MCP and LLM traffic.
 
 ## Create an A2A Proxy
 
 1. From the Gamma console sidebar, select **Agent Management**.
 2. Under **Secure**, select **A2A Proxies**.
 3. To launch the wizard, select **Create A2A proxy**.
-4. **Step 1: Define**: Provide a name and the **Context path** where clients reach the proxy on the gateway. A description is optional.
+4. **Step 1: Define**: Provide a name and the **Context path** where clients reach the proxy on the gateway. The wizard derives the context path from the name, so you can accept the suggested value or replace it. A description is optional.
 5. **Step 2: Secure**: Choose how clients authenticate to the gateway, either **API Key** or **mTLS**. A default plan is created and published with the proxy.
 6. **Step 3: Connect**: Enter the **Target URL** of the upstream agent, and then choose how the gateway authenticates to it at runtime. **Static credential** injects a credential into a request header on every call, and **No upstream auth** calls the upstream without credentials.
 7. **Step 4: Review**: Confirm the summary, and then select **Create A2A proxy**.
 
-The A2A Proxy is created and starts running. Its **Overview** page shows the gateway URL that clients call and the upstream agent URL that the proxy forwards to.
+The A2A Proxy is created and starts running. Its **Overview** page shows the configured gateway URL and the upstream agent URL that the proxy forwards to.
+
+## Give a client access
+
+The proxy rejects unauthenticated requests, including requests for the agent card. To let a client call a proxy secured with an API key, complete the following steps:
+
+1. In the APIM console, create an application, or open an existing one.
+2. Subscribe the application to the proxy's default plan.
+3. Approve the subscription. The default plan uses manual validation, so subscriptions start as pending.
+4. Copy the API key from the subscription.
+
+Clients send the key in the `Authorization` header as `Bearer <api-key>`. The `X-Gravitee-Api-Key` header is not accepted.
+
+If you secured the proxy with mTLS instead, configure the trusted certificate authorities and the certificate validation rules in the gateway-level TLS settings.
 
 ## The `/.well-known/agent-card.json` descriptor
 
@@ -38,9 +51,10 @@ Clients fetch the agent card from the gateway at the following address:
 https://<your-gateway-host>/<context-path>/.well-known/agent-card.json
 ```
 
-The proxy returns the upstream agent's own card with its advertised URLs rewritten to the gateway address. A client that discovers the agent this way sends every subsequent request through the proxy. The contents of the descriptor, including its declared skills, come from the upstream agent.
+The proxy returns the upstream agent's own card with its advertised endpoint URL rewritten to the gateway address. A client that discovers the agent this way sends every subsequent request through the proxy. The contents of the descriptor, including its declared skills, come from the upstream agent.
 
 ## Next steps
 
-* **[Create an agent identity](create-an-agent-identity.md)**. Agent identities are managed separately, under **Catalog** in Agent Management.
+* **[Create an agent identity](create-an-agent-identity.md)**. Agent identities are managed under **Agent Identity**, in the **Catalog** section of Agent Management.
 * **[Add policies to your A2A Proxy](configure-your-a2a-proxy/add-policies-to-a2a-proxy.md)**. Use the Policy Studio to apply security, transformation, and traffic policies to agent traffic.
+* **[Author an authorization policy](../../authorization-management/configure/create-update-delete-policies.md)**. In Authorization Management, select **A2A Agents** to grant or restrict which principals can invoke an agent. Policies target an agent from the Catalog, so import the agent there first.

--- a/docs/gamma/4.13/agent-management/build/expose-agent-with-a2a-proxy.md
+++ b/docs/gamma/4.13/agent-management/build/expose-agent-with-a2a-proxy.md
@@ -1,69 +1,46 @@
 ---
+description: >-
+  Expose an upstream agent behind the AI Gateway with an Agent-to-Agent (A2A)
+  Proxy so that other agents can discover and call it.
 hidden: false
 noIndex: false
 ---
 
 # Expose your agent with the A2A Proxy
 
-The A2A (Agent-to-Agent) Proxy makes an agent's skills discoverable and callable by other agents — across trust boundaries, providers, and organizations. It implements the A2A protocol by serving a `/.well-known/agent.json` descriptor that advertises the agent's skills, and then governs every invocation through the AI Gateway.
+The Agent-to-Agent (A2A) Proxy makes an upstream agent reachable by other agents across trust boundaries, providers, and organizations. It implements the A2A protocol by serving the agent's `/.well-known/agent-card.json` descriptor through the gateway. The AI Gateway then governs every invocation.
 
 ## What the A2A Proxy does
 
-When you expose an agent through the A2A Proxy:
+When you expose an agent through the A2A Proxy, the proxy provides the following:
 
-1. **Skill discovery** — The proxy serves `/.well-known/agent.json`, the A2A standard for advertising agent capabilities. Other agents or systems can discover what this agent can do by reading the descriptor.
-2. **Per-skill authorization** — The proxy publishes each discovered skill to Authorization Management as a cataloged entity. This means you can write fine-grained authorization policies at the skill level: _"Agent X can invoke the `analyze-contract` skill but not the `execute-payment` skill."_
-3. **Wire-level governance** — Every skill invocation passes through the AI Gateway with full observability, authentication, and policy enforcement — the same governance applied to MCP and LLM traffic.
-
-## How skill publishing works
-
-When an agent is exposed through the A2A Proxy:
-
-1. The proxy reads the agent's declared skills (from the Catalog or the agent's A2A descriptor)
-2. Each skill is published to Authorization Management as a cataloged entity with metadata (skill name, description, input/output schemas)
-3. Authorization policies can reference individual skills as resources
-4. When another agent invokes a skill, the AI Gateway evaluates the applicable policies before forwarding the invocation
-
-This is structurally different from tool-level authorization on MCP Proxies — skills represent higher-level capabilities that may span multiple tool invocations.
+* **Agent card discovery**. The proxy serves the upstream agent's `/.well-known/agent-card.json` descriptor, the A2A standard for advertising agent capabilities. It rewrites the URLs that the descriptor advertises so that callers reach the agent through the gateway instead of directly. The gateway handles the legacy `/.well-known/agent.json` path and the extended agent card endpoint the same way.
+* **Client authentication**. Every caller authenticates against a plan on the proxy, using either an API key or a client certificate. The upstream agent is never exposed directly to the network.
+* **Wire-level governance**. Every invocation passes through the AI Gateway with full observability, authentication, and policy enforcement. This is the same governance applied to MCP and LLM traffic.
 
 ## Create an A2A Proxy
 
 1. From the Gamma console sidebar, select **Agent Management**.
-2. Navigate to **Build** and select **A2A Proxies**.
-3. Select **Create A2A proxy** to launch the wizard.
-4. **Step 1: Define**: Provide a name and optional description for your proxy.
-5. **Step 2: Connect**: Enter the target A2A endpoint URL. The gateway will resolve its configuration by fetching `/.well-known/agent-card.json`.
-6. **Step 3: Secure**: Attach security plans to control who can access the proxy.
-7. **Step 4: Review**: Confirm the settings and select **Create A2A proxy**.
+2. Under **Secure**, select **A2A Proxies**.
+3. To launch the wizard, select **Create A2A proxy**.
+4. **Step 1: Define**: Provide a name and the **Context path** where clients reach the proxy on the gateway. A description is optional.
+5. **Step 2: Secure**: Choose how clients authenticate to the gateway, either **API Key** or **mTLS**. A default plan is created and published with the proxy.
+6. **Step 3: Connect**: Enter the **Target URL** of the upstream agent, and then choose how the gateway authenticates to it at runtime. **Static credential** injects a credential into a request header on every call, and **No upstream auth** calls the upstream without credentials.
+7. **Step 4: Review**: Confirm the summary, and then select **Create A2A proxy**.
 
-The A2A Proxy is created and begins serving the `/.well-known/agent-card.json` descriptor. Other agents and systems can now discover and invoke this agent's skills through the AI Gateway.
+The A2A Proxy is created and starts running. Its **Overview** page shows the gateway URL that clients call and the upstream agent URL that the proxy forwards to.
 
 ## The `/.well-known/agent-card.json` descriptor
 
-The A2A Proxy generates and serves an agent card descriptor at:
+Clients fetch the agent card from the gateway at the following address:
 
 ```
 https://<your-gateway-host>/<context-path>/.well-known/agent-card.json
 ```
 
-This descriptor includes standard capabilities and inline skills. For example:
-
-```json
-{
-  "agentType": "AUTONOMOUS",
-  "capabilities": {
-    "mcp": true
-  },
-  "skills": [
-    {
-      "name": "analyze-contract",
-      "description": "Analyzes a PDF contract for compliance."
-    }
-  ]
-}
-```
+The proxy returns the upstream agent's own card with its advertised URLs rewritten to the gateway address. A client that discovers the agent this way sends every subsequent request through the proxy. The contents of the descriptor, including its declared skills, come from the upstream agent.
 
 ## Next steps
 
-* [Create an agent identity](create-an-agent-identity.md) — An agent must have an identity before it can be exposed through the A2A Proxy.
-* [Add policies to your MCP server](configure-your-mcp/add-policies-to-mcp-server.md) — The policy model for skill-level authorization follows the same pattern as tool-level authorization.
+* **[Create an agent identity](create-an-agent-identity.md)**. Agent identities are managed separately, under **Catalog** in Agent Management.
+* **[Add policies to your A2A Proxy](configure-your-a2a-proxy/add-policies-to-a2a-proxy.md)**. Use the Policy Studio to apply security, transformation, and traffic policies to agent traffic.


### PR DESCRIPTION
## What this is

A Doc Verification Pipeline run on `docs/gamma/4.12/agent-management/build/expose-agent-with-a2a-proxy.md`.

Verified against a live Gamma 4.12 console (Docker, EE licence) by walking the documented procedure end to end and creating a real A2A proxy through the wizard. Claims with a code-level counterpart were cross-checked against the components shipped in the 4.12 distribution.

`docs/gamma/4.13/.../expose-agent-with-a2a-proxy.md` was byte-identical before the edit, so it receives the same change in this PR.

## Verdict table

| # | Claim | Code truth | Live truth | Verdict |
|---|---|---|---|---|
| 1 | The proxy implements A2A by serving a `/.well-known/agent.json` descriptor | The gateway answers `/.well-known/agent-card.json`, and also accepts the legacy `/.well-known/agent.json` path and an extended agent card path | Not determined — no A2A upstream agent in this stack, so no card could be fetched | **Fix** — use `agent-card.json` |
| 2 | "Skill discovery" — the proxy serves the descriptor advertising agent capabilities | The gateway takes the upstream agent's card and rewrites the URLs it advertises so callers are routed back through the gateway | Not determined | **Fix** — reworded to describe pass-through and URL rewriting |
| 3 | "Per-skill authorization" — the proxy publishes each discovered skill to Authorization Management as a cataloged entity | An A2A proxy carries only a name, context path, target URL, and status. Nothing in the shipped 4.12 components relates A2A proxies to skills or to Authorization Management entities | The wizard never discovers or asks for skills; the created proxy has no skills view | **Contradicted — removed** |
| 4 | "How skill publishing works" — the 4-step publish-and-evaluate sequence | Same as row 3 | Same as row 3 | **Contradicted — removed** |
| 5 | Skill-level authorization is "structurally different from tool-level authorization on MCP Proxies" | Depends on row 3 | Depends on row 3 | **Contradicted — removed** |
| 6 | Wire-level governance through the AI Gateway with observability, authentication, and policy enforcement | Plans and policy attachment exist for A2A proxies | Confirmed — the proxy has Policy Studio, Dashboard, Logs, and Tracing, and a published plan | **Confirmed** |
| 7 | From the Gamma console sidebar, select **Agent Management** | n/a | Confirmed | **Confirmed** |
| 8 | Navigate to **Build** and select **A2A Proxies** | n/a | The Agent Management sidebar groups are General, Catalog, Secure, and Observability. **A2A Proxies** is under **Secure**. There is no Build group | **Fix** |
| 9 | Select **Create A2A proxy** to launch the wizard | n/a | Confirmed — button label matches exactly | **Confirmed** |
| 10 | **Step 1: Define** — provide a name and optional description | n/a | Step 1 is labelled **Define**. The panel asks for **Name** (required), **Context path** (required), and **Description** (optional) | **Fix** — **Context path** was undocumented |
| 11 | **Step 2: Connect** — enter the target A2A endpoint URL | n/a | Step 2 is **Secure**, not Connect | **Fix** — step order |
| 12 | **Step 3: Secure** — attach security plans | n/a | Step 3 is **Connect**, not Secure | **Fix** — step order |
| 13 | The Secure step content | The only client authentication types an A2A proxy accepts at creation are API key and mTLS | The step offers exactly **API Key** and **mTLS**, and states that a default plan is created and published with the proxy | **Fix** — options now named |
| 14 | The Connect step content | n/a | The step is "Connect to upstream agent": **Target URL** (required), plus an upstream authentication choice of **Static credential** or **No upstream auth** | **Fix** — upstream authentication was undocumented |
| 15 | "The gateway will resolve its configuration by fetching `/.well-known/agent-card.json`" during creation | The card is read and rewritten while proxying a request, not while creating the proxy | The wizard accepted an unreachable target URL and created the proxy without fetching anything | **Fix — removed** |
| 16 | **Step 4: Review** — confirm the settings and select **Create A2A proxy** | n/a | Confirmed — "Review configuration" summary, button reads **Create A2A proxy** | **Confirmed** |
| 17 | "The A2A Proxy generates and serves an agent card descriptor" | The gateway returns the upstream agent's card with its advertised URLs rewritten; it does not synthesise a card | Not determined | **Fix** |
| 18 | Descriptor address `https://<gateway-host>/<context-path>/.well-known/agent-card.json` | Consistent with the path the gateway matches | The proxy Overview shows a gateway URL of the form `https://<host>/<context-path>` | **Confirmed** |
| 19 | Sample descriptor with `agentType: "AUTONOMOUS"`, `capabilities: { "mcp": true }`, and skills carrying only `name` and `description` | `agentType` is a property of a catalogued agent identity, not of an agent card. No `capabilities.mcp` field exists anywhere in the product. A skill on an agent card carries more than a name and a description | Not determined | **Contradicted — removed** |
| 20 | "An agent must have an identity before it can be exposed through the A2A Proxy" | n/a | Contradicted — a working proxy was created with no agent identity anywhere in the environment | **Fix** |
| 21 | Next steps link to the MCP policies page for the skill-authorization pattern | Depends on row 3 | An "Add policies to your A2A Proxy" page already exists as a sibling | **Fix** — link retargeted |
| 22 | Images | n/a | n/a | The page carries no figures, so there was nothing to verify or replace |

## Note for the writer (not a fix)

The page has no screenshot. "Create an A2A Proxy" is a four-step wizard the reader arrives at for the first time, which is one of the triggers in `style-guide/05-formatting-and-document-structure/images-and-figures.md`. Whether to add one is a writer's call, so the pipeline left the images alone.

## What could not be verified

There is no upstream A2A agent in this environment, so nothing that requires a real agent card fetch or a real delegation could be observed. Rows 1, 2, 17, and 19 are marked "not determined" on the live column for that reason, and their verdicts rest on the code cross-check alone. This is a partial verification, honestly reported.

## Other changes

- Added the missing `description:` frontmatter.
- Ran the style pass over the whole page. Every non-factual hunk was diffed and confirmed meaning-preserving.
