### PR TITLE
docs(gamma): apply the Configure Edge Management corrections to 4.13

### DIFF
--- a/docs/gamma/4.13/edge-management/connect/configure-edge-management.md
+++ b/docs/gamma/4.13/edge-management/connect/configure-edge-management.md
@@ -8,36 +8,37 @@ description: How to configure the Edge Management settings, proxy routes, and sh
 
 ## Overview
 
-Edge Management is configured from a single **Configuration** page in the Gamma console. The page is split into the following sections: Gateway, Proxy, Shadow AI monitoring, and a Daemon Deployment section used to deploy the daemon to devices. For more information about deploying Kandji to the Edge Daemon, see [Configure Kandji to deploy the Edge Daemon](configure-kandji-daemon.md).
+Edge Management is configured from a single **Configuration** page in the Gamma console. The page is split into the following sections: Gateway, Proxy, Shadow AI monitoring, and a Daemon Deployment section used to deploy the daemon to devices. For more information about using Kandji to deploy the Edge Daemon, see [Configure Kandji to deploy the Edge Daemon](configure-kandji-daemon.md).
 
 The first time you open the page, there is no configuration. Configure the fields, and then save to create the configuration. When you save the configuration, the corresponding Edge API is published on the Gateway so the daemon's traffic can be captured.
 
-## Configure Edge Management 
+## Configure Edge Management
 
 To configure Edge Management, complete the following steps:
