### PR TITLE
docs(gamma): verify Create API tools against 4.12 and fix console labels

### DIFF
--- a/docs/gamma/4.12/agent-management/import/create-api-tools.md
+++ b/docs/gamma/4.12/agent-management/import/create-api-tools.md
@@ -1,49 +1,44 @@
 ---
+description: Expose REST APIs governed in API Management as agent-accessible API tools in the Agent Management Catalog.
 hidden: false
 noIndex: false
 ---
 
 # Create API tools
 
-API tools bridge API Management and Agent Management. They expose REST APIs governed in API Management as agent-accessible tools in the Catalog, so agents can invoke your existing APIs through MCP without the APIs needing to learn MCP.
+API tools bridge API Management and Agent Management. They expose REST APIs governed in API Management as agent-accessible tools in the Catalog. Agents can then invoke your existing APIs through MCP without the APIs needing to learn MCP.
 
 ## How it works
 
-The conversion path:
+The conversion path includes the following stages:
 
-1. A REST API is created and governed in **API Management** (see [Create an API proxy](../../api-management/build/create-an-api-proxy.md))
-2. The API is exposed as an **API Tool** in the Catalog
-3. The API Tool becomes available as a building block in **MCP Studio** alongside MCP-native tools, resources, prompts, and skills
+1. A REST API is created and governed in **API Management**. See [Create an API proxy](../../api-management/build/create-an-api-proxy.md).
+2. The API is exposed as an **API tool** in the Catalog.
+3. The API tool becomes available as a building block in **MCP Studio** alongside MCP-native tools, resources, prompts, and skills.
 
-This bridge means that the enterprise APIs you've already built and governed — including their security plans, rate limits, and policies — become agent-accessible without redevelopment.
+This bridge means that the enterprise APIs you've already built and governed—including their security plans, rate limits, and policies—become agent-accessible without redevelopment.
 
 ## Create an API tool
 
 1. From the Gamma console sidebar, select **Agent Management**.
-2. Navigate to the **Catalog** → **Tools** list.
-3. Select **Add Tool**, then choose **API Tool**.
-4. **Step 1: Pick sources**
-   - Search for one or more APIs with an OpenAPI documentation to shape the tool. Selected APIs display their version and active security plans.
-   - Alternatively, use **Add from OAS** to paste an OpenAPI URL or upload a spec file.
-5. **Step 2: Choose capabilities**
-   - For each selected API source, review the available endpoints (capabilities) detected from its documentation.
-   - Select the specific endpoints (e.g., `GET /pets`) you want to transform into tools.
-   - You can review and adjust the generated **Tool name** and **Tool description** to ensure agents understand when and how to invoke the tool.
-6. **Step 3: Review**
-   - Confirm the selected capabilities and APIs.
-7. Select **Save**.
+2. In the **Catalog** section, select **Tools**.
+3. Select **Create tool**, and then choose **API tool**.
+4. On the **Pick sources** step, search for one or more APIs that have OpenAPI documentation to shape the tool. Selected APIs display their version and their published security plans.
+5. On the **Choose capabilities** step, review the endpoints, or capabilities, detected from each selected API source, and then select the specific endpoints, such as `GET /pets`, that you want to transform into tools.
+6. Review and adjust the generated **Tool name** and **Tool description** to ensure agents understand when and how to invoke the tool.
+7. On the **Review** step, confirm the selected capabilities and APIs.
+8. Select **Create API tool**.
 
 The capabilities are extracted, analyzed, and added to the Catalog as individual tools. They become available in MCP Studio's tool palette.
 
-## What an API Tool inherits
+## What an API tool inherits
 
-When you create an API Tool from an API proxy, the tool inherits:
+When you create an API tool from an API proxy, the tool inherits the following:
 
-* **Security plans** — The API Tool carries over the `planSecurityTypes` of the source API (e.g., `API_KEY`, `JWT`, `KEY_LESS`, `OAUTH2`). Agents invoking the tool must satisfy these requirements.
-* **Endpoint configuration** — The API Tool routes through the API Gateway, preserving existing backend security and upstream configuration.
-* **Policies** — Request/response policies applied to the source API continue to execute.
+* **Security plans**. The API tool carries over the security types of the source API's published plans, such as API Key, JWT, Keyless, OAuth2, or mTLS. Agents invoking the tool must satisfy these requirements.
+* **Endpoint configuration**. The API tool routes through the API Gateway, preserving existing backend security and upstream configuration.
+* **Policies**. Request and response policies applied to the source API continue to execute.
 
 ## Next steps
 
-* **Compose into a Studio** — Include API Tools in a Composite MCP Server alongside MCP-native tools. See [Create an MCP Studio](../build/create-an-mcp-studio.md).
-
+* **Compose into a Studio**. Include API tools in a Composite MCP Server alongside MCP-native tools. See [Create an MCP Studio](../build/create-an-mcp-studio.md).

