### PR TITLE
docs(gamma): remove malformed draft markers from published ESM pages

### DIFF
--- a/docs/gamma/4.12/event-stream-management/build/README.md
+++ b/docs/gamma/4.12/event-stream-management/build/README.md
@@ -2,7 +2,7 @@
 hidden: false
 noIndex: false
 ---
-<--to be published -->
+
 # Build
 
 Create and configure governed Kafka services and virtual clusters on top of your registered Kafka infrastructure.

--- a/docs/gamma/4.12/event-stream-management/build/create-a-kafka-service-with-a-virtual-cluster.md
+++ b/docs/gamma/4.12/event-stream-management/build/create-a-kafka-service-with-a-virtual-cluster.md
@@ -2,7 +2,6 @@
 hidden: false
 noIndex: false
 ---
-<--- to be published --->
 
 # Create a Kafka service with a Virtual Cluster
 

--- a/docs/gamma/4.12/event-stream-management/build/establish-a-virtual-cluster.md
+++ b/docs/gamma/4.12/event-stream-management/build/establish-a-virtual-cluster.md
@@ -2,7 +2,7 @@
 hidden: false
 noIndex: false
 ---
-<-- to be published-->
+
 # Establish a Virtual Cluster
 
 A Virtual Cluster federates multiple independent Kafka backends into a single unified endpoint. Instead of managing separate cluster connections for each team or workload, a Virtual Cluster lets clients connect to one endpoint and transparently interact with topics spread across multiple underlying Registered Clusters.

--- a/docs/gamma/4.13/event-stream-management/build/README.md
+++ b/docs/gamma/4.13/event-stream-management/build/README.md
@@ -2,7 +2,7 @@
 hidden: false
 noIndex: false
 ---
-<--to be published -->
+
 # Build
 
 Create and configure governed Kafka services and virtual clusters on top of your registered Kafka infrastructure.

--- a/docs/gamma/4.13/event-stream-management/build/create-a-kafka-service-with-a-registered-cluster.md
+++ b/docs/gamma/4.13/event-stream-management/build/create-a-kafka-service-with-a-registered-cluster.md
@@ -3,7 +3,6 @@ description: Create a Kafka Service in Event Stream Management and bind it to a 
 hidden: false
 noIndex: false
 ---
-<--- to be published --->
 
 # Create a Kafka service with a registered cluster
 

--- a/docs/gamma/4.13/event-stream-management/build/create-a-kafka-service-with-a-virtual-cluster.md
+++ b/docs/gamma/4.13/event-stream-management/build/create-a-kafka-service-with-a-virtual-cluster.md
@@ -2,7 +2,6 @@
 hidden: false
 noIndex: false
 ---
-<--- to be published --->
 
 # Create a Kafka service with a Virtual Cluster
 

--- a/docs/gamma/4.13/event-stream-management/build/establish-a-virtual-cluster.md
+++ b/docs/gamma/4.13/event-stream-management/build/establish-a-virtual-cluster.md
@@ -2,7 +2,7 @@
 hidden: false
 noIndex: false
 ---
-<-- to be published-->
+
 # Establish a Virtual Cluster
 
 A Virtual Cluster federates multiple independent Kafka backends into a single unified endpoint. Instead of managing separate cluster connections for each team or workload, a Virtual Cluster lets clients connect to one endpoint and transparently interact with topics spread across multiple underlying Registered Clusters.


### PR DESCRIPTION
Removes a "to be published" draft marker from seven Event Stream Management build pages across 4.12 and 4.13.

## Why this matters

The markers appear in three inconsistent forms:

```
<--to be published -->
<--- to be published --->
<-- to be published-->
```

**None of them is a valid HTML comment.** A comment opens with `<!--`, not `<--` or `<---`. They were never hidden — they render as visible text, sitting between the frontmatter and the H1, so they appear directly above the page title.

Every affected page is `hidden: false` and `noIndex: false`, so all seven are published.

## Files

**4.12**
- `event-stream-management/build/README.md`
- `event-stream-management/build/create-a-kafka-service-with-a-virtual-cluster.md`
- `event-stream-management/build/establish-a-virtual-cluster.md`

**4.13**
- `event-stream-management/build/README.md`
- `event-stream-management/build/create-a-kafka-service-with-a-registered-cluster.md`
- `event-stream-management/build/create-a-kafka-service-with-a-virtual-cluster.md`
- `event-stream-management/build/establish-a-virtual-cluster.md`

## What changed

The marker line is removed and the blank line between the frontmatter and the heading is normalised. Nothing else on any page is touched — 4 insertions, 7 deletions across 7 files.

A repo-wide scan confirms no instance of this pattern remains in `docs/`.

## Note

If these pages genuinely are not ready to publish, the marker was not achieving that — they have been live regardless. Setting `hidden: true` / `noIndex: true` is the mechanism that actually withholds a page, and that is an editorial call rather than something this PR assumes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)