### PR TITLE
docs(gamma): correct the Manage applications page against the 4.12 console

### DIFF
--- a/docs/gamma/4.12/platform-management/manage-applications.md
+++ b/docs/gamma/4.12/platform-management/manage-applications.md
@@ -1,4 +1,7 @@
 ---
+description: >-
+  View, create, and manage the consumer applications that subscribe to your API
+  plans from the Applications page in the Gamma console.
 hidden: false
 noIndex: false
 ---
@@ -9,56 +12,54 @@ Applications represent external consumers that call your APIs. The Applications 
 
 ## View applications
 
-From the Gamma console sidebar, select **Platform Management**, then navigate to **Applications**. The page header shows KPI tiles for **Active applications** and **Archived applications** counts.
+From the Gamma console sidebar, select **Platform Management**, and then navigate to **Applications**. The page header shows KPI tiles for the **Active applications** and **Archived applications** counts.
 
-The applications table displays:
+The applications table displays the following columns:
 
-* **Name** — Application name (sortable)
-* **Type** — Application type (Backend, Service, Web, etc.)
-* **Owner** — The user who created the application
-* **Actions** — Edit and management actions
+* **Name**. The application name. You can sort the table on this column.
+* **Type**. The application type, such as Backend, Service, or Web.
+* **Owner**. The user who created the application.
+* **Actions**. A row menu that contains the **View Details** and **Manage Subscriptions** actions.
 
