### PR TITLE
docs(gamma): verify and correct Configure Edge Management for 4.12

### DIFF
--- a/docs/gamma/4.12/edge-management/connect/configure-edge-management.md
+++ b/docs/gamma/4.12/edge-management/connect/configure-edge-management.md
@@ -8,7 +8,7 @@ description: >-
 
 ## Overview
 
-Edge Management is configured from a single **Configuration** page in the Gamma console. The page is split into the following sections: Gateway, Proxy, Shadow AI monitoring, and a Daemon Deployment section used to deploy the daemon to devices. For more information about deploying Kandji to the Edge Daemon, see [Configure Kandji to deploy the Edge Daemon](configure-kandji-daemon.md).
+Edge Management is configured from a single **Configuration** page in the Gamma console. The page is split into the following sections: Gateway, Proxy, Shadow AI monitoring, and a Daemon Deployment section used to deploy the daemon to devices. For more information about using Kandji to deploy the Edge Daemon, see [Configure Kandji to deploy the Edge Daemon](configure-kandji-daemon.md).
 
 The first time you open the page, there is no configuration. Configure the fields, and then save to create the configuration. When you save the configuration, the corresponding Edge API is published on the Gateway so the daemon's traffic can be captured.
 
@@ -16,29 +16,29 @@ The first time you open the page, there is no configuration. Configure the field
 
 To configure Edge Management, complete the following steps:
 
