### PR TITLE
docs(gamma): correct the A2A Proxy Policy Studio procedure for 4.12

### DIFF
--- a/docs/gamma/4.12/agent-management/build/configure-your-a2a-proxy/add-policies-to-a2a-proxy.md
+++ b/docs/gamma/4.12/agent-management/build/configure-your-a2a-proxy/add-policies-to-a2a-proxy.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Use the Policy Studio to add, configure, and manage policies on your A2A Proxy.
 ---
 
 # Add policies to your A2A Proxy
@@ -11,14 +12,12 @@ You can use the Policy Studio to add, configure, and manage policies on your Age
 
 To attach policies to your A2A Proxy:
 
-1. In the Gamma console, navigate to **Agent Management**.
+1. In the Gamma console, navigate to **Agent Management**. In the **Secure** section of the sidebar, select **A2A Proxies**.
 2. Select your A2A proxy from the proxy list.
-3. In the sidebar, select **Policy Studio**.
-4. In the Policy Studio builder, you can define **Flows**. A flow is a combination of a selector (such as a path or condition) and a set of policies to execute when the selector matches.
-5. Search for policies in the policy palette.
-6. Drag and drop the selected policies onto the desired phase of your flow.
+3. In the **Design** section of the proxy sidebar, select **Policy Studio**.
+4. Create a flow. A flow is a combination of a selector, such as a path or condition, and a set of policies to execute when the selector matches. Click **Add plan flow** to scope the flow to a subscription plan, or **Add common flow** to apply the flow to all traffic regardless of plan.
+5. Select the flow, and then click **Browse all** on either the **Request Phase** or the **Response Phase**. The **Add Policy** panel lists the policies available for the phase you selected. To narrow the list, use the search field or the **Category** filter.
+6. Select a policy to review its documentation, and then click **Add to flow**.
 7. Select the policy in the flow to configure its specific properties.
-8. Click **Save** to persist and apply your changes.
-
-
-
+8. Click **Save** to persist your changes.
+9. Click **Deploy** to push your changes to the AI Gateway. Until you deploy, the proxy reports that it is out of sync and your changes are not live.


### PR DESCRIPTION
Verified `docs/gamma/4.12/agent-management/build/configure-your-a2a-proxy/add-policies-to-a2a-proxy.md` against a live 4.12 Gamma console by walking the documented procedure end to end on a real A2A proxy.

Four of the eight steps did not match the product.

## Verdict table

| # | Claim | Code evidence | Live observation | Verdict |
|---|---|---|---|---|
| 1 | Step 1: "navigate to **Agent Management**" | Confirms the sidebar groups | Incomplete. The sidebar groups are General, Catalog, Secure, and Observability. A2A proxies are in **Secure**. | **Fixed** |
| 2 | Step 2: select your A2A proxy from the proxy list | Not applicable | Matches. The list shows name, context path, target URL, and status. | OK |
| 3 | Step 3: "In the sidebar, select **Policy Studio**" | Not applicable | Matches, but ambiguous. The proxy has its own sidebar with General, Design, and Observability groups; Policy Studio is in **Design**. | **Fixed** (disambiguated) |
| 4 | Step 4: a flow is a selector plus a set of policies | Not applicable | Matches. The flow dialog has Flow name, Operator with Equals and Starts With, Path, HTTP methods, and Condition. | OK |
| 5 | Step 4: flows can simply be "defined" | Not applicable | Incomplete. A flow must exist before any policy can be added, and it is either an **Add plan flow** scoped to a subscription plan or an **Add common flow** applying to all traffic. Plan flows require an associated plan. | **Fixed** |
| 6 | Step 5: "Search for policies in the policy palette" | Not applicable | Doesn't match. There is no "policy palette". The catalog is a panel titled **Add Policy**, opened with **Browse all** from either the **Request Phase** or the **Response Phase**, with a search field and a **Category** filter. | **Fixed** |
| 7 | Step 6: "**Drag and drop** the selected policies onto the desired phase" | Contradicts. The Policy Studio has no drag-and-drop implementation. | Contradicts. You choose the phase first by opening the catalog from it, then select a policy and click **Add to flow**. The catalog only offers the policies valid for that phase. | **Fixed** |
| 8 | Step 7: select the policy in the flow to configure its properties | Not applicable | Matches. A **Configuration** tab opens; it also opens automatically after **Add to flow**. | OK |
| 9 | Step 8: "Click **Save** to persist **and apply** your changes" | Contradicts. An out-of-sync banner with a single Deploy action is shown whenever the proxy needs redeploying. | Contradicts. After **Save** the console shows "This deployable is out of sync. Your latest changes are not live yet. Deploy to push them to the gateway." plus a **Deploy** button. | **Fixed** |
| 10 | Frontmatter `description` | Not applicable | Missing. | **Fixed** |
| 11 | Images | Not applicable | The page has no figures, so there was nothing to check or replace. | n/a |
| 12 | Whether a policy actually executes on agent traffic | Not applicable | **Not determined.** | Not determined |

## What could not be verified

The environment used for this check has no gateway and no upstream agent, so nothing requiring live traffic could be exercised. The deploy step is documented from the console's own out-of-sync banner and Deploy action, not from an observed request passing through a policy. The claim that policies "enforce security, modify payloads, and control traffic behavior" is left as written and is recorded as not determined rather than verified.

## Note for the writer, not changed here

This page has no screenshot. The Policy Studio flow editor is a place the reader arrives somewhere new and meets an unfamiliar two-phase canvas, which is one of the triggers in the image criteria. Whether to add one is a writer's call, so no image was added.

The sibling `configure-your-a2a-proxy/README.md` describes the proxy sidebar as General, Design, and Observability. The groups are right, but it omits **Endpoint** from General and names the observability entries "Metrics" and "Traces" where the console shows **Dashboard** and **Tracing**. Out of scope for this PR.

## 4.13

The 4.13 copy of this page had already diverged from 4.12 before this change: it carries the `description` frontmatter and a differently worded step 6. Per the versioning convention it was left untouched. It still needs the navigation path, the flow-creation step, the phase-before-policy ordering, and the missing deploy step, which should be a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