-Use the search bar to filter applications by name. The **Active/Archived** dropdown filter toggles between active and archived application views. When viewing archived applications, you can restore them directly from the table using the restore action. The list supports pagination for large application sets.
+Use the search bar to filter applications by name. The **Active**/**Archived** dropdown filter toggles between the active and archived application views. The archived view lists each application with the date it was archived, and you can restore an application directly from its row. The **View** control chooses which columns the table displays, and the list supports pagination for large application sets.
 
 <figure><img src="https://3745118555-files.gitbook.io/~/files/v0/b/gitbook-x-prod.appspot.com/o/spaces%2Fa6QVD3iIxTvnV5eQ8OH1%2Fuploads%2Fgit-blob-1763f30d911da54e240765f4394566d04264e60d%2Fgamma-platform-applications.png?alt=media" alt="Platform Applications page showing a searchable table of consumer applications with type and owner columns"><figcaption><p>The Applications page lists all consumer applications with their type (Backend, Service, Web) and owner. Use the search bar and Active/Archived filter to find specific applications.</p></figcaption></figure>
 
 ## Create an application
 
+To create an application, complete the following steps:
 
-1. Select **Register Application** from the applications list.
-2. Enter the application details:
+1. From the applications list, select **Register Application**.
+2. In the **General** section, enter the application details described in the following table:
 
-| Field           | Description                                                      | Required |
-| --------------- | ---------------------------------------------------------------- | -------- |
-| **Name**        | A human-readable name to identify the application.               | Yes      |
-| **Description** | Freeform text describing the application's purpose.              | Yes      |
-| **Domain**      | The domain associated with this application.                     | No       |
-| **Groups**      | Assign the application to one or more groups for access control. | No       |
+    | Field           | Description                                         | Required |
+    | --------------- | --------------------------------------------------- | -------- |
+    | **Name**        | A human-readable name to identify the application.  | Yes      |
+    | **Description** | Freeform text describing the application's purpose. | Yes      |
+    | **Domain**      | The domain associated with this application.        | No       |
 
-3. Select the application type:
+3. In the **Security** section, select the application type. **Simple** is a standalone client for which you manage your own client ID. Additional OAuth application types are available only when Dynamic Client Registration is enabled for the environment.
+4. Complete the remaining **Security** fields described in the following table:
 
-| Type                   | Description                                                             | Redirect URIs required |
-| ---------------------- | ----------------------------------------------------------------------- | ---------------------- |
-| **Simple**             | Basic application with an optional client ID. No OAuth grant types.     | No                     |
-| **SPA (Browser)**      | Single-page application. Default grant type: Authorization Code.        | Yes                    |
-| **Web**                | Server-side web application. Default grant type: Authorization Code.    | Yes                    |
-| **Native**             | Mobile or desktop application. Default grant type: Authorization Code.  | Yes                    |
-| **Backend-to-Backend** | Machine-to-machine application. Default grant type: Client Credentials. | No                     |
+    | Field                              | Description                                                                                                   | Required |
+    | ---------------------------------- | ------------------------------------------------------------------------------------------------------------- | -------- |
+    | **Type**                           | A freeform descriptor of the application, such as mobile or web.                                              | No       |
+    | **Client ID**                      | The client ID of the application. This field is required to subscribe to certain types of API plan, such as OAuth2 and JWT. | No       |
+    | **Client Certificate (PEM Only)**  | The PEM-encoded client certificate of the application. This field is required to subscribe to certain mTLS plans. | No       |
 
-4. For OAuth-enabled types (SPA, Web, Native, Backend-to-Backend), configure grant types and redirect URIs as required.
-5. For TLS-based authentication, upload a client certificate in the TLS settings section.
-6. Select **Create** to register the application.
+5. Select **Create Application**.
 
 ## Application details
 
-Select an application from the list to view its detail page, which includes:
+Select an application from the list to open its detail page, which contains the following sections:
 
-* **General** — Name, description, type, domain, group membership, client ID, certificates, and metadata. The metadata editor includes built-in safeguards to highlight and prevent saving duplicate custom keys.
-* **User Permissions** — Manage direct members, configure group access, and transfer application ownership.
-* **Notifications** — Configure email and webhook notifications for application events.
-* **Subscriptions** — Active subscriptions to API plans. View subscription status, manage API keys, and see subscription history.
+* **Overview**. A setup checklist for the application and a snapshot of its subscription counts.
+* **General**. The application name, description, domain, images, owner, creation date, type, API key mode, client ID, and mTLS client certificates. This section also holds the action that archives the application.
+* **User Permissions**. Manage direct members, configure group access, and transfer application ownership.
+* **Subscriptions**. The plans this application subscribes to. Create a subscription, filter by API and status, search by API key, and review each subscription's status and dates.
+* **Notification settings**. Configure the events that trigger a notifier for this application, using either the default email notifier or the default webhook notifier. This section also holds the custom metadata available in notification templates. The metadata editor rejects a duplicate key and reports that the metadata already exists.
 
 ## Next steps
 
-* [Manage resources](manage-resources.md) — Configure shared resources used across your APIs.
-* [Establish consumer access](../api-management/build/configure-your-api-proxy/establish-consumer-access.md) — Set up subscriptions between applications and API plans.
+* [Manage resources](manage-resources.md). Configure shared resources used across your APIs.
+* [Establish consumer access](../api-management/build/configure-your-api-proxy/establish-consumer-access.md). Configure subscriptions between applications and API plans.

--- a/docs/gamma/4.13/platform-management/manage-applications.md
+++ b/docs/gamma/4.13/platform-management/manage-applications.md
@@ -1,4 +1,7 @@
 ---
+description: >-
+  View, create, and manage the consumer applications that subscribe to your API
+  plans from the Applications page in the Gamma console.
 hidden: false
 noIndex: false
 ---
@@ -9,56 +12,54 @@ Applications represent external consumers that call your APIs. The Applications 
 
 ## View applications
 
-From the Gamma console sidebar, select **Platform Management**, then navigate to **Applications**. The page header shows KPI tiles for **Active applications** and **Archived applications** counts.
+From the Gamma console sidebar, select **Platform Management**, and then navigate to **Applications**. The page header shows KPI tiles for the **Active applications** and **Archived applications** counts.
 
-The applications table displays:
+The applications table displays the following columns:
 
-* **Name** — Application name (sortable)
-* **Type** — Application type (Backend, Service, Web, etc.)
-* **Owner** — The user who created the application
-* **Actions** — Edit and management actions
+* **Name**. The application name. You can sort the table on this column.
+* **Type**. The application type, such as Backend, Service, or Web.
+* **Owner**. The user who created the application.
+* **Actions**. A row menu that contains the **View Details** and **Manage Subscriptions** actions.
 
-Use the search bar to filter applications by name. The **Active/Archived** dropdown filter toggles between active and archived application views. When viewing archived applications, you can restore them directly from the table using the restore action. The list supports pagination for large application sets.
+Use the search bar to filter applications by name. The **Active**/**Archived** dropdown filter toggles between the active and archived application views. The archived view lists each application with the date it was archived, and you can restore an application directly from its row. The **View** control chooses which columns the table displays, and the list supports pagination for large application sets.
 
 <figure><img src="https://3745118555-files.gitbook.io/~/files/v0/b/gitbook-x-prod.appspot.com/o/spaces%2Fa6QVD3iIxTvnV5eQ8OH1%2Fuploads%2Fgit-blob-1763f30d911da54e240765f4394566d04264e60d%2Fgamma-platform-applications.png?alt=media" alt="Platform Applications page showing a searchable table of consumer applications with type and owner columns"><figcaption><p>The Applications page lists all consumer applications with their type (Backend, Service, Web) and owner. Use the search bar and Active/Archived filter to find specific applications.</p></figcaption></figure>
 
 ## Create an application
 
