### PR TITLE
docs(gamma): apply the A2A Proxy Policy Studio fixes to 4.13

### DIFF
--- a/docs/gamma/4.13/agent-management/build/configure-your-a2a-proxy/add-policies-to-a2a-proxy.md
+++ b/docs/gamma/4.13/agent-management/build/configure-your-a2a-proxy/add-policies-to-a2a-proxy.md
@@ -12,14 +12,12 @@ You can use the Policy Studio to add, configure, and manage policies on your Age
 
 To attach policies to your A2A Proxy:
 
-1. In the Gamma console, navigate to **Agent Management**.
+1. In the Gamma console, navigate to **Agent Management**. In the **Secure** section of the sidebar, select **A2A Proxies**.
 2. Select your A2A proxy from the proxy list.
-3. In the sidebar, select **Policy Studio**.
-4. In the Policy Studio builder, define **Flows**. A flow is a combination of a selector, such as a path or condition, and a set of policies to execute when the selector matches.
-5. Search for policies in the policy palette.
-6. Select a policy from the palette, choose the **Request** or **Response** phase where it should run, and then select **Add to flow**.
+3. In the **Design** section of the proxy sidebar, select **Policy Studio**.
+4. Create a flow. A flow is a combination of a selector, such as a path or condition, and a set of policies to execute when the selector matches. Click **Add plan flow** to scope the flow to a subscription plan, or **Add common flow** to apply the flow to all traffic regardless of plan.
+5. Select the flow, and then click **Browse all** on either the **Request Phase** or the **Response Phase**. The **Add Policy** panel lists the policies available for the phase you selected. To narrow the list, use the search field or the **Category** filter.
+6. Select a policy to review its documentation, and then click **Add to flow**.
 7. Select the policy in the flow to configure its specific properties.
-8. Click **Save** to persist and apply your changes.
-
-
-
+8. Click **Save** to persist your changes.
+9. Click **Deploy** to push your changes to the AI Gateway. Until you deploy, the proxy reports that it is out of sync and your changes are not live.


### PR DESCRIPTION
Ports the corrections from #2108 to `docs/gamma/4.13/agent-management/build/configure-your-a2a-proxy/add-policies-to-a2a-proxy.md`.

#2108 verified the 4.12 copy of this page against a live 4.12 Gamma console and fixed four steps that did not match the product. The 4.13 copy had already diverged (it carried the `description` frontmatter and a partially reworded step 6), so it was left untouched there and flagged as a follow-up. This is that follow-up.

## What changed in 4.13

| Step | Before | After |
|---|---|---|
| 1 | "navigate to **Agent Management**" | Adds the path: A2A proxies are under **Secure** → **A2A Proxies**. |
| 3 | "In the sidebar, select **Policy Studio**" | Disambiguates: the proxy has its own sidebar, and Policy Studio is under **Design**. |
| 4 | Flows can simply be "defined" | A flow must be created first, either **Add plan flow** (scoped to a subscription plan) or **Add common flow** (all traffic). |
| 5 | "Search for policies in the policy palette" | There is no policy palette. The catalog is the **Add Policy** panel, opened with **Browse all** from the **Request Phase** or **Response Phase**, with a search field and a **Category** filter. |
| 6 | Select a policy, then choose the phase | Phase comes first — the catalog only offers policies valid for the phase it was opened from. Now just: select a policy, click **Add to flow**. |
| 8 | "**Save** to persist **and apply**" | Save only persists. |
| 9 | (missing) | New step: **Deploy** pushes changes to the AI Gateway; until then the proxy is out of sync. |

The `description` frontmatter was already present in 4.13, so only the procedure changed. The 4.12 and 4.13 pages are now byte-identical.

## Verification

No new console verification was done for 4.13 — this ports text verified against a live 4.12 console in #2108. Everything #2108 recorded as not determined stays not determined here: whether a policy actually executes on agent traffic was not exercised (no gateway, no upstream agent), and the "enforce security, modify payloads, and control traffic behavior" claim in the intro is left as written.

Merge order does not matter; the two PRs touch different files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)