### PR TITLE
docs(gamma): apply the Kafka service verification fixes to 4.13

### DIFF
--- a/docs/gamma/4.13/event-stream-management/build/create-a-kafka-service-with-a-registered-cluster.md
+++ b/docs/gamma/4.13/event-stream-management/build/create-a-kafka-service-with-a-registered-cluster.md
@@ -1,4 +1,5 @@
 ---
+description: Create a Kafka Service in Event Stream Management and bind it to a connection on a registered Kafka cluster.
 hidden: false
 noIndex: false
 ---
@@ -6,7 +7,7 @@ noIndex: false
 
 # Create a Kafka service with a registered cluster
 
-A Kafka Service is the client-facing endpoint managed by Gravitee. It is the Event Stream Management equivalent of an API proxy — the Kafka Service is the governance layer that enforces authentication, security plans, ACLs, and quotas before routing traffic to the backend infrastructure. 
+A Kafka Service is the client-facing endpoint managed by Gravitee. It is the Event Stream Management equivalent of an API proxy. The Kafka Service is the governance layer that enforces authentication, security plans, ACLs, and quotas before routing traffic to the backend infrastructure.
 
 The backend infrastructure can be a standalone broker list, a specific connection on a registered physical cluster, or a Virtual Cluster.
 
@@ -16,9 +17,9 @@ For a simplified walkthrough that covers just the basics, see [Create your first
 
 ## How Kafka services work
 
-When you create a Kafka Service, you define how clients connect to it (the **Listener**) and how the service reaches Kafka (the **Endpoint Binding**). The Event Gateway enforces the service's configuration at runtime — every produce and consume operation passes through the gateway, where security plans, authorization policies, and rate limits are evaluated.
+When you create a Kafka Service, you define the **Listener** that clients connect to, and the **Endpoint binding** that determines how the service reaches Kafka. The Event Gateway enforces the service's configuration at runtime. Every produce and consume operation passes through the gateway, where security plans, authorization policies, and rate limits are evaluated.
 
-A single Kafka Service can route to multiple clusters by binding to a Virtual Cluster, or multiple Kafka Services can bind to the same registered cluster to provide different governance tiers.
+A single Kafka Service can route to multiple clusters by binding to a Virtual Cluster. Alternatively, multiple Kafka Services can bind to the same registered cluster to provide different governance tiers.
 
 ## Prerequisites
 
@@ -31,31 +32,38 @@ A single Kafka Service can route to multiple clusters by binding to a Virtual Cl
 2. Navigate to **Kafka Services**.
 3. Select **Create Kafka Service**.
 
-### 1. Identity
+The wizard has four steps. To configure the service, complete the following steps:
 
-| Field            | Description                                                                          |
-| ---------------- | ------------------------------------------------------------------------------------ |
-| **Name**         | A human-readable name that identifies this Kafka Service in the console and Catalog. |
-| **Version**      | The version of this service (e.g., 1.0).                                             |
-| **Description**  | Optional. A description of the service's purpose.                                    |
+1. [Identity](#identity)
+2. [Listener](#listener)
+3. [Endpoint](#endpoint)
+4. [Review and create](#review-and-create)
 
-### 2. Listener
+### Identity
 
-The listener defines the entrypoint that Kafka clients will connect to. 
+| Field           | Description                                                                                          |
+| --------------- | ---------------------------------------------------------------------------------------------------- |
+| **Name**        | A human-readable name that identifies this Kafka Service in the Kafka Service list and detail views. |
+| **Version**     | The version of this service, for example 1.0.                                                        |
+| **Description** | Optional. A description of the service's purpose.                                                    |
 
-| Field           | Description                                                                                                  |
-| --------------- | ----------------------------------------------------------------------------------------------------------- |
-| **Host prefix** | A single DNS label (lowercase letters, digits, and hyphens; max 63 characters). The Event Gateway appends its configured domain, and clients connect on the gateway's SNI port — for example `orders.<gateway-domain>:<sni-port>`. The port is a gateway-level setting and is not configured here. |
+### Listener
 
-### 3. Endpoint
+The listener defines the entrypoint that Kafka clients connect to.
+
+| Field           | Description                                                                                                                                                                                                                                                    |
+| --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Host prefix** | A single DNS label of lowercase letters, digits, and hyphens, up to 63 characters. The Event Gateway appends its configured domain, and clients connect on the gateway's SNI port, for example `orders.<gateway-domain>:<sni-port>`. The port is a gateway-level setting and is not configured here. |
+
+### Endpoint
 
 The endpoint binding determines how the Kafka Service reaches Kafka. Choose one of the following modes:
 
-* **Standalone**: Manually provide a comma-separated list of `host:port` bootstrap servers.
-* **Managed cluster**: Select a registered Kafka cluster and one of its configured connections.
-* **Virtual Cluster**: Select a Virtual Cluster to route traffic through a unified namespace or Kafka Mesh.
+* **Standalone**. Manually provide a comma-separated list of `host:port` bootstrap servers.
+* **Managed cluster**. Select a registered Kafka cluster and one of its configured connections.
+* **Virtual Cluster**. Select a Virtual Cluster to route traffic through a unified namespace or Kafka Mesh.
 
-### 4. Review and create
+### Review and create
 
 1. Review the service identity, listener, and endpoint binding.
 2. Select **Create Kafka Service**.
@@ -67,21 +75,18 @@ The console creates the Kafka Service and redirects you to its overview page.
 After creating the Kafka Service, you must configure a **Plan** to allow clients to consume from or produce to the service.
 
 The following security plan types are available:
-* **Keyless (Public)**
-* **API Key**
+
+* **Keyless**
+* **API key**
 * **OAuth2**
 * **JWT**
 * **mTLS**
 
-Plans support **Subscription validation** (Auto or Manual) and advanced **Port-based routing** (Bootstrap port, broker range start, broker range end) for gateways running in port routing mode without SNI.
+Every plan also carries a **Subscription validation** mode, set to either `AUTO` or `MANUAL`.
 
 Once a plan is established, you can apply **Policies** to enforce quotas, message filtering, or access controls.
 
-## Expose as a Kafka API Tool
-
-Once a Kafka Service is running, you can expose its topics as **Kafka API Tools** in the Catalog, bridging your event infrastructure to the AI agent layer. Kafka API Tools become available as building blocks in MCP Studio alongside other tools, resources, and prompts.
-
 ## Next steps
 
-* **Provision a Virtual Cluster** — Add multi-tenant isolation on top of your Kafka Service. See [Establish a virtual cluster](establish-a-virtual-cluster.md).
-* **Create topics** — Set up Kafka topics for producing and consuming messages.
+* **Provision a Virtual Cluster**. Add multi-tenant isolation on top of your Kafka Service. See [Establish a virtual cluster](establish-a-virtual-cluster.md).
+* **Create topics**. Create Kafka topics for producing and consuming messages.


### PR DESCRIPTION
Follow-up to #2104, which verified `docs/gamma/4.12/event-stream-management/build/create-a-kafka-service-with-a-registered-cluster.md` against a live Gamma 4.12 console and left 4.13 untouched.

That PR's own notes flagged this gap:

> **4.13 was not patched.** `docs/gamma/4.13/.../create-a-kafka-service-with-a-registered-cluster.md` already differed from 4.12 before this change: it carries `hidden`/`noIndex` frontmatter and a `<--- to be published --->` marker, and already uses the `##`/`###` heading hierarchy. Per the divergence convention it was left alone, but it still contains all five factual errors corrected here and should get a follow-up.

This is that follow-up. The 4.13 page is now identical in body to the corrected 4.12 page.

## Factual fixes

All five carry over verbatim from the #2104 verdict table. No new verification was performed here — the 4.13 page was byte-identical in substance to the pre-fix 4.12 page.

| # | Claim | Correction |
|---|---|---|
| 5 | Name "identifies this Kafka Service in the console and Catalog" | There is no Catalog surface for Kafka Services. Now reads "in the Kafka Service list and detail views", matching the field help. |
| 16 | Security plan types `Keyless (Public)`, `API Key` | Console labels are **Keyless** and **API key**. |
| 17 | Subscription validation, Auto or Manual | Real values are `AUTO` and `MANUAL`. |
| 18 | Plans support Port-based routing (bootstrap port, broker range start/end) | Not offered by the plan form. Sentence removed. |
| 20 | "Expose as a Kafka API Tool" section | No such capability exists in the product. Section removed. |

## Style pass

Applied to match the corrected 4.12 page:

- Added `description:` frontmatter.
- Dropped the numbering from the wizard step headings (`### 1. Identity` to `### Identity`) and added a procedure overview with anchor links to the four steps.
- Replaced `e.g.` with plain English, removed explanatory parentheses, split two over-long sentences, and switched bulleted term/explanation separators from colons and em dashes to periods.

## Preserved

The 4.13-only `hidden: false` / `noIndex: false` frontmatter keys and the `<--- to be published --->` marker are both kept. The `description:` key was added alongside them rather than replacing the block.

## Verified

The three relative links (`create-your-first-kafka-service.md`, `register-your-kafka-clusters.md`, `establish-a-virtual-cluster.md`) all resolve to existing files under `docs/gamma/4.13/`.

## Still outstanding from #2104

Not addressed here, unchanged in scope:

- `create-your-first-kafka-service.md` (both versions) repeats the "Keyless (Public)" and Catalog-wording errors.
- The page has no screenshots; adding one to the first wizard step is a writer's call.
- Standalone binding mode exposes a **Security protocol** selector the page doesn't mention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)