### PR TITLE
docs(gamma): verify Create an MCP proxy against 4.12

### DIFF
--- a/docs/gamma/4.12/agent-management/build/create-an-mcp-proxy.md
+++ b/docs/gamma/4.12/agent-management/build/create-an-mcp-proxy.md
@@ -1,11 +1,12 @@
 ---
 hidden: false
 noIndex: false
+description: Create an MCP proxy in Gravitee to add governance to an upstream MCP server.
 ---
 
 # Create an MCP proxy
 
-An MCP Proxy sits in front of an upstream MCP server and applies governance — authentication, fine-grained authorization, observability, and rate limiting — to every tool invocation. The proxy speaks protocol-native MCP (JSON-RPC 2.0), operates on typed MCP objects (tool name, arguments, resource URI), and supports OAuth authorization discovery.
+An MCP Proxy sits in front of an upstream MCP server and applies governance—authentication, fine-grained authorization, observability, and rate limiting—to every tool invocation. The proxy speaks protocol-native MCP, JSON-RPC 2.0. It operates on typed MCP objects—tool name, arguments, and resource URI—and supports OAuth authorization discovery.
 
 {% hint style="info" %}
 For a quickstart with minimal configuration, see [Create your first MCP server](../get-started/create-your-first-mcp-server.md).
@@ -17,66 +18,76 @@ The MCP Proxy operates in two modes:
 
 {% tabs %}
 {% tab title="Proxy mode" %}
-A transparent intermediary in front of an existing upstream MCP server. Proxy mode adds governance without changing the server — like a classic API proxy for MCP traffic.
+A transparent intermediary in front of an existing upstream MCP server. Proxy mode adds governance without changing the server—like a classic API proxy for MCP traffic.
 
-**Use case:** You have an upstream MCP server (HubSpot, GitHub, Salesforce) and want to add authentication, authorization, and observability without modifying the server.
+**Use case:** You have an upstream MCP server, such as HubSpot, GitHub, or Salesforce, and want to add authentication, authorization, and observability without modifying the server.
 {% endtab %}
 
 {% tab title="Studio mode" %}
-An authoring environment for Composite MCP Servers. In Studio mode, you compose tools, resources, prompts, and skills from multiple sources into a new MCP server that didn't exist as a single unit upstream.
+An authoring environment that assembles catalog tools into a unified MCP entrypoint. In Studio mode, you select tools from the catalog to expose through a new MCP server that didn't exist as a single unit upstream.
 
 For Studio mode, see [Create an MCP Studio](create-an-mcp-studio.md).
 {% endtab %}
 {% endtabs %}
 
