### PR TITLE
docs(gamma): verify and correct the policy editor reference (4.12 + 4.13)

### DIFF
--- a/docs/gamma/4.12/authorization-management/configure/create-update-delete-policies.md
+++ b/docs/gamma/4.12/authorization-management/configure/create-update-delete-policies.md
@@ -1,72 +1,88 @@
 ---
+description: Reference for the Authorization Management policy editor, covering how to create, update, deploy, and delete GAPL policies.
 hidden: false
 noIndex: false
 ---
 
 # Create, update, and delete policies
 
-This is the comprehensive reference for the Authorization Management policy editor. Policies are written in GAPL (Gravitee Authorization Policy Language) and enforced by the gateway's Policy Decision Point.
+This is the comprehensive reference for the Authorization Management policy editor. Policies are written in Gravitee Authorization Policy Language (GAPL) and enforced by the gateway's Policy Decision Point (PDP).
 
 ## Policy editor overview
 
-The policy editor opens as a slide-out panel from any policy management page (MCPs, AI Models, APIs, or Custom Policies). It provides two editing modes:
+The policy editor opens as a slide-out panel from any policy management page: **MCPs**, **AI Models**, **APIs**, **A2A Agents**, or **Custom Policies**. It provides the following two editing modes:
 
 | Mode | Description |
 |------|-------------|
 | **Visual** | Build policies using statement cards with chip pickers for principals, actions, and resources |
 | **Code** | Edit GAPL directly in a Monaco editor with syntax highlighting |
 
-Toggle between modes using the **Visual / Code** toggle in the editor header. If your GAPL uses features the visual editor cannot represent, the Visual toggle is disabled with the explanation: "This policy uses GAPL features that the visual editor cannot represent. Use the Code view to edit it directly."
+Toggle between modes using the **Visual / Code** toggle in the editor header. If your GAPL uses features the visual editor cannot represent, the **Visual** toggle is disabled with the explanation: "This policy uses GAPL features that the visual editor cannot represent. Use the Code view to edit it directly."
 
-## Creating a policy
+## Create a policy
 
-### 1. Choose the policy category
+To create a policy, complete the following steps:
 