-* [Configure the Gateway](configure-edge-management.md#configure-the-gateway)
-* [Configure the Proxy](configure-edge-management.md#configure-the-proxy)
-* [Configure Shadow AI monitoring](configure-edge-management.md#configure-shadow-ai-monitoring)
-* [Save the configuration](configure-edge-management.md#save-the-configuration)
+1. [Configure the Gateway](configure-edge-management.md#configure-the-gateway)
+2. [Configure the Proxy](configure-edge-management.md#configure-the-proxy)
+3. [Configure Shadow AI monitoring](configure-edge-management.md#configure-shadow-ai-monitoring)
+4. [Save the configuration](configure-edge-management.md#save-the-configuration)
 
-## Configure the Gateway
+### Configure the Gateway
 
-Conection URLs are used by the Edge Daemon to reach the Gravitee Gateway and reactor. To configure the Edge Daemon for the Gateway, com
+The Edge Daemon uses connection URLs to communicate with the Gravitee API Gateway and the Edge Reactor. To configure the Edge Daemon for the Gateway, complete the following fields:
 
 <figure><img src="../../.gitbook/assets/edge-config-gateway (1).png" alt="Gateway section: Gateway URL and Reactor URL, locked after creation"><figcaption><p>The Gateway and Reactor URLs are locked once the configuration is created.</p></figcaption></figure>
 
-The following fields define the connection URLs the Edge Daemon uses to reach the Gravitee gateway and reactor:
+The following table describes each field:
 
 | Field           | Description                                                                                   |
 | --------------- | --------------------------------------------------------------------------------------------- |
-| **Gateway URL** | Base URL of the AI Gateway the daemon routes proxied traffic to.                              |
+| **Gateway URL** | Base URL of the Gravitee API Gateway that the daemon routes traffic to.                       |
 | **Reactor URL** | URL of the Edge Reactor that serves daemon configuration and collects heartbeats and metrics. |
 
 {% hint style="info" %}
-The Gateway URL and Reactor URL are locked after you create the configuration is first created. They cannot be changed after you complete the configuration.
+The Gateway URL and Reactor URL are locked after the configuration is first created. They cannot be changed afterwards.
 {% endhint %}
 
-## Configure the Proxy
+### Configure the Proxy
 
 Configure how the daemon intercepts traffic and routes it to gateway APIs.
 
@@ -46,11 +46,11 @@ Configure how the daemon intercepts traffic and routes it to gateway APIs.
 
 Configure the following settings:
 
-* **DNS domains (interception mode).** The domains the daemon's DNS resolver intercepts. For example `api.anthropic.com`. Traffic to these domains is captured and routed according to the route configuration.
+* **DNS domains (interception mode).** The domains the daemon's DNS resolver intercepts. For example, `api.anthropic.com`. Traffic to these domains is captured and routed according to the route configuration.
 * **Routes.** Ordered rules that map a request path to a Gateway API. **First match wins.** Each route has the following properties:
-  * A**path prefix**. For example `/v1/messages`.
-  * An **API path**. The gateway API endpoint that handles it. For example `/interception/claude`.
-  * (Optional)A **provider**. For example `anthropic`.
+  * A **path prefix**. For example, `/v1/messages`.
+  * An **API path**. The gateway API endpoint that handles it. For example, `/interception/claude`.
+  * A **provider**. This property is optional. For example, `anthropic`.
 
 A typical Claude Code setup uses the following two routes:
 
@@ -61,7 +61,7 @@ A typical Claude Code setup uses the following two routes:
 
 LLM calls to `/v1/messages` are routed to the **LLM Proxy API**. All other traffic reaches the **HTTP Proxy API**.
 
-## Configure Shadow AI monitoring
+### Configure Shadow AI monitoring
 
 Detect direct connections to AI providers that bypass the Gateway.
 
@@ -69,16 +69,19 @@ Detect direct connections to AI providers that bypass the Gateway.
 
 Configure the following settings:
 
-* **Monitored domains.** Domains to watch for non-proxied direct connections. For example `api.openai.com`. Detection is based on TCP connection monitoring. No traffic content is inspected.
-* **Report interval (seconds).** How often the daemon aggregates and reports detections, with a minimum of 10 seconds.
+* **Monitored domains.** Domains to watch for non-proxied direct connections. For example, `api.openai.com`. Detection is based on TCP connection monitoring. No traffic content is inspected.
+* **Report interval (seconds).** How often the daemon aggregates and reports detections. The minimum is 10 seconds and the default is 120 seconds.
 
-## Save the configuration
+### Save the configuration
 
-* Select either of the following actions:
-* **Create connfiguration** to deploy your configuration.
-* **Save changes** to save your configuration but not deploy it.
+The **Configuration** page has a single save action. Depending on whether a configuration already exists, the button displays one of the following labels:
 
-When you deploy the fconfiguration, The DNS domains, routes, and shadow AI settings are pushed to daemons the next time they poll the Edge Reactor for configuration. The configuration applies without restarting the daemon.
+* **Create configuration**. This label appears the first time you configure Edge Management. Select it to create and deploy the configuration.
+* **Save changes**. This label appears when you edit an existing configuration. Select it to update and redeploy the configuration.
+
+To discard unsaved edits and restore the last saved values, select **Reset**.
+
+Saving always deploys the configuration. The DNS domains, routes, and shadow AI settings are pushed to daemons the next time they poll the Edge Reactor for configuration. The configuration applies without restarting the daemon.
 
 ## Next steps
 


### PR DESCRIPTION
## Summary

Ran the Doc Verification Pipeline on `docs/gamma/4.12/edge-management/connect/configure-edge-management.md` against a live 4.12 Gamma console and the shipped Edge Management module.

The page had several genuine defects: a sentence that ended mid-word, a garbled clause, three misspellings of "configuration", a duplicated bullet marker, and an incorrect description of the save actions. All are fixed here from live evidence.

### How the two meaning-level defects were resolved

**The truncated sentence.** The page read "To configure the Edge Daemon for the Gateway, com" and stopped. The Gateway section of the live console contains exactly two controls, **Gateway URL** and **Reactor URL**, and nothing else — no buttons and no sub-steps — and the sentence is immediately followed by a table describing those two fields. The sentence now reads "To configure the Edge Daemon for the Gateway, complete the following fields:", which is the only completion the section supports. Nothing was invented.

**The garbled clause.** "locked after you create the configuration is first created" collapsed two drafts of the same sentence. The underlying fact is correct and was confirmed live: once a configuration exists, both URL fields are disabled and carry a **Locked** badge whose tooltip states they are set during initial configuration and cannot be changed afterwards. The sentence now reads "locked after the configuration is first created. They cannot be changed afterwards."

### Verdict table

| # | Claim | Evidence from the shipped module | Live console | Verdict |
|---|---|---|---|---|
| 1 | Configured from a single **Configuration** page | Single configuration route | One **Configuration** item in the Edge Management sidebar | Confirmed |
| 2 | Sections are Gateway, Proxy, Shadow AI monitoring, Daemon Deployment | Four sections in that order | Observed in that order | Confirmed |
| 3 | The first time you open the page there is no configuration | Empty state shown when none exists | "No configuration yet" observed | Confirmed |
| 4 | Saving publishes the corresponding Edge API on the Gateway | Saving creates or updates the API and raises a publish event | Not observable — no gateway is running and no configuration was created | Confirmed by the shipped module; **not observed live** |
| 5 | "deploying Kandji to the Edge Daemon" | — | Console: "Download and deploy the Edge Daemon agent to managed devices using Kandji" | **Contradicted — fixed** (relationship was reversed) |
| 6 | "Conection URLs" | — | — | **Typo — fixed** |
| 7 | Sentence ends mid-word at "com" | — | Section contains only the two URL fields | **Truncated — fixed** |
| 8 | Field **Gateway URL** | Label matches | Observed | Confirmed |
| 9 | Gateway URL is the "AI Gateway" | Field description names the Gravitee API Gateway | Same live, and the same wording appears in the page's own Gateway screenshot | **Contradicted — fixed** |
| 10 | Field **Reactor URL** | Label matches | Observed | Confirmed |
| 11 | Reactor URL "collects heartbeats and metrics" | The field description covers daemon configuration and coordination only | Cannot be observed without an enrolled daemon | **Not determined** — left unchanged |
| 12 | Gateway URL and Reactor URL lock after creation | Both fields are disabled whenever a configuration exists, with a **Locked** badge | Empty state shows both editable and unbadged, consistent with the rule | Fact confirmed; **sentence garbled — fixed** |
| 13 | **DNS domains (interception mode)** label, helper text, `api.anthropic.com` example | Matches | Observed | Confirmed |
| 14 | Routes are ordered and **first match wins** | Helper text states "First match wins"; routes can be reordered | Observed | Confirmed |
| 15 | Route properties: path prefix, API path, optional provider | Columns are **Path prefix**, **API path**, **Provider**; a route can be added without a provider | Observed | Confirmed, including that provider is optional |
| 16 | Typical Claude Code route table | API path is a free-text field, so these values are user-chosen rather than supplied by the product | Not observable | **Not determined**; consistent with the page's own Proxy screenshot, so left unchanged |
| 17 | Shadow AI detection uses TCP connection monitoring and inspects no content | The module states TCP monitoring of connections to the configured provider domains, with no traffic content intercepted | Labels and helper text observed | Confirmed |
| 18 | Report interval minimum is 10 seconds | Field enforces a minimum of 10 | — | Confirmed |
| 19 | Report interval default | Default configuration is 2 minutes; the field falls back to 120 | Fresh unconfigured page pre-filled with **120** | **Omitted from the page — added** |
| 20 | "Select either of the following actions: Create configuration / Save changes" | One save button whose label is **Create configuration** when no configuration exists and **Save changes** when editing one, beside a **Reset** button | Empty state shows **Create configuration** and **Reset** only; no **Save changes** | **Contradicted — fixed** |
| 21 | "**Save changes** to save your configuration but not deploy it" | Every save both persists and deploys; there is no save-without-deploy path | Not observable — no configuration was created | **Contradicted — fixed** |
| 22 | Duplicated bullet marker under "Save the configuration" | — | — | **Formatting — fixed** |
| 23 | "connfiguration", "fconfiguration", "Create connfiguration" | — | — | **Typos — fixed** |
| 24 | Settings reach daemons on their next poll and apply without a restart | Not evidenced on this surface | No daemon is enrolled | **Not determined** — left unchanged |
| 25 | Figure: Gateway section | — | Labels, descriptions, and **Locked** badges all match the live console | Current — not replaced |
| 26 | Figure: Proxy section | — | Labels, helper text, placeholders, and buttons all match | Current — not replaced |
| 27 | Figure: Shadow AI section | — | Labels and helper text match | Current — not replaced |

### Style pass

Applied over the whole page, meaning-preserving: numbered the procedure overview and demoted its four subsections to `h3` beneath it, repaired the duplicated bullet marker, removed a parenthetical "(Optional)" aside in favor of a complete sentence, added the missing space in "A**path prefix**", added commas after "For example", gave the field table a complete introduction, and normalized table alignment. Bold UI labels in bulleted lists were preserved throughout. Anchors are unaffected by the heading demotion because they derive from heading text.

### Notes for the writer

- **No images were added, replaced, or deleted.** All three screenshots still match the live console.
- The page carries three screenshots across four subsections, which is within the one-per-task guidance. No action taken.
- **Duplicate assets.** The page references `edge-config-gateway (1).png`, `edge-config-proxy (1).png`, and `edge-config-shadow-ai (1).png`, and byte-identical copies exist without the ` (1)` suffix. Worth consolidating separately; not touched here to avoid orphaning assets.
- **4.13 was not patched.** `docs/gamma/4.13/edge-management/connect/configure-edge-management.md` already differed from 4.12 before this change, so per convention it was left alone. It carries the same content defects and needs its own pass. See the differences noted in the review thread.
- The **Daemon Deployment** section is named in the overview but not documented on this page; it defers to the Kandji page. Left as-is.

### Not verified

The stack backing this run is the console, management API, MongoDB, and Elasticsearch. No gateway is up, no Edge devices are enrolled, and no Edge Daemon is running. Anything requiring a daemon, device enrolment, traffic interception, or a live gateway could not be checked and is marked "not determined" above rather than assumed.

No Edge configuration was created during this run. The Edge configuration is a singleton with no delete action anywhere in the product, so creating one would have left permanent state behind. The create-time behavior in rows 12, 20, and 21 was established from the shipped module instead of by clicking through it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