--- a/docs/gamma/4.13/agent-management/import/create-api-tools.md
+++ b/docs/gamma/4.13/agent-management/import/create-api-tools.md
@@ -1,49 +1,44 @@
 ---
+description: Expose REST APIs governed in API Management as agent-accessible API tools in the Agent Management Catalog.
 hidden: false
 noIndex: false
 ---
 
 # Create API tools
 
-API tools bridge API Management and Agent Management. They expose REST APIs governed in API Management as agent-accessible tools in the Catalog, so agents can invoke your existing APIs through MCP without the APIs needing to learn MCP.
+API tools bridge API Management and Agent Management. They expose REST APIs governed in API Management as agent-accessible tools in the Catalog. Agents can then invoke your existing APIs through MCP without the APIs needing to learn MCP.
 
 ## How it works
 
-The conversion path:
+The conversion path includes the following stages:
 
-1. A REST API is created and governed in **API Management** (see [Create an API proxy](../../api-management/build/create-an-api-proxy.md))
-2. The API is exposed as an **API Tool** in the Catalog
-3. The API Tool becomes available as a building block in **MCP Studio** alongside MCP-native tools, resources, prompts, and skills
+1. A REST API is created and governed in **API Management**. See [Create an API proxy](../../api-management/build/create-an-api-proxy.md).
+2. The API is exposed as an **API tool** in the Catalog.
+3. The API tool becomes available as a building block in **MCP Studio** alongside MCP-native tools, resources, prompts, and skills.
 
-This bridge means that the enterprise APIs you've already built and governed — including their security plans, rate limits, and policies — become agent-accessible without redevelopment.
+This bridge means that the enterprise APIs you've already built and governed—including their security plans, rate limits, and policies—become agent-accessible without redevelopment.
 
 ## Create an API tool
 
 1. From the Gamma console sidebar, select **Agent Management**.
-2. Navigate to the **Catalog** → **Tools** list.
-3. Select **Add Tool**, then choose **API Tool**.
-4. **Step 1: Pick sources**
-   - Search for one or more APIs with an OpenAPI documentation to shape the tool. Selected APIs display their version and active security plans.
-   - Alternatively, use **Add from OAS** to paste an OpenAPI URL or upload a spec file.
-5. **Step 2: Choose capabilities**
-   - For each selected API source, review the available endpoints (capabilities) detected from its documentation.
-   - Select the specific endpoints (e.g., `GET /pets`) you want to transform into tools.
-   - You can review and adjust the generated **Tool name** and **Tool description** to ensure agents understand when and how to invoke the tool.
-6. **Step 3: Review**
-   - Confirm the selected capabilities and APIs.
-7. Select **Save**.
+2. In the **Catalog** section, select **Tools**.
+3. Select **Create tool**, and then choose **API tool**.
+4. On the **Pick sources** step, search for one or more APIs that have OpenAPI documentation to shape the tool. Selected APIs display their version and their published security plans.
+5. On the **Choose capabilities** step, review the endpoints, or capabilities, detected from each selected API source, and then select the specific endpoints, such as `GET /pets`, that you want to transform into tools.
+6. Review and adjust the generated **Tool name** and **Tool description** to ensure agents understand when and how to invoke the tool.
+7. On the **Review** step, confirm the selected capabilities and APIs.
+8. Select **Create API tool**.
 
 The capabilities are extracted, analyzed, and added to the Catalog as individual tools. They become available in MCP Studio's tool palette.
 
-## What an API Tool inherits
+## What an API tool inherits
 
-When you create an API Tool from an API proxy, the tool inherits:
+When you create an API tool from an API proxy, the tool inherits the following:
 
-* **Security plans** — The API Tool carries over the `planSecurityTypes` of the source API (e.g., `API_KEY`, `JWT`, `KEY_LESS`, `OAUTH2`). Agents invoking the tool must satisfy these requirements.
-* **Endpoint configuration** — The API Tool routes through the API Gateway, preserving existing backend security and upstream configuration.
-* **Policies** — Request/response policies applied to the source API continue to execute.
+* **Security plans**. The API tool carries over the security types of the source API's published plans, such as API Key, JWT, Keyless, OAuth2, or mTLS. Agents invoking the tool must satisfy these requirements.
+* **Endpoint configuration**. The API tool routes through the API Gateway, preserving existing backend security and upstream configuration.
+* **Policies**. Request and response policies applied to the source API continue to execute.
 
 ## Next steps
 
-* **Compose into a Studio** — Include API Tools in a Composite MCP Server alongside MCP-native tools. See [Create an MCP Studio](../build/create-an-mcp-studio.md).
-
+* **Compose into a Studio**. Include API tools in a Composite MCP Server alongside MCP-native tools. See [Create an MCP Studio](../build/create-an-mcp-studio.md).