-* [Configure the Gateway](configure-edge-management.md#configure-the-gateway)
-* [Configure the Proxy](configure-edge-management.md#configure-the-proxy)
-* [Configure Shadow AI monitoring](configure-edge-management.md#configure-shadow-ai-monitoring)
-* [Save the configuration](configure-edge-management.md#save-the-configuration)
 
-## Configure the Gateway
+1. [Configure the Gateway](configure-edge-management.md#configure-the-gateway)
+2. [Configure the Proxy](configure-edge-management.md#configure-the-proxy)
+3. [Configure Shadow AI monitoring](configure-edge-management.md#configure-shadow-ai-monitoring)
+4. [Save the configuration](configure-edge-management.md#save-the-configuration)
 
-Conection URLs are used by the Edge Daemon to reach the Gravitee Gateway and reactor. To configure the Edge Daemon for the Gateway, com
+### Configure the Gateway
+
+The Edge Daemon uses connection URLs to communicate with the Gravitee API Gateway and the Edge Reactor. To configure the Edge Daemon for the Gateway, complete the following fields:
 
 <figure><img src="../../.gitbook/assets/edge-config-gateway.png" alt="Gateway section: Gateway URL and Reactor URL, locked after creation"><figcaption><p>The Gateway and Reactor URLs are locked once the configuration is created.</p></figcaption></figure>
 
-The following fields define the connection URLs the Edge Daemon uses to reach the Gravitee gateway and reactor:
+The following table describes each field:
 
-| Field           | Description                                                                                    |
-| --------------- | ---------------------------------------------------------------------------------------------- |
-| **Gateway URL** | Base URL of the AI Gateway the daemon routes proxied traffic to.                               |
-| **Reactor URL** | URL of the Edge Reactor that serves daemon configuration and collects heartbeats and metrics.      |
+| Field           | Description                                                                                   |
+| --------------- | --------------------------------------------------------------------------------------------- |
+| **Gateway URL** | Base URL of the Gravitee API Gateway that the daemon routes traffic to.                       |
+| **Reactor URL** | URL of the Edge Reactor that serves daemon configuration and collects heartbeats and metrics. |
 
-{% hint style="caution" %}
-The Gateway URL and Reactor URL are locked after you create the configuration is first created. They cannot be changed after you complete the configuration.
+{% hint style="info" %}
+The Gateway URL and Reactor URL are locked after the configuration is first created. They cannot be changed afterwards.
 {% endhint %}
 
-## Configure the Proxy
+### Configure the Proxy
 
 Configure how the daemon intercepts traffic and routes it to gateway APIs.
 
@@ -45,22 +46,22 @@ Configure how the daemon intercepts traffic and routes it to gateway APIs.
 
 Configure the following settings:
 
-* **DNS domains (interception mode).** The domains the daemon's DNS resolver intercepts. For example `api.anthropic.com`. Traffic to these domains is captured and routed according to the route configuration.
+* **DNS domains (interception mode).** The domains the daemon's DNS resolver intercepts. For example, `api.anthropic.com`. Traffic to these domains is captured and routed according to the route configuration.
 * **Routes.** Ordered rules that map a request path to a Gateway API. **First match wins.** Each route has the following properties:
-  * A**path prefix**. For example `/v1/messages`.
-  * An **API path**. The gateway API endpoint that handles it. For example `/interception/claude`.
-  * (Optional)A **provider**. For example `anthropic`.
+  * A **path prefix**. For example, `/v1/messages`.
+  * An **API path**. The gateway API endpoint that handles it. For example, `/interception/claude`.
+  * A **provider**. This property is optional. For example, `anthropic`.
 
 A typical Claude Code setup uses the following two routes:
 
-| Path prefix     | API path                   | Provider    | Captured by     |
-| --------------- | -------------------------- | ----------- | --------------- |
-| `/v1/messages`  | `/interception/claude`     | `anthropic` | LLM Proxy API   |
-| `/`             | `/interception/passthrough`| `anthropic` | HTTP Proxy API  |
+| Path prefix    | API path                    | Provider    | Captured by    |
+| -------------- | --------------------------- | ----------- | -------------- |
+| `/v1/messages` | `/interception/claude`      | `anthropic` | LLM Proxy API  |
+| `/`            | `/interception/passthrough` | `anthropic` | HTTP Proxy API |
 
 LLM calls to `/v1/messages` are routed to the **LLM Proxy API**. All other traffic reaches the **HTTP Proxy API**.
 
-## Configure Shadow AI monitoring
+### Configure Shadow AI monitoring
 
 Detect direct connections to AI providers that bypass the Gateway.
 
@@ -68,16 +69,19 @@ Detect direct connections to AI providers that bypass the Gateway.
 
 Configure the following settings:
 
-* **Monitored domains.** Domains to watch for non-proxied direct connections. For example `api.openai.com`. Detection is based on TCP connection monitoring. No traffic content is inspected.
-* **Report interval (seconds).** How often the daemon aggregates and reports detections, with a minimum of 10 seconds.
+* **Monitored domains.** Domains to watch for non-proxied direct connections. For example, `api.openai.com`. Detection is based on TCP connection monitoring. No traffic content is inspected.
+* **Report interval (seconds).** How often the daemon aggregates and reports detections. The minimum is 10 seconds and the default is 120 seconds.
 
-## Save the configuration
+### Save the configuration
 
-* Select either of the following actions:
- * **Create connfiguration** to deploy your configuration. 
- * **Save changes** to save your configuration but not deploy it. 
+The **Configuration** page has a single save action. Depending on whether a configuration already exists, the button displays one of the following labels:
 
- When you deploy the fconfiguration, The DNS domains, routes, and shadow AI settings are pushed to daemons the next time they poll the Edge Reactor for configuration. The configuration applies without restarting the daemon.
+* **Create configuration**. This label appears the first time you configure Edge Management. Select it to create and deploy the configuration.
+* **Save changes**. This label appears when you edit an existing configuration. Select it to update and redeploy the configuration.
+
+To discard unsaved edits and restore the last saved values, select **Reset**.
+
+Saving always deploys the configuration. The DNS domains, routes, and shadow AI settings are pushed to daemons the next time they poll the Edge Reactor for configuration. The configuration applies without restarting the daemon.
 
 ## Next steps
 


### PR DESCRIPTION
Brings `docs/gamma/4.13/edge-management/connect/configure-edge-management.md` in line with the 4.12 page verified against the live console in #2117.

## Why this was left behind

#2117 verified and repaired the 4.12 page. Its 4.13 copy had already diverged, so that PR deliberately did not touch it — and the divergence was cosmetic, not editorial. The result is that **every defect stayed on 4.13**, and unlike the hidden pages in this area, this one is `hidden: false` / `noIndex: false`, so it is published.

Most visibly, a sentence ended mid-word on the live page:

> Conection URLs are used by the Edge Daemon to reach the Gravitee Gateway and reactor. To configure the Edge Daemon for the Gateway, com

## What changed

**Meaning-level, all traced to the 4.12 verification:**

- The truncated sentence is completed as "complete the following fields:". This was resolved against the live console rather than guessed: the Gateway section contains exactly two controls, no buttons and no sub-steps, and the sentence is followed by a table describing those two fields.
- The garbled clause "locked after you create the configuration is first created" becomes "locked after the configuration is first created. They cannot be changed afterwards." The underlying fact is correct and confirmed — both URL fields are disabled once a configuration exists, with a **Locked** badge.
- The save section was wrong beyond its typos. It described **Create configuration** and **Save changes** as two actions you choose between, with **Save changes** saving without deploying. There is one save button whose label switches on whether a configuration exists, and every save both persists and deploys. There is no save-without-deploy path.
- The report interval default of 120 seconds was missing.
- "deploying Kandji to the Edge Daemon" reversed the relationship.
- "AI Gateway" corrected to "Gravitee API Gateway", matching the console's own helper text and this page's screenshot.

**Form-level:**

- Typos: `Conection`, `connfiguration`, `fconfiguration`, and a duplicated bullet marker.
- `{% hint style="caution" %}` replaced with `info`. GitBook does not support `caution`, so that hint was not rendering as intended.
- Procedure subsection overview with anchor links, and subsection headings demoted beneath it.

## Version differences preserved

4.13 keeps its own frontmatter and its unsuffixed image filenames. After this change those are the **only** two differences between the 4.12 and 4.13 copies — verified by diffing the two files directly.

## Note for the writer

The `edge-config-*.png` assets exist as byte-identical pairs under 4.12, with and without a ` (1)` suffix; 4.12 references the suffixed set and 4.13 its own unsuffixed set. Consolidating them is deliberately out of scope here, since the auto-rename-images workflow has an orphan-deletion behaviour that makes it risky to do incidentally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)