### PR TITLE
docs(gamma): apply the Create an MCP proxy fixes to 4.13

### DIFF
--- a/docs/gamma/4.13/agent-management/build/create-an-mcp-proxy.md
+++ b/docs/gamma/4.13/agent-management/build/create-an-mcp-proxy.md
@@ -24,7 +24,7 @@ A transparent intermediary in front of an existing upstream MCP server. Proxy mo
 {% endtab %}
 
 {% tab title="Studio mode" %}
-An authoring environment for Composite MCP Servers. In Studio mode, you compose tools, resources, prompts, and skills from multiple sources into a new MCP server that didn't exist as a single unit upstream.
+An authoring environment that assembles catalog tools into a unified MCP entrypoint. In Studio mode, you select tools from the catalog to expose through a new MCP server that didn't exist as a single unit upstream.
 
 For Studio mode, see [Create an MCP Studio](create-an-mcp-studio.md).
 {% endtab %}
@@ -43,8 +43,8 @@ To create an MCP proxy, complete the following steps:
 ### Open the MCP Proxy wizard
 
 1. From the Gamma console sidebar, select **Agent Management**.
-2. In the **Secure** section, select **MCP Proxies**.
-3. Select **Create MCP proxy**.
+2. Under **Secure**, select **MCP Proxies**.
+3. Select **+ Create MCP proxy**.
 
 ### Define your proxy
 
@@ -54,7 +54,7 @@ To create an MCP proxy, complete the following steps:
 
 ### Configure consumer security
 
-Choose how clients authenticate to the proxy entrypoint:
+Choose how clients authenticate to the proxy entrypoint. The wizard offers the following methods:
 
 | Security method                      | Description                                                                                                 |
 | ------------------------------------ | ----------------------------------------------------------------------------------------------------------- |
@@ -65,29 +65,29 @@ Choose how clients authenticate to the proxy entrypoint:
 
 ### Connect to the upstream MCP server
 
-Enter the **Server URL** of the upstream MCP endpoint, and then configure how the Gateway authenticates to it at runtime:
+Enter the **Server URL** of the upstream MCP endpoint, and then choose how the Gateway authenticates to that server at runtime. The wizard offers the following methods:
 
 | Method                | Description                                                                                              |
 | --------------------- | -------------------------------------------------------------------------------------------------------- |
 | **Static credential** | Inject a static credential—API key, Bearer token, Basic auth, or Custom secret—into a request header on every call. |
-| **No upstream auth**  | Call the upstream without injecting credentials—passthrough.                                             |
+| **No upstream auth**  | Call the upstream without injecting credentials.                                                         |
 
 ### Review and create
 
-Review the MCP Proxy configuration, including security and upstream authentication. Then select **Create only** to register the proxy, or **Create & deploy** to register and deploy it in one step.
+Review the MCP Proxy configuration, including security and upstream authentication. Then select **Create only** to register the proxy without deploying it, or **Create & deploy** to register and deploy it in one step.
 
-The MCP Proxy is created and registered in the AI Gateway. Every tool invocation through this proxy is now subject to the configured authentication, policies, and observability.
+**Create only** leaves the proxy stopped and out of sync. Select **Deploy** on the proxy overview to push it to the AI Gateway. Once the proxy is deployed, every tool invocation through it is subject to the configured authentication, policies, and observability.
 
 ## After creation
 
 Once the MCP Proxy is created, you can do the following:
 
 * **Add authorization policies**. Control which consumers can invoke specific tools. See [Add policies to your MCP server](configure-your-mcp/add-policies-to-mcp-server.md).
-* **Configure mediation**. Configure token exchange and credential management for upstream OAuth. See [Configure your MCP proxy](configure-your-mcp/README.md).
-* **View in the Catalog**. The MCP Proxy appears in the API Management console alongside API proxies.
+* **Configure upstream authentication**. Manage the credentials the Gateway injects when it calls the upstream server. See [Configure your MCP proxy](configure-your-mcp/README.md).
+* **Backing API**. Gravitee backs each MCP Proxy with an API in API Management. Deleting the MCP Proxy also deletes that API.
 
 ## Next steps
 
-* [Configure your MCP proxy](configure-your-mcp/README.md). Configure mediation and advanced configuration.
+* [Configure your MCP proxy](configure-your-mcp/README.md). Configure upstream authentication and other advanced settings.
 * [Add policies to your MCP server](configure-your-mcp/add-policies-to-mcp-server.md). Apply fine-grained authorization.
 * [Create an MCP Studio](create-an-mcp-studio.md). Compose tools from this server with tools from other sources.


### PR DESCRIPTION
Version parity follow-up to #2111, which verified `docs/gamma/4.12/agent-management/build/create-an-mcp-proxy.md` against a running Gamma 4.12 console.

That PR left 4.13 untouched because the page had already diverged and carried most of the corrections. It did not carry all of them — the remaining contradicted claims are ported here, so the two versions are now byte-identical.

## Ported from #2111

| Claim in 4.13 | Correction | Source row in #2111 |
|---|---|---|
| Studio mode is "an authoring environment for Composite MCP Servers" where you compose tools, resources, prompts, and skills | "Composite MCP Server" appears nowhere in the shipped module; the wizard assembles catalog **tools** only | 3, 4 |
| "Select **Create MCP proxy**" | Button reads **+ Create MCP proxy** | 5 |
| "The MCP Proxy is created and registered in the AI Gateway" after either create option | **Create only** leaves the proxy stopped and out of sync; it must be deployed | 12 |
| "Configure mediation — token exchange and credential management for upstream OAuth" | No such capability in the shipped module; upstream auth is static credential injection or none | 13 |
| "The MCP Proxy appears in the API Management console alongside API proxies" | The API Management **API Proxies** list excludes MCP proxies; the relationship is a backing API that is deleted with the proxy | 14 |

Also picked up the smaller wording alignments from that PR: "Under **Secure**", "The wizard offers the following methods", and dropping the "passthrough" gloss on **No upstream auth**.

## Scope

No new console verification was run against 4.13 — this is a straight port of the 4.12 findings on the assumption the behaviour is unchanged between the two versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)