### PR DESCRIPTION
## Summary

Verified `docs/gamma/4.12/agent-management/import/create-api-tools.md` against a live Gamma 4.12 console and the deployed Agent Management module, then fixed the claims that did not match.

The procedure was executed end to end: an HTTP proxy API with OpenAPI documentation was created in API Management, run through the **Create API tool** wizard, and the resulting tool was confirmed in the Catalog and in the MCP Studio composition step.

The 4.13 copy of this page was byte-identical before the edit, so the same change is applied to both versions in this PR.

## Verdict table

| # | Claim | Code truth | Live truth | Verdict |
|---|---|---|---|---|
| 1 | Sidebar: select **Agent Management** | Confirmed | Confirmed | OK |
| 2 | Navigate to **Catalog** → **Tools** | Confirmed | **Catalog** section contains **Tools** | OK (arrow removed for style) |
| 3 | Button label **Add Tool** | Contradicted | Button reads **Create tool** | **Fixed** |
| 4 | Tool type **API Tool** | Contradicted (casing) | Card reads **API tool** | **Fixed** |
| 5 | Wizard has 3 steps, in order Sources, Capabilities, Review | Confirmed | Confirmed | OK |
| 6 | Step 1 panel heading **Pick sources** | Confirmed | Confirmed | OK |
| 7 | "Search for one or more APIs with an OpenAPI documentation" | Confirmed | Confirmed | OK |
| 8 | Selected APIs display version and active security plans | Confirmed | Version badge plus a badge per published plan security type | OK (wording tightened to "published") |
| 9 | Alternative import route in step 1 | Contradicted | Could not be exercised in 4.12 | **Fixed** (bullet removed) |
| 10 | Step 2 panel heading **Choose capabilities** | Confirmed | Confirmed | OK |
| 11 | Endpoints detected from the API's documentation, selectable individually | Confirmed | Confirmed (`GET /pets`, `POST /pets`, `GET /pets/{petId}`) | OK |
| 12 | **Tool name** and **Tool description** are editable | Confirmed | Confirmed | OK |
| 13 | Step 3 panel heading **Review**, confirms capabilities and APIs | Confirmed | Confirmed | OK |
| 14 | Final action is **Save** | Contradicted | Button reads **Create API tool** | **Fixed** |
| 15 | Capabilities are added to the Catalog as individual tools | Confirmed | Tool appears in the Catalog with type **API tool** | OK |
| 16 | API tool is a building block in MCP Studio alongside tools, resources, prompts, and skills | Confirmed | Appears in the Studio **Compose** step | OK |
| 17 | Tool inherits the source API's security plans | Confirmed | Plan security types shown against the source | OK (example values corrected) |
| 18 | Tool routes through the API Gateway, preserving backend security and upstream config | Not determined | Not determined | Unchanged |
| 19 | Request and response policies of the source API continue to execute | Not determined | Not determined | Unchanged |

Rows 18 and 19 need real traffic through a running gateway and a live upstream. Neither was available in the verification environment, so both claims were left exactly as written rather than confirmed or contradicted.

The page carries no figures, so no image work was in scope.

## What changed

* Corrected the two button labels the procedure depends on: **Create tool** to open the picker, and **Create API tool** to finish the wizard.
* Corrected the tool type label to **API tool**, and normalized "API Tool" to "API tool" throughout to match the console.
* Rewrote the numbered procedure so each wizard step is an action the reader performs, naming the **Pick sources**, **Choose capabilities**, and **Review** panels.
* Removed a step 1 bullet describing an alternative import route that could not be exercised in the verified 4.12 environment.
* Replaced an internal field name and its example values in the "Security plans" bullet with the plan security types the console actually shows, and changed "active" to "published" to match how the wizard selects them.
* Added the required `description:` frontmatter.
* Whole-document style pass: parentheses removed except around acronyms, Latin abbreviations replaced, arrow symbol replaced with words, list introductions given the "following" form with a colon, bulleted term/explanation pairs separated into sentences with the bold term kept, and unspaced em dashes.

## Notes for the writer

* The procedure never names the two controls that advance the wizard between steps, so a reader following it literally stops after selecting sources. Left unedited, since it is an omission rather than a contradiction.
* The **Choose capabilities** step also exposes behavioral annotations and a generated input schema for each tool, neither of which the page mentions.
* The page does not state which APIs qualify as sources. The wizard only lists HTTP proxy APIs that publish at least one OpenAPI documentation page.
* "Composite MCP Server" and "tool palette" are documentation terms rather than console labels. They are used consistently across the Gamma page set, so they were left alone here rather than changed on one page.