+To create an application, complete the following steps:
 
-1. Select **Register Application** from the applications list.
-2. Enter the application details:
+1. From the applications list, select **Register Application**.
+2. In the **General** section, enter the application details described in the following table:
 
-| Field           | Description                                                      | Required |
-| --------------- | ---------------------------------------------------------------- | -------- |
-| **Name**        | A human-readable name to identify the application.               | Yes      |
-| **Description** | Freeform text describing the application's purpose.              | Yes      |
-| **Domain**      | The domain associated with this application.                     | No       |
-| **Groups**      | Assign the application to one or more groups for access control. | No       |
+    | Field           | Description                                         | Required |
+    | --------------- | --------------------------------------------------- | -------- |
+    | **Name**        | A human-readable name to identify the application.  | Yes      |
+    | **Description** | Freeform text describing the application's purpose. | Yes      |
+    | **Domain**      | The domain associated with this application.        | No       |
 
-3. Select the application type:
+3. In the **Security** section, select the application type. **Simple** is a standalone client for which you manage your own client ID. Additional OAuth application types are available only when Dynamic Client Registration is enabled for the environment.
+4. Complete the remaining **Security** fields described in the following table:
 
-| Type                   | Description                                                             | Redirect URIs required |
-| ---------------------- | ----------------------------------------------------------------------- | ---------------------- |
-| **Simple**             | Basic application with an optional client ID. No OAuth grant types.     | No                     |
-| **SPA (Browser)**      | Single-page application. Default grant type: Authorization Code.        | Yes                    |
-| **Web**                | Server-side web application. Default grant type: Authorization Code.    | Yes                    |
-| **Native**             | Mobile or desktop application. Default grant type: Authorization Code.  | Yes                    |
-| **Backend-to-Backend** | Machine-to-machine application. Default grant type: Client Credentials. | No                     |
+    | Field                              | Description                                                                                                   | Required |
+    | ---------------------------------- | ------------------------------------------------------------------------------------------------------------- | -------- |
+    | **Type**                           | A freeform descriptor of the application, such as mobile or web.                                              | No       |
+    | **Client ID**                      | The client ID of the application. This field is required to subscribe to certain types of API plan, such as OAuth2 and JWT. | No       |
+    | **Client Certificate (PEM Only)**  | The PEM-encoded client certificate of the application. This field is required to subscribe to certain mTLS plans. | No       |
 
-4. For OAuth-enabled types (SPA, Web, Native, Backend-to-Backend), configure grant types and redirect URIs as required.
-5. For TLS-based authentication, upload a client certificate in the TLS settings section.
-6. Select **Create** to register the application.
+5. Select **Create Application**.
 
 ## Application details
 
-Select an application from the list to view its detail page, which includes:
+Select an application from the list to open its detail page, which contains the following sections:
 
-* **General** — Name, description, type, domain, group membership, client ID, certificates, and metadata. The metadata editor includes built-in safeguards to highlight and prevent saving duplicate custom keys.
-* **User Permissions** — Manage direct members, configure group access, and transfer application ownership.
-* **Notifications** — Configure email and webhook notifications for application events.
-* **Subscriptions** — Active subscriptions to API plans. View subscription status, manage API keys, and see subscription history.
+* **Overview**. A setup checklist for the application and a snapshot of its subscription counts.
+* **General**. The application name, description, domain, images, owner, creation date, type, API key mode, client ID, and mTLS client certificates. This section also holds the action that archives the application.
+* **User Permissions**. Manage direct members, configure group access, and transfer application ownership.
+* **Subscriptions**. The plans this application subscribes to. Create a subscription, filter by API and status, search by API key, and review each subscription's status and dates.
+* **Notification settings**. Configure the events that trigger a notifier for this application, using either the default email notifier or the default webhook notifier. This section also holds the custom metadata available in notification templates. The metadata editor rejects a duplicate key and reports that the metadata already exists.
 
 ## Next steps
 
-* [Manage resources](manage-resources.md) — Configure shared resources used across your APIs.
-* [Establish consumer access](../api-management/build/configure-your-api-proxy/establish-consumer-access.md) — Set up subscriptions between applications and API plans.
+* [Manage resources](manage-resources.md). Configure shared resources used across your APIs.
+* [Establish consumer access](../api-management/build/configure-your-api-proxy/establish-consumer-access.md). Configure subscriptions between applications and API plans.


### PR DESCRIPTION
## What this is

