### PR TITLE
docs(gamma): verify the Platform Management Install landing page (4.12 + 4.13)

### DIFF
--- a/docs/gamma/4.12/platform-management/install/README.md
+++ b/docs/gamma/4.12/platform-management/install/README.md
@@ -1,10 +1,11 @@
 ---
+description: Choose between a self-hosted and a hybrid Gamma installation.
 hidden: false
 noIndex: false
 ---
 # Install
 
-Choose the installation type that matches your deployment model.
+To match your deployment model, choose one of the following installation types:
 
-* [Self-hosted installation guides](self-hosted-installation-guides/README.md) — run every component in your own infrastructure.
-* [Hybrid installation guides](hybrid-installation-guides/README.md) — Gravitee hosts the control plane; you run the data plane.
+* [**Self-hosted installation guides**](self-hosted-installation-guides/README.md)**.** You run every component in your own infrastructure.
+* [**Hybrid installation guides**](hybrid-installation-guides/README.md)**.** Gravitee hosts the control plane and you run the data plane.

--- a/docs/gamma/4.13/platform-management/install/README.md
+++ b/docs/gamma/4.13/platform-management/install/README.md
@@ -1,10 +1,11 @@
 ---
+description: Choose between a self-hosted and a hybrid Gamma installation.
 hidden: false
 noIndex: false
 ---
 # Install
 
-Choose the installation type that matches your deployment model.
+To match your deployment model, choose one of the following installation types:
 
-* [Self-hosted installation guides](self-hosted-installation-guides/README.md) — run every component in your own infrastructure.
-* [Hybrid installation guides](hybrid-installation-guides/README.md) — Gravitee hosts the control plane; you run the data plane.
+* [**Self-hosted installation guides**](self-hosted-installation-guides/README.md)**.** You run every component in your own infrastructure.
+* [**Hybrid installation guides**](hybrid-installation-guides/README.md)**.** Gravitee hosts the control plane and you run the data plane.


### PR DESCRIPTION
## What this is

Doc Verification Pipeline run on `docs/gamma/4.12/platform-management/install/README.md`, the Platform Management **Install** landing page, checked against a running local Gamma 4.12 environment and against this repo's own installation guides.

**Result: no factual contradictions.** Everything the page asserts holds up. The changes here are frontmatter and style-guide conformance only.

## Step 4 verdict table

| # | Claim | Code / repo truth | Live truth | Verdict |
|---|---|---|---|---|
| 1 | Two installation types are offered: self-hosted and hybrid | `SUMMARY.md` lists exactly these two children under **Install**, and both directories exist with no third sibling | n/a — no UI surface for this claim | Confirmed |
| 2 | `self-hosted-installation-guides/README.md` link resolves | File exists | n/a | Confirmed |
| 3 | `hybrid-installation-guides/README.md` link resolves | File exists | n/a | Confirmed |
| 4 | Self-hosted means you "run every component in your own infrastructure" | The self-hosted guide enumerates the components, and the self-hosted Docker Compose stack defines all of them in one user-run compose project | Confirmed against the running local stack, which is exactly such a self-hosted deployment: console, Management API, MongoDB, and Elasticsearch all running locally | Confirmed |
| 5 | Hybrid means "Gravitee hosts the control plane; you run the data plane" | The hybrid guide states the same split, with the Gateway as the self-run data plane connecting to a Gravitee Cloud control plane | Not determined — verifying a hybrid deployment would require provisioning a Gravitee Cloud control plane and standing up a Gateway against it, which this run did not do | Not contradicted; corroborated by the linked guide |
| 6 | Missing `description:` frontmatter | Required by the frontmatter rule in the style guide | n/a | Needs fix (house convention, not a factual error) |
| 7 | Bulleted-list introduction | Style guide requires the introducing sentence to contain "following" and end with a colon | n/a | Needs fix (style) |
| 8 | Em dash separating each list item from its explanation | Style guide forbids an em dash, en dash, hyphen, or colon as the separator; the term must end with a period and the explanation must be its own complete sentence. The spaced em dashes also break the no-spaces-around-dashes rule | n/a | Needs fix (style) |
| 9 | Images | The page contains no `<figure>`, no Markdown image, and no hotlinked figure | n/a | None present — nothing added, nothing removed |

## What changed

- Added the required `description:` frontmatter.
- Reworded the list introduction to "To match your deployment model, choose one of the following installation types:" so it contains "following" and ends with a colon.
- Replaced the em dash separators with a period, so each entry reads as a term followed by a grammatically complete sentence, and bolded the link text to match the convention used on the other Gamma landing pages.

No technical meaning changed: both installation types, both link targets, and both descriptions carry the same information as before.

## Notes for the writer

- **Terminology conflict, deliberately not applied.** The terminology rules call for *Control Plane* and *Data Plane* in title case, but Gamma 4.12 docs use lowercase "control plane" and "data plane" in the large majority of occurrences, including in the hybrid installation guide this page links to. Capitalizing them on this one landing page would have made it inconsistent with the page directly beneath it, so the lowercase form is preserved. This is worth a consistent repo-wide decision rather than a per-page fix.
- **Not determined:** the hybrid claim (row 5) can only be fully confirmed by performing a hybrid installation against a Gravitee Cloud control plane, which this run deliberately did not do. It is corroborated by the linked hybrid guide but was not independently exercised.

## Versions

`docs/gamma/4.13/platform-management/install/README.md` was byte-identical to the 4.12 page before this change and contains no version-specific strings, so the identical change is applied to both in this PR.
