### PR TITLE
docs(gamma): remove internal source reference from Manage resources

### DIFF
--- a/docs/gamma/4.12/platform-management/manage-resources.md
+++ b/docs/gamma/4.12/platform-management/manage-resources.md
@@ -8,7 +8,7 @@ noIndex: true
 Resources are shared, reusable components that API proxies reference at runtime. Common examples include OAuth2 token validation endpoints, cache stores, and authentication providers.
 
 {% hint style="warning" %}
-The Resources tab is marked **Coming soon** in the current build. No resource management UI is available yet. This page documents the planned capability. Source: `ApiDetailSidebarNav.tsx:L79` — `comingSoon: true`.
+The Resources tab is marked **Coming soon** in the current build. No resource management UI is available yet. This page documents the planned capability.
 {% endhint %}
 
 ## Resource types

--- a/docs/gamma/4.13/platform-management/manage-resources.md
+++ b/docs/gamma/4.13/platform-management/manage-resources.md
@@ -8,7 +8,7 @@ noIndex: true
 Resources are shared, reusable components that API proxies reference at runtime. Common examples include OAuth2 token validation endpoints, cache stores, and authentication providers.
 
 {% hint style="warning" %}
-The Resources tab is marked **Coming soon** in the current build. No resource management UI is available yet. This page documents the planned capability. Source: `ApiDetailSidebarNav.tsx:L79` — `comingSoon: true`.
+The Resources tab is marked **Coming soon** in the current build. No resource management UI is available yet. This page documents the planned capability.
 {% endhint %}
 
 ## Resource types


### PR DESCRIPTION
Removes an internal code reference from the *Coming soon* hint on **Manage resources**, in both 4.12 and 4.13.

## Why

The hint ended with a citation naming an internal frontend source file, a line number, and a build flag. `gravitee-platform-docs` is a public repository and the module in question is not, so that detail should not be here.

The page is `hidden: true` / `noIndex: true`, so it never reached the documentation site — but the Markdown is public on GitHub.

## What changed

The trailing citation is deleted. Nothing else on either page is touched.

The user-facing statement is deliberately preserved: the Resources tab is still described as **Coming soon** with no resource management UI yet. That is what the product itself displays, so it is not sensitive.

## Notes

- Both version copies were byte-identical before this change and remain so.
- Found during the Gamma 4.12 documentation verification batch (#2087-#2117). It predates that work — it arrived with the 4.13 folder split in #2005 — and is unrelated to any of those PRs.
- A repo-wide scan found no other instance of this pattern. The only other source-file references in `docs/` are the deliberate `FooHeaderCheck*` tutorial examples in the public custom-policy guides.
- This removes the text going forward. It remains in git history; purging that would require a history rewrite, which seems disproportionate here — flagging it so the decision is explicit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)