Doc Verification Pipeline run on `docs/gamma/4.12/platform-management/manage-applications.md`, checked claim by claim against a running Gamma 4.12 console. The 4.13 copy was byte-identical before the change, so the same edit is applied there in this PR.

## Step 4 verdict table

| # | Claim | Live truth | Verdict |
|---|---|---|---|
| 1 | Sidebar: **Platform Management**, then **Applications** | Selecting Platform Management lands on Applications; the item is in the sidebar | Confirmed |
| 2 | KPI tiles for **Active applications** and **Archived applications** | Both tiles present, each with an "in this environment" count | Confirmed |
| 3 | Columns **Name** (sortable), **Type**, **Owner**, **Actions** | All four present; only Name sorts | Confirmed |
| 4 | Actions column is "Edit and management actions" | The row menu offers **View Details** and **Manage Subscriptions** | Corrected |
| 5 | Search bar filters by name | Typing a partial name narrowed the list | Confirmed |
| 6 | **Active/Archived** dropdown filter | Dropdown with **Active** and **Archived** options | Confirmed |
| 7 | Restore an archived application from the table | Archived view shows **Name** and **Archived at**, with a **Restore** action per row | Confirmed; added the Archived at detail |
| 8 | List supports pagination | Items per page selector and page controls present | Confirmed |
| 9 | Figure: Applications list screenshot | Matches the console — same header, tiles, search bar, filter, columns, and pagination | Confirmed, image unchanged |
| 10 | Step 1: **Register Application** | Button reads Register Application | Confirmed |
| 11 | Creation fields **Name** (required), **Description** (required), **Domain** (optional) | Present in the **General** section, with Name and Description marked required | Confirmed |
| 12 | Creation field **Groups** | No Groups field on the creation form; group access is set on **User Permissions** | Corrected — removed |
| 13 | Step 3 offers five application types with grant types and redirect URI rules | The **Security** section offers the **Simple** type. Other OAuth types require Dynamic Client Registration to be enabled for the environment | Corrected |
| 14 | Step 4: configure grant types and redirect URIs | No grant type or redirect URI controls on the form | Corrected — removed |
| 15 | Step 5: upload a client certificate in the "TLS settings" section | The Security section has a **Client Certificate (PEM Only)** field, alongside **Type** and **Client ID**. There is no TLS settings section and nothing to upload | Corrected |
| 16 | Step 6: select **Create** | Button reads **Create Application** | Corrected |
| 17 | Detail sections: General, User Permissions, Notifications, Subscriptions | Overview, General, User Permissions, Subscriptions, Notification settings | Corrected |
| 18 | **General** includes group membership | Not on General | Corrected — removed |
| 19 | **General** includes metadata with duplicate-key safeguards | Custom metadata lives on **Notification settings**. Saving a second entry with an existing name is rejected with a "metadata already exists" message | Corrected — safeguard is real, the location was wrong |
| 20 | **User Permissions**: direct members, group access, transfer ownership | **Add members**, **Manage groups**, and **Transfer ownership** all present | Confirmed |
| 21 | Notifications are email and webhook | Notifier choices are the default email notifier and the default webhook notifier | Confirmed |
| 22 | **Subscriptions**: status, API keys, history | Tab offers **Create a subscription**, API and status filters, an API key search, and per-subscription status and dates | Confirmed |
| 23 | Type column examples Backend, Service, Web | Matches the values shown in the page's own screenshot | Confirmed |
| 24 | House convention: `description:` frontmatter | Absent | Added |

## Not determined

Whether an application can actually authenticate and call an API — API key use, mTLS handshakes, and grant type behavior — was not exercised. This run verified console behavior only, so none of those runtime claims are asserted either way.

## Notes for the writer, not changed here

- The page carries one screenshot, on the section where the reader arrives at the Applications list. That is within the one-screenshot-per-task guidance, and it still matches the console, so it is untouched.
- That figure is hotlinked to a `gitbook.io` URL rather than a repo-relative asset. It is one of nine files under `docs/gamma/4.12/` in that state. Since the image did not need replacing, it was left as-is rather than converted in isolation.
- The page never explains how an application becomes archived in the first place, even though it tells you how to restore one. Worth a short addition, but it is new content rather than a correction, so it is out of scope for this run.
- The **Next steps** link to *Manage resources* points at a page that is currently not published, so readers following it from the site would dead-end.

## Style pass

The whole page was brought into style-guide conformance: bulleted list items no longer use an em dash between the term and its explanation, list and table introductions are complete sentences ending in a colon, Latin abbreviations are gone, and the step tables are indented under their steps so the procedure numbers run 1 to 5. `Client Certificate (PEM Only)` keeps its parentheses because that is the literal field label.