-## Step 1: Open the MCP Proxy wizard
+## Create the MCP proxy
+
+To create an MCP proxy, complete the following steps:
+
+1. [Open the MCP Proxy wizard](#open-the-mcp-proxy-wizard)
+2. [Define your proxy](#define-your-proxy)
+3. [Configure consumer security](#configure-consumer-security)
+4. [Connect to the upstream MCP server](#connect-to-the-upstream-mcp-server)
+5. [Review and create](#review-and-create)
+
+### Open the MCP Proxy wizard
 
 1. From the Gamma console sidebar, select **Agent Management**.
-2. Navigate to **Build**.
-3. Select **Create MCP Proxy**.
+2. Under **Secure**, select **MCP Proxies**.
+3. Select **+ Create MCP proxy**.
 
-## Step 2: Define your proxy
+### Define your proxy
 
 1. Choose **Proxy mode** to act as a transparent intermediary for an existing MCP server.
 2. Provide a **Name** and an optional **Description**.
-3. Enter the **Context path** (the URL path prefix clients will use to reach this proxy).
+3. Enter the **Context path**, the URL path prefix clients use to reach this proxy.
 
-## Step 3: Configure consumer security
+### Configure consumer security
 
-Choose how clients authenticate to the proxy entrypoint:
+Choose how clients authenticate to the proxy entrypoint. The wizard offers the following methods:
 
-| Security method                     | Description                                                                                             |
-| ----------------------------------- | ------------------------------------------------------------------------------------------------------- |
-| **Gravitee as Authorization Server**| Uses Gravitee Identity & Access Management to secure access, handling OAuth token issuance. (Recommended)|
-| **External Authorization Server**   | Use an external identity provider (Auth0, Keycloak, PingFederate, etc.) as your authorization server.   |
-| **API Key**                         | Use a shared key for server access when user-level identity is not available.                           |
-| **Passthrough**                     | Gravitee passes all requests through without enforcing any authentication.                              |
+| Security method                      | Description                                                                                                 |
+| ------------------------------------ | ----------------------------------------------------------------------------------------------------------- |
+| **Gravitee as Authorization Server** | Uses Gravitee Identity & Access Management to secure access, handling OAuth token issuance. Recommended.     |
+| **External Authorization Server**    | Use an external identity provider, such as Auth0, Keycloak, or PingFederate, as your authorization server.   |
+| **API Key**                          | Use a shared key for server access when user-level identity is not available.                               |
+| **Passthrough**                      | Gravitee passes all requests through without enforcing any authentication.                                  |
 
-## Step 4: Configure upstream authentication
+### Connect to the upstream MCP server
 
-Configure how the proxy authenticates with the upstream MCP server:
+Enter the **Server URL** of the upstream MCP endpoint, and then choose how the Gateway authenticates to that server at runtime. The wizard offers the following methods:
 
-| Method                 | Description                                                                 |
-| ---------------------- | --------------------------------------------------------------------------- |
-| **Static credential**  | Inject a static credential (API key, Bearer token, Basic auth, or Custom secret) into a request header on every call. |
-| **No upstream auth**   | Call the upstream without injecting credentials (passthrough).              |
+| Method                | Description                                                                                              |
+| --------------------- | -------------------------------------------------------------------------------------------------------- |
+| **Static credential** | Inject a static credential—API key, Bearer token, Basic auth, or Custom secret—into a request header on every call. |
+| **No upstream auth**  | Call the upstream without injecting credentials.                                                         |
 
-## Step 5: Review and create
+### Review and create
 
-Review the MCP Proxy configuration — including security and upstream authentication — then select **Create**.
+Review the MCP Proxy configuration, including security and upstream authentication. Then select **Create only** to register the proxy without deploying it, or **Create & deploy** to register and deploy it in one step.
 
-The MCP Proxy is created and registered in the AI Gateway. Every tool invocation through this proxy is now subject to the configured authentication, policies, and observability.
+**Create only** leaves the proxy stopped and out of sync. Select **Deploy** on the proxy overview to push it to the AI Gateway. Once the proxy is deployed, every tool invocation through it is subject to the configured authentication, policies, and observability.
 
 ## After creation
 
-Once the MCP Proxy is created, you can:
+Once the MCP Proxy is created, you can do the following:
 
-* **Add authorization policies** — Control which consumers can invoke specific tools. See [Add policies to your MCP server](configure-your-mcp/add-policies-to-mcp-server.md).
-* **Configure mediation** — Set up token exchange and credential management for upstream OAuth. See [Configure your MCP proxy](configure-your-mcp/README.md).
-* **View in the Catalog** — The MCP Proxy appears in the API Management console alongside API proxies.
+* **Add authorization policies**. Control which consumers can invoke specific tools. See [Add policies to your MCP server](configure-your-mcp/add-policies-to-mcp-server.md).
+* **Configure upstream authentication**. Manage the credentials the Gateway injects when it calls the upstream server. See [Configure your MCP proxy](configure-your-mcp/README.md).
+* **Backing API**. Gravitee backs each MCP Proxy with an API in API Management. Deleting the MCP Proxy also deletes that API.
 
 ## Next steps
 
-* [Configure your MCP proxy](configure-your-mcp/README.md) — Set up mediation and advanced configuration.
-* [Add policies to your MCP server](configure-your-mcp/add-policies-to-mcp-server.md) — Apply fine-grained authorization.
-* [Create an MCP Studio](create-an-mcp-studio.md) — Compose tools from this server with tools from other sources.
+* [Configure your MCP proxy](configure-your-mcp/README.md). Configure upstream authentication and other advanced settings.
+* [Add policies to your MCP server](configure-your-mcp/add-policies-to-mcp-server.md). Apply fine-grained authorization.
+* [Create an MCP Studio](create-an-mcp-studio.md). Compose tools from this server with tools from other sources.


### PR DESCRIPTION
Doc Verification Pipeline run on `docs/gamma/4.12/agent-management/build/create-an-mcp-proxy.md`.

Verified against a running Gamma 4.12 console (Agent Management, Enterprise licence) by walking the MCP proxy creation wizard end to end, plus a cross-check against the shipped Agent Management module.

## Step 4 verdict table

| # | Claim | Code truth | Live truth | Verdict |
|---|---|---|---|---|
| 1 | The MCP Proxy operates in two modes, Proxy and Studio | Mode has exactly two values | Wizard "Choose a mode" offers **Proxy mode** and **Studio mode** | Confirmed |
| 2 | Proxy mode is a transparent intermediary that adds governance without changing the server | Consistent | Card reads "Connect to an upstream MCP endpoint — Expose any MCP endpoint with security, observability, and traffic policies" | Confirmed |
| 3 | Studio mode is "an authoring environment for Composite MCP Servers" | "Composite MCP Server" appears nowhere in the shipped module | Studio card reads "Compose assets from the catalog"; wizard subtitle is "Assemble catalog tools into a unified MCP entrypoint" | **Contradicted — fixed** |
| 4 | In Studio mode you compose tools, resources, prompts, and skills | — | The Compose step reads "Select tools to expose through this MCP entrypoint" and offers tools only | **Contradicted — fixed** |
| 5 | Navigate to **Build**, then select **Create MCP Proxy** | Navigation groups are General, Catalog, Secure, Observability | There is no **Build** group. MCP Proxies sits under **Secure**, and the button reads **+ Create MCP proxy** | **Contradicted — fixed** |
| 6 | Define step asks for Name, optional Description, and Context path | Consistent | "General information" shows Name, Entity ID (read-only, derived from the name), Description, and Context path | Confirmed. Entity ID is undocumented — noted, not edited |
| 7 | Consumer security offers Gravitee as Authorization Server (recommended), External Authorization Server, API Key, and Passthrough | Consistent | The Secure step lists exactly those four, with matching descriptions | Confirmed |
| 8 | Upstream auth offers Static credential (API key, Bearer token, Basic auth, Custom secret) and No upstream auth | Consistent | Connect step offers **Static credential** and **No upstream auth**; Credential type lists API key, Bearer token, Basic auth, Custom secret | Confirmed |
| 9 | The upstream step covers authentication only | The connection payload requires a server URL | The step is **Connect to upstream MCP server** and **Server URL** is required | **Contradicted — fixed** |
| 10 | The page presents five numbered steps | Wizard defines four steps | Stepper reads Define, Secure, Connect, Review | **Partially contradicted — fixed.** The page's old Steps 3 and 4 are one wizard step |
| 11 | "Review the configuration, then select **Create**" | Create carries a deploy flag | Review footer offers **Create only** and **Create & deploy**; there is no **Create** | **Contradicted — fixed** |
| 12 | "The MCP Proxy is created and registered in the AI Gateway. Every tool invocation through this proxy is now subject to…" | Deploy flag governs whether it goes live | After **Create only** the proxy is **Stopped**, with "This deployable is out of sync. Your latest changes are not live yet. Deploy to push them to the gateway." | **Contradicted — fixed** |
| 13 | "Configure mediation — token exchange and credential management for upstream OAuth" | No such capability in the shipped module | The only upstream options are static credential injection and no upstream auth; the linked page documents static credentials only | **Contradicted — fixed** |
| 14 | "The MCP Proxy appears in the API Management console alongside API proxies" | The proxy is backed by an API Management API | The API Management **API Proxies** list excludes MCP proxies. The proxy's own delete dialog states it removes the proxy "and its APIM API" | **Contradicted — fixed** |
| 15 | All relative links resolve | — | Every target file exists in the 4.12 tree | Confirmed |
| 16 | Images | — | The page contains no figures | Not applicable |
| 17 | "Every tool invocation is subject to the configured authentication, policies, and observability" | — | Not observable: this environment has no gateway and no upstream MCP server | **Not determined** — left as written, scoped to the deployed proxy |

## What changed

Meaning-level fixes are limited to rows 3, 4, 5, 9, 10, 11, 12, 13, and 14. The rest of the diff is the style pass over the whole page: added the missing `description` frontmatter, converted the numbered `## Step N:` headings into a procedure overview with anchor links and `###` subsections, removed parentheses used for asides, replaced Latin abbreviations, and tightened em dash spacing.

## Version parity

`docs/gamma/4.13/.../create-an-mcp-proxy.md` already diverged from 4.12 before this run and already carried most of these corrections, so it was left untouched per the both-versions convention.

## For the writer

* The **Entity ID** field on the Define step is read-only and derived from the name, and the page doesn't mention it. Not a contradiction, so it wasn't edited in.
* The page has no screenshots. The wizard is a multi-screen flow where a reader arrives somewhere new, so one screenshot on the first step would meet the image trigger — that's a writer's call, not a pipeline edit.