-Navigate to the appropriate page under **Policy Management**:
+1. [Choose the policy category](#choose-the-policy-category)
+2. [Open the editor](#open-the-editor)
+3. [Name the policy](#name-the-policy)
+4. [Build statements](#build-statements)
+5. [Add conditions](#add-conditions)
+6. [Set target gateways](#set-target-gateways)
+7. [Save or deploy](#save-or-deploy)
 
-| Page | Policy type | Has target? | Resource groups |
-|------|------------|-------------|-----------------|
-| **MCPs** | `MCP` | Yes (MCP Server) | MCPServer, MCPTool, MCPPrompt, MCPResource |
-| **AI Models** | `MODEL` | Yes (Model) | LLMProvider, Model |
-| **APIs** | `API` | Yes (API) | API, Endpoint, DataField |
-| **Custom Policies** | `CUSTOM` | No | User-defined |
+### Choose the policy category
 
-### 2. Open the editor
+Navigate to the appropriate page under **Policy Management**. The following table lists each page, the policy type it creates, the target it applies to, and the resource groups available to it:
 
-Click the create button (for example, **Create Policy for MCP**). For service policies, you first select a **target** — the specific catalog entry the policy applies to.
+| Page | Policy type | Target | Resource groups |
+|------|------------|--------|-----------------|
+| **MCPs** | `MCP` | MCP Server | MCPServer, MCPTool, MCPPrompt, MCPResource |
+| **AI Models** | `MODEL` | Model | LLMProvider, Model |
+| **APIs** | `API` | API | API, Endpoint, DataField |
+| **A2A Agents** | `AGENT` | Agent | Agent |
+| **Custom Policies** | `CUSTOM` | None | User-defined |
 
-### 3. Name the policy
+### Open the editor
 
-Enter a **Policy name** (required). The status badge shows **Draft**. Add an optional **Description** in the sub-header.
+On the **MCPs**, **AI Models**, **APIs**, or **A2A Agents** page, click **Create policy**. A **Create policy for** dialog opens so you can pick the catalog entry the policy applies to, and then the editor opens.
 
-### 4. Build statements
+On the **Custom Policies** page, click **Create Custom Policy**. The editor opens straight away, because a custom policy has no target.
 
-Each policy contains one or more statements. A statement has:
+### Name the policy
+
+Enter a **Policy name**. The name is required, and the status badge shows **Draft**. The **Description** field is optional.
+
+### Build statements
+
+Each policy contains one or more statements. Each statement is built from the following parts:
 
 | Part | Visual editor | GAPL syntax |
 |------|--------------|-------------|
 | **Effect** | Toggle between `permit` and `forbid` | `permit (…)` or `forbid (…)` |
-| **Principals** | Chip picker from Entities (Principals tab) | `principal == User::"alice"` |
-| **Actions** | Chip picker from the Actions page | `action == Action::"invoke"` |
-| **Resources** | Chip picker scoped by resource group | `resource == MCPTool::"search"` |
+| **Principal** | Chip picker from the **Principals** tab of the **Entities** page | `principal == User::"alice"` |
+| **Action** | Chip picker from the **Actions** page | `action == Action::"invoke"` |
+| **Resource** | Chip picker scoped by resource group | `resource == MCPTool::"search"` |
+| **Agents** | Chip picker of imported agent identities | `context.agent == AgentIdentity::"planner"` |
 | **Condition** | Condition block with snippet insertion | `when { context.time.hour >= 9 }` |
 
 #### Match modes
 
-Each clause supports two match modes:
+Each clause supports the following two match modes:
 
 | Mode | Operator | Use case |
 |------|----------|----------|
 | **Exact** | `==` | Match this specific entity |
 | **Includes** | `in` | Match this entity and its descendants |
 
-For principal clauses, the default depends on the entity type:
-- **Groups and Roles** → `includes` (membership containers)
-- **Users, Service Accounts, Agent Identities** → `exact` (leaf principals)
+For principal clauses, the default depends on the following entity types:
+
+* **Groups and Roles** default to **Includes**. They are membership containers.
+* **Users**, **Service Accounts**, and **Agent Identities** default to **Exact**. They are leaf principals.
 
 #### Multiple entities in a clause
 
-When multiple entities are selected in a single clause, they are joined with `in [list]`:
+In the **Visual** view, the **Principal** and **Resource** pickers each hold one entity, while the **Action** and **Agents** pickers accept several. When a clause holds multiple entities, GAPL joins them with `in [list]`:
 
 ```
 permit (
@@ -76,15 +92,17 @@ permit (
 );
 ```
 
-### 5. Add conditions
+### Add conditions
 
-Click **Add condition** on a statement card. The editor shows pre-built condition snippets specific to the policy category. You can also type custom conditions.
+On a statement card, expand the **Condition** section, which is marked **Optional**. The editor shows pre-built condition snippets specific to the policy category, each one a chip prefixed with a plus sign. You can also type custom conditions.
 
-### 6. Set target gateways
+### Set target gateways
 
-Below the header, the **Target gateways** picker scopes the policy to specific PDP gateways. Select `*` for all gateways, or pick individual targets from registered PDP gateways.
+The **Target gateways** picker scopes the policy to specific PDP gateways. Select **\* (all gateways)** to cover every gateway, or pick individual targets from registered PDP gateways.
 
-### 7. Save or deploy
+### Save or deploy
+
+The following table lists each save and deploy action, the status it produces, and the toast message it shows:
 
 | Action | Status after | Toast message |
 |--------|-------------|---------------|
@@ -94,56 +112,68 @@ Below the header, the **Target gateways** picker scopes the policy to specific P
 | **Deploy to PDP Runtime** | `DEPLOYED` | "Policy deployed. Gateway sync expected within 30s." |
 | **Undeploy** | `DISABLED` | "Policy undeployed. Gateway sync will drop it within 30s." |
 
-## Updating a policy
+## Update a policy
 
-1. On the policy list page, click a policy name to open the editor
-2. Modify statements, conditions, or metadata
-3. Click **Update policy** to save changes
-4. If the policy is deployed, changes take effect after gateway sync (~30 seconds)
+1. On the policy list page, click a policy name to open the editor.
+2. Modify statements, conditions, or metadata.
+3. Click **Update policy** to save your changes.
+4. If the policy is deployed, changes take effect after gateway sync, which takes about 30 seconds.
 
 ## Policy lifecycle states
 
+The following table lists each policy status, what it means, and the transitions available from it:
+
 | Status | Meaning | Transitions |
 |--------|---------|-------------|
-| **Draft** | Saved, not enforced | → Deployed |
-| **Deployed** | Active, enforced by the gateway | → Disabled (via Undeploy) |
-| **Disabled** | Suspended, not enforced | → Deployed (via Deploy) |
+| **Draft** | Saved, not enforced | Deployed |
+| **Deployed** | Active, enforced by the gateway | Disabled, by clicking **Undeploy** |
+| **Disabled** | Suspended, not enforced | Deployed, by clicking **Deploy to PDP Runtime** |
 
 {% hint style="info" %}
-There is no `DEPLOYED → DRAFT` transition. Undeploying writes `DISABLED`. To return to a draft-like state, undeploy and then edit.
+A `DEPLOYED` policy never returns to `DRAFT`. Undeploy writes `DISABLED` instead. To return to a draft-like state, undeploy the policy, and then edit it.
 {% endhint %}
 
-## Deleting a policy
+## Delete a policy
 
-Delete policies from the policy list page using the row-level action menu. Deleting a deployed policy removes it from gateway enforcement on the next sync cycle.
+On the policy list page, delete a policy using the row-level action menu. When you delete a deployed policy, the gateway drops it from enforcement on the next sync cycle.
 
-## Visual ↔ Code round-tripping
+## Round-trip between the Visual and Code views
+
+The following table describes what happens when you switch between the **Visual** and **Code** views:
 
 | Scenario | Behavior |
 |----------|----------|
-| Visual → Code | The generated GAPL is populated in the Monaco editor |
-| Code → Visual | The parser attempts to convert GAPL back to statement cards. If the GAPL uses unsupported features, the Visual toggle is disabled |
+| Visual to Code | The generated GAPL is populated in the Monaco editor |
+| Code to Visual | The parser attempts to convert GAPL back to statement cards. If the GAPL uses unsupported features, the **Visual** toggle is disabled |
 | Code edits while drafting | While drafting a new policy, the code editor mirrors the generated GAPL until you edit directly |
 
 ## GAPL template
 
-New policies start with the default template:
+A new policy starts with a single empty `permit` statement. The **Code** view renders it as the following GAPL, with the policy name as a comment:
 
 ```
-permit (principal, action, resource);
+// Policy: <policy name>
+permit (
+  principal,
+  action,
+  resource
+);
 ```
 
 ## Permissions
 
+The following table lists the permission each policy action requires:
+
 | Action | Required permission |
 |--------|-------------------|
-| Create / Update policy | `ENVIRONMENT_AUTHZ_POLICY[CREATE]` or `[UPDATE]` |
-| Deploy / Undeploy | `ENVIRONMENT_AUTHZ_PDP[UPDATE]` |
-| Delete policy | `ENVIRONMENT_AUTHZ_POLICY[DELETE]` |
+| Create policy | `ENVIRONMENT_AUTHZ_POLICIES[CREATE]` |
+| Update policy | `ENVIRONMENT_AUTHZ_POLICIES[UPDATE]` |
+| Deploy or undeploy | `ENVIRONMENT_AUTHZ_PDP[UPDATE]` |
+| Delete policy | `ENVIRONMENT_AUTHZ_POLICIES[DELETE]` |
 
 ## Next steps
 
-* [MCP policy examples](mcp-policy-examples.md) — Real-world MCP policy patterns
-* [API policy examples](api-policy-examples.md) — API access control patterns
-* [AI policy example](ai-policy-example.md) — Token budget and cost ceiling policies
-* [Custom policies overview](custom-policies/custom-policies-overview.md) — Policies for non-routed resources
+* [MCP policy examples](mcp-policy-examples.md). Real-world MCP policy patterns.
+* [API policy examples](api-policy-examples.md). API access control patterns.
+* [AI policy example](ai-policy-example.md). Token budget and cost ceiling policies.
+* [Custom policies overview](custom-policies/custom-policies-overview.md). Policies for non-routed resources.

--- a/docs/gamma/4.12/authorization-management/configure/create-update-delete-policies.md
+++ b/docs/gamma/4.12/authorization-management/configure/create-update-delete-policies.md
@@ -66,6 +66,8 @@ Each policy contains one or more statements. Each statement is built from the fo
 | **Agents** | Chip picker of imported agent identities | `context.agent == AgentIdentity::"planner"` |
 | **Condition** | Condition block with snippet insertion | `when { context.time.hour >= 9 }` |
 
+The **Agents** picker does not add a clause of its own. It writes a `context.agent` expression into the **Condition** field and joins it to any text already there with `&&`, so the agent restriction and your own condition are emitted together in a single `when { }` block.
+
 #### Match modes
 
 Each clause supports the following two match modes:
@@ -82,13 +84,13 @@ For principal clauses, the default depends on the following entity types:
 
 #### Multiple entities in a clause
 
-In the **Visual** view, the **Principal** and **Resource** pickers each hold one entity, while the **Action** and **Agents** pickers accept several. When a clause holds multiple entities, GAPL joins them with `in [list]`:
+A GAPL principal or resource scope binds a single entity, so the **Principal** and **Resource** pickers each hold one entity and a new selection replaces the current one. The **Action** and **Agents** pickers accept several entities. When a clause holds multiple entities, GAPL joins them with `in [list]`:
 
 ```
 permit (
-  principal in [User::"alice", User::"bob"],
-  action == Action::"invoke",
-  resource in [MCPTool::"search", MCPTool::"create-issue"]
+  principal == User::"alice",
+  action in [Action::"invoke", Action::"read"],
+  resource == MCPTool::"search"
 );
 ```
 
@@ -153,12 +155,16 @@ A new policy starts with a single empty `permit` statement. The **Code** view re
 
 ```
 // Policy: <policy name>
+// Target: <target name>
+
 permit (
   principal,
   action,
   resource
 );
 ```
+
+The `// Target:` comment is only present for the categories that have a target, which are **MCPs**, **AI Models**, **APIs**, and **A2A Agents**. A custom policy has no target, so its template opens with the `// Policy:` comment alone.
 
 ## Permissions
 

--- a/docs/gamma/4.13/authorization-management/configure/create-update-delete-policies.md
+++ b/docs/gamma/4.13/authorization-management/configure/create-update-delete-policies.md
@@ -1,72 +1,88 @@
 ---
+description: Reference for the Authorization Management policy editor, covering how to create, update, deploy, and delete GAPL policies.
 hidden: false
 noIndex: false
 ---
 
 # Create, update, and delete policies
 
-This is the comprehensive reference for the Authorization Management policy editor. Policies are written in GAPL (Gravitee Authorization Policy Language) and enforced by the gateway's Policy Decision Point.
+This is the comprehensive reference for the Authorization Management policy editor. Policies are written in Gravitee Authorization Policy Language (GAPL) and enforced by the gateway's Policy Decision Point (PDP).
 
 ## Policy editor overview
 
-The policy editor opens as a slide-out panel from any policy management page (MCPs, AI Models, APIs, or Custom Policies). It provides two editing modes:
+The policy editor opens as a slide-out panel from any policy management page: **MCPs**, **AI Models**, **APIs**, **A2A Agents**, or **Custom Policies**. It provides the following two editing modes:
 
 | Mode | Description |
 |------|-------------|
 | **Visual** | Build policies using statement cards with chip pickers for principals, actions, and resources |
 | **Code** | Edit GAPL directly in a Monaco editor with syntax highlighting |
 
-Toggle between modes using the **Visual / Code** toggle in the editor header. If your GAPL uses features the visual editor cannot represent, the Visual toggle is disabled with the explanation: "This policy uses GAPL features that the visual editor cannot represent. Use the Code view to edit it directly."
+Toggle between modes using the **Visual / Code** toggle in the editor header. If your GAPL uses features the visual editor cannot represent, the **Visual** toggle is disabled with the explanation: "This policy uses GAPL features that the visual editor cannot represent. Use the Code view to edit it directly."
 
-## Creating a policy
+## Create a policy
 
-### 1. Choose the policy category
+To create a policy, complete the following steps:
 
-Navigate to the appropriate page under **Policy Management**:
+1. [Choose the policy category](#choose-the-policy-category)
+2. [Open the editor](#open-the-editor)
+3. [Name the policy](#name-the-policy)
+4. [Build statements](#build-statements)
+5. [Add conditions](#add-conditions)
+6. [Set target gateways](#set-target-gateways)
+7. [Save or deploy](#save-or-deploy)
 
-| Page | Policy type | Has target? | Resource groups |
-|------|------------|-------------|-----------------|
-| **MCPs** | `MCP` | Yes (MCP Server) | MCPServer, MCPTool, MCPPrompt, MCPResource |
-| **AI Models** | `MODEL` | Yes (Model) | LLMProvider, Model |
-| **APIs** | `API` | Yes (API) | API, Endpoint, DataField |
-| **Custom Policies** | `CUSTOM` | No | User-defined |
+### Choose the policy category
 
-### 2. Open the editor
+Navigate to the appropriate page under **Policy Management**. The following table lists each page, the policy type it creates, the target it applies to, and the resource groups available to it:
 
-Click the create button (for example, **Create Policy for MCP**). For service policies, you first select a **target** — the specific catalog entry the policy applies to.
+| Page | Policy type | Target | Resource groups |
+|------|------------|--------|-----------------|
+| **MCPs** | `MCP` | MCP Server | MCPServer, MCPTool, MCPPrompt, MCPResource |
+| **AI Models** | `MODEL` | Model | LLMProvider, Model |
+| **APIs** | `API` | API | API, Endpoint, DataField |
+| **A2A Agents** | `AGENT` | Agent | Agent |
+| **Custom Policies** | `CUSTOM` | None | User-defined |
 
-### 3. Name the policy
+### Open the editor
 
-Enter a **Policy name** (required). The status badge shows **Draft**. Add an optional **Description** in the sub-header.
+On the **MCPs**, **AI Models**, **APIs**, or **A2A Agents** page, click **Create policy**. A **Create policy for** dialog opens so you can pick the catalog entry the policy applies to, and then the editor opens.
 
-### 4. Build statements
+On the **Custom Policies** page, click **Create Custom Policy**. The editor opens straight away, because a custom policy has no target.
 
-Each policy contains one or more statements. A statement has:
+### Name the policy
+
+Enter a **Policy name**. The name is required, and the status badge shows **Draft**. The **Description** field is optional.
+
+### Build statements
+
+Each policy contains one or more statements. Each statement is built from the following parts:
 
 | Part | Visual editor | GAPL syntax |
 |------|--------------|-------------|
 | **Effect** | Toggle between `permit` and `forbid` | `permit (…)` or `forbid (…)` |
-| **Principals** | Chip picker from Entities (Principals tab) | `principal == User::"alice"` |
-| **Actions** | Chip picker from the Actions page | `action == Action::"invoke"` |
-| **Resources** | Chip picker scoped by resource group | `resource == MCPTool::"search"` |
+| **Principal** | Chip picker from the **Principals** tab of the **Entities** page | `principal == User::"alice"` |
+| **Action** | Chip picker from the **Actions** page | `action == Action::"invoke"` |
+| **Resource** | Chip picker scoped by resource group | `resource == MCPTool::"search"` |
+| **Agents** | Chip picker of imported agent identities | `context.agent == AgentIdentity::"planner"` |
 | **Condition** | Condition block with snippet insertion | `when { context.time.hour >= 9 }` |
 
 #### Match modes
 
-Each clause supports two match modes:
+Each clause supports the following two match modes:
 
 | Mode | Operator | Use case |
 |------|----------|----------|
 | **Exact** | `==` | Match this specific entity |
 | **Includes** | `in` | Match this entity and its descendants |
 
-For principal clauses, the default depends on the entity type:
-- **Groups and Roles** → `includes` (membership containers)
-- **Users, Service Accounts, Agent Identities** → `exact` (leaf principals)
+For principal clauses, the default depends on the following entity types:
+
+* **Groups and Roles** default to **Includes**. They are membership containers.
+* **Users**, **Service Accounts**, and **Agent Identities** default to **Exact**. They are leaf principals.
 
 #### Multiple entities in a clause
 
-When multiple entities are selected in a single clause, they are joined with `in [list]`:
+In the **Visual** view, the **Principal** and **Resource** pickers each hold one entity, while the **Action** and **Agents** pickers accept several. When a clause holds multiple entities, GAPL joins them with `in [list]`:
 
 ```
 permit (
@@ -76,15 +92,17 @@ permit (
 );
 ```
 
-### 5. Add conditions
+### Add conditions
 
-Click **Add condition** on a statement card. The editor shows pre-built condition snippets specific to the policy category. You can also type custom conditions.
+On a statement card, expand the **Condition** section, which is marked **Optional**. The editor shows pre-built condition snippets specific to the policy category, each one a chip prefixed with a plus sign. You can also type custom conditions.
 
-### 6. Set target gateways
+### Set target gateways
 
-Below the header, the **Target gateways** picker scopes the policy to specific PDP gateways. Select `*` for all gateways, or pick individual targets from registered PDP gateways.
+The **Target gateways** picker scopes the policy to specific PDP gateways. Select **\* (all gateways)** to cover every gateway, or pick individual targets from registered PDP gateways.
 
-### 7. Save or deploy
+### Save or deploy
+
+The following table lists each save and deploy action, the status it produces, and the toast message it shows:
 
 | Action | Status after | Toast message |
 |--------|-------------|---------------|
@@ -94,56 +112,68 @@ Below the header, the **Target gateways** picker scopes the policy to specific P
 | **Deploy to PDP Runtime** | `DEPLOYED` | "Policy deployed. Gateway sync expected within 30s." |
 | **Undeploy** | `DISABLED` | "Policy undeployed. Gateway sync will drop it within 30s." |
 
-## Updating a policy
+## Update a policy
 
-1. On the policy list page, click a policy name to open the editor
-2. Modify statements, conditions, or metadata
-3. Click **Update policy** to save changes
-4. If the policy is deployed, changes take effect after gateway sync (~30 seconds)
+1. On the policy list page, click a policy name to open the editor.
+2. Modify statements, conditions, or metadata.
+3. Click **Update policy** to save your changes.
+4. If the policy is deployed, changes take effect after gateway sync, which takes about 30 seconds.
 
 ## Policy lifecycle states
 
+The following table lists each policy status, what it means, and the transitions available from it:
+
 | Status | Meaning | Transitions |
 |--------|---------|-------------|
-| **Draft** | Saved, not enforced | → Deployed |
-| **Deployed** | Active, enforced by the gateway | → Disabled (via Undeploy) |
-| **Disabled** | Suspended, not enforced | → Deployed (via Deploy) |
+| **Draft** | Saved, not enforced | Deployed |
+| **Deployed** | Active, enforced by the gateway | Disabled, by clicking **Undeploy** |
+| **Disabled** | Suspended, not enforced | Deployed, by clicking **Deploy to PDP Runtime** |
 
 {% hint style="info" %}
-There is no `DEPLOYED → DRAFT` transition. Undeploying writes `DISABLED`. To return to a draft-like state, undeploy and then edit.
+A `DEPLOYED` policy never returns to `DRAFT`. Undeploy writes `DISABLED` instead. To return to a draft-like state, undeploy the policy, and then edit it.
 {% endhint %}
 
-## Deleting a policy
+## Delete a policy
 
-Delete policies from the policy list page using the row-level action menu. Deleting a deployed policy removes it from gateway enforcement on the next sync cycle.
+On the policy list page, delete a policy using the row-level action menu. When you delete a deployed policy, the gateway drops it from enforcement on the next sync cycle.
 
-## Visual ↔ Code round-tripping
+## Round-trip between the Visual and Code views
+
+The following table describes what happens when you switch between the **Visual** and **Code** views:
 
 | Scenario | Behavior |
 |----------|----------|
-| Visual → Code | The generated GAPL is populated in the Monaco editor |
-| Code → Visual | The parser attempts to convert GAPL back to statement cards. If the GAPL uses unsupported features, the Visual toggle is disabled |
+| Visual to Code | The generated GAPL is populated in the Monaco editor |
+| Code to Visual | The parser attempts to convert GAPL back to statement cards. If the GAPL uses unsupported features, the **Visual** toggle is disabled |
 | Code edits while drafting | While drafting a new policy, the code editor mirrors the generated GAPL until you edit directly |
 
 ## GAPL template
 
-New policies start with the default template:
+A new policy starts with a single empty `permit` statement. The **Code** view renders it as the following GAPL, with the policy name as a comment:
 
 ```
-permit (principal, action, resource);
+// Policy: <policy name>
+permit (
+  principal,
+  action,
+  resource
+);
 ```
 
 ## Permissions
 
+The following table lists the permission each policy action requires:
+
 | Action | Required permission |
 |--------|-------------------|
-| Create / Update policy | `ENVIRONMENT_AUTHZ_POLICY[CREATE]` or `[UPDATE]` |
-| Deploy / Undeploy | `ENVIRONMENT_AUTHZ_PDP[UPDATE]` |
-| Delete policy | `ENVIRONMENT_AUTHZ_POLICY[DELETE]` |
+| Create policy | `ENVIRONMENT_AUTHZ_POLICIES[CREATE]` |
+| Update policy | `ENVIRONMENT_AUTHZ_POLICIES[UPDATE]` |
+| Deploy or undeploy | `ENVIRONMENT_AUTHZ_PDP[UPDATE]` |
+| Delete policy | `ENVIRONMENT_AUTHZ_POLICIES[DELETE]` |
 
 ## Next steps
 
-* [MCP policy examples](mcp-policy-examples.md) — Real-world MCP policy patterns
-* [API policy examples](api-policy-examples.md) — API access control patterns
-* [AI policy example](ai-policy-example.md) — Token budget and cost ceiling policies
-* [Custom policies overview](custom-policies/custom-policies-overview.md) — Policies for non-routed resources
+* [MCP policy examples](mcp-policy-examples.md). Real-world MCP policy patterns.
+* [API policy examples](api-policy-examples.md). API access control patterns.
+* [AI policy example](ai-policy-example.md). Token budget and cost ceiling policies.
+* [Custom policies overview](custom-policies/custom-policies-overview.md). Policies for non-routed resources.

--- a/docs/gamma/4.13/authorization-management/configure/create-update-delete-policies.md
+++ b/docs/gamma/4.13/authorization-management/configure/create-update-delete-policies.md
@@ -66,6 +66,8 @@ Each policy contains one or more statements. Each statement is built from the fo
 | **Agents** | Chip picker of imported agent identities | `context.agent == AgentIdentity::"planner"` |
 | **Condition** | Condition block with snippet insertion | `when { context.time.hour >= 9 }` |
 
+The **Agents** picker does not add a clause of its own. It writes a `context.agent` expression into the **Condition** field and joins it to any text already there with `&&`, so the agent restriction and your own condition are emitted together in a single `when { }` block.
+
 #### Match modes
 
 Each clause supports the following two match modes:
@@ -82,13 +84,13 @@ For principal clauses, the default depends on the following entity types:
 
 #### Multiple entities in a clause
 
-In the **Visual** view, the **Principal** and **Resource** pickers each hold one entity, while the **Action** and **Agents** pickers accept several. When a clause holds multiple entities, GAPL joins them with `in [list]`:
+A GAPL principal or resource scope binds a single entity, so the **Principal** and **Resource** pickers each hold one entity and a new selection replaces the current one. The **Action** and **Agents** pickers accept several entities. When a clause holds multiple entities, GAPL joins them with `in [list]`:
 
 ```
 permit (
-  principal in [User::"alice", User::"bob"],
-  action == Action::"invoke",
-  resource in [MCPTool::"search", MCPTool::"create-issue"]
+  principal == User::"alice",
+  action in [Action::"invoke", Action::"read"],
+  resource == MCPTool::"search"
 );
 ```
 
@@ -153,12 +155,16 @@ A new policy starts with a single empty `permit` statement. The **Code** view re
 
 ```
 // Policy: <policy name>
+// Target: <target name>
+
 permit (
   principal,
   action,
   resource
 );
 ```
+
+The `// Target:` comment is only present for the categories that have a target, which are **MCPs**, **AI Models**, **APIs**, and **A2A Agents**. A custom policy has no target, so its template opens with the `// Policy:` comment alone.
 
 ## Permissions
 


### PR DESCRIPTION
## What this is

A Doc Verification Pipeline run over the Authorization Management policy editor reference. Every checkable claim on the page — navigation paths, page and button labels, field names, statuses, toast strings, and GAPL output — was checked against a live 4.12 Gamma console and against the Authorization Management module deployed in that environment.

The live check exercised the full procedure end to end: a policy was created, updated, deployed, undeployed, and deleted. The environment was left with zero policies and zero entities, exactly as it started.

**Target file:** `docs/gamma/4.12/authorization-management/configure/create-update-delete-policies.md`

**4.13:** the 4.13 copy was byte-identical before this change, so it is patched identically in the same commit.

**Images:** the page has no figures, and none were added or removed.

## Verdict table

| # | Claim | Code evidence | Live evidence | Verdict |
|---|---|---|---|---|
| 1 | Editor opens as a slide-out panel from any policy management page | Rendered as a right-side sheet | Confirmed | ✅ Correct |
| 2 | Policy management pages are MCPs, AI Models, APIs, Custom Policies | Five categories are registered, including A2A Agents | Sidebar and pages show all five | ❌ **Fixed** |
| 3 | Category table rows and resource groups | Resource groups match for MCP, AI Model, API and Custom; the A2A Agents row is absent | All five pages present | ❌ **Fixed** (row added) |
| 4 | Create button reads "Create Policy for MCP" | The category-specific label is used only where the category has no target | MCPs / AI Models / APIs / A2A Agents show **Create policy**; Custom Policies shows **Create Custom Policy** | ❌ **Fixed** |
| 5 | Targeted categories ask for a target first | Target picker dialog | Dialog "Create policy for MCP" — "Pick a MCP Server from the catalog." | ✅ Correct |
| 6 | Two editing modes with a Visual / Code toggle | Confirmed | Confirmed | ✅ Correct |
| 7 | Text shown when the Visual toggle is disabled | Verbatim match | Not reproducible without unsupported GAPL | ✅ Correct (code) |
| 8 | Policy name required, Draft badge, optional Description | Name is validated as required | Both fields and the **Draft** badge observed | ✅ Correct |
| 9 | Statement parts: Effect, Principals, Actions, Resources, Condition | An Agents clause also exists | Statement card shows PRINCIPAL, ACTION, RESOURCE, **AGENTS**, CONDITION | ❌ **Fixed** (row added) |
| 10 | Principals come from the Entities page, Principals tab | Empty-state hint points at Entities | Entities page has **Principals** and **Resources** tabs | ✅ Correct |
| 11 | Exact (`==`) and Includes (`in`) match modes | Toggle plus explanatory tooltip | Toggle present | ✅ Correct |
| 12 | Groups and Roles default to includes; Users, Service Accounts, Agent Identities to exact | Confirmed | Not exercised — no entities in this environment | ✅ Correct (code) |
| 13 | Multiple entities in a clause join with `in [list]` | GAPL generator confirms the join, but the Principal and Resource pickers each accept a single entity | Pickers present, empty in this environment | ⚠️ **Clarified** |
| 14 | "Click **Add condition** on a statement card" | No such control exists | Statement card has a collapsible **CONDITION / Optional** section with a textarea and snippet chips | ❌ **Fixed** |
| 15 | Condition snippets are specific to the policy category | Per-category snippet sets | Custom policy chips: Corporate IP range, MFA required, Business hours, Owner only | ✅ Correct |
| 16 | Target gateways picker, `*` selects all gateways | Label confirmed | Dropdown offers **\* (all gateways)** | ✅ Correct |
| 17 | Create policy leaves the policy in Draft with no toast | Confirmed | Created `verify-policy-9234`, status **Draft**, no toast | ✅ Correct |
| 18 | Update policy leaves the status unchanged | Confirmed | Status stayed **Draft** after an edit | ✅ Correct |
| 19 | Deploy sets Deployed and shows "Policy deployed. Gateway sync expected within 30s." | Verbatim match | Toast captured verbatim, status became **Deployed** | ✅ Correct |
| 20 | Undeploy sets Disabled with its own toast | Verbatim match | Status became **Disabled** | ✅ Correct |
| 21 | Create and Deploy sets Deployed with its own toast | Verbatim match | Not exercised | ✅ Correct (code) |
| 22 | Lifecycle states are Draft, Deployed, Disabled | Confirmed | Status filter offers exactly those three | ✅ Correct |
| 23 | No transition from Deployed back to Draft | Undeploy writes Disabled | Undeploy produced **Disabled**, not Draft | ✅ Correct |
| 24 | Clicking a policy name opens the editor; Update policy saves | Confirmed | Confirmed | ✅ Correct |
| 25 | Delete from the row-level action menu | Row menu offers Edit and Delete | Menu observed, delete confirmed through the "Delete policy?" dialog | ✅ Correct |
| 26 | Visual and Code round-tripping behavior | Confirmed | Switched both ways | ✅ Correct |
| 27 | New policies start with the template `permit (principal, action, resource);` | The Code view renders the default statement, not that one-liner | Code view of a new policy shows `// Policy: <name>` followed by a multi-line `permit` statement | ❌ **Fixed** |
| 28 | Permissions table identifiers | The policy permission identifier differs from the one documented; the deploy and undeploy permission is correct | Not user-visible | ❌ **Fixed** |
| 29 | Next steps links resolve | All four target files exist | — | ✅ Correct |

## Changes

**Factual (Step 5):** items 2, 3, 4, 9, 13, 14, 27, and 28 in the table.

**Style pass (Step 6), meaning-preserving:**

* Added the `description` frontmatter.
* Replaced gerund headings with imperatives: Create / Update / Delete a policy, and Round-trip between the Visual and Code views.
* Turned the numbered `### 1.`–`### 7.` subsections into a procedure overview with anchor links and unnumbered subsection headings.
* Removed arrow symbols from the lifecycle and round-tripping tables and from the match-mode list.
* Replaced "via" and parenthetical asides, and put the acronym after its expanded form for GAPL and PDP.
* Added introductory sentences to the tables that lacked one.
* Removed directional language from the Target gateways step.
* Reformatted the Next steps and match-mode bullets so each term ends with a period and its explanation is a separate sentence, keeping the bold term text.

## Notes for the writer

* The page has no screenshots. Several steps would meet an image trigger — the statement card in particular is hard to describe in words — but adding one is a writer's call, so nothing was captured.
* A description typed into the editor when creating a policy did not come back when the policy was reopened. This looks like a product issue rather than a documentation one, so the page is unchanged on that point and it is not reported as a doc defect.
* Two claims could not be exercised live because this environment has no catalog entities: selecting a target for an MCP, AI Model, API, or A2A Agent policy, and picking principals, actions, or resources in a statement. Both are recorded above as code-confirmed rather than live-confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
