### PR TITLE
docs(gamma): redirect 14 legacy URLs that 404 after the IA restructure

### DIFF
--- a/docs/gamma/4.12/.gitbook.yaml
+++ b/docs/gamma/4.12/.gitbook.yaml
@@ -3,3 +3,19 @@ root: ./
 structure:
   readme: README.md
   summary: SUMMARY.md
+
+redirects:
+ agent-management/edge-daemon: edge-management/get-started/README.md
+ agent-management/edge-daemon/connect-claude-code-to-daemon: edge-management/connect/README.md
+ agent-management/import/create-event-tools: agent-management/import/README.md
+ authorization-management/build: authorization-management/get-started/README.md
+ authorization-management/build/create-authorization-policies: authorization-management/configure/create-update-delete-policies.md
+ event-management/build/create-a-kafka-service: event-stream-management/build/create-a-kafka-service-with-a-registered-cluster.md
+ event-management/explorer: event-stream-management/get-started/README.md
+ event-management/explorer/create-kafka-topics: event-stream-management/get-started/README.md
+ event-management/explorer/inspect-kafka-messages: event-stream-management/get-started/README.md
+ event-management/explorer/manage-connections: event-stream-management/get-started/README.md
+ event-management/get-started: event-stream-management/get-started/README.md
+ event-management/get-started/create-your-first-kafka-topic: event-stream-management/get-started/README.md
+ event-management/get-started/event-management-overview: event-stream-management/get-started/event-stream-management-overview.md
+ platform-management/manage-the-platform: platform-management/overview.md

--- a/docs/gamma/4.12/authorization-management/get-started/authorization-management-overview.md
+++ b/docs/gamma/4.12/authorization-management/get-started/authorization-management-overview.md
@@ -6,7 +6,7 @@ noIndex: false
 
 # Authorization Management overview
 
-Authorization Management provides fine-grained, catalog-aware access control across all Gamma traffic types—APIs, MCP servers, AI models, agents, and custom resources. Policies are written in Gravitee Authorization Policy Language (GAPL), a subset of the Cedar policy language, and enforced at the wire level by Gamma's gateways.
+Authorization Management provides fine-grained, catalog-aware access control across all Gamma traffic types: APIs, MCP servers, AI models, agents, and custom resources. Policies are written in Gravitee Authorization Policy Language (GAPL), a subset of the Cedar policy language, and enforced at the wire level by Gamma's gateways.
 
 ## How it works
 
@@ -42,11 +42,11 @@ Authorization Management organizes policies into service-specific categories. Ea
 
 | Category              | What it governs                                                                                                                      | Entity types                               |
 | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------ |
-| **MCP Policies**      | Access to MCP servers, their tools, prompts, and resources.                                                                          | MCPServer, MCPTool, MCPPrompt, MCPResource |
-| **AI Model Policies** | Access to AI providers and specific models, with cost and token usage constraints.                                                   | LLMProvider, Model                         |
-| **API Policies**      | Access to API proxies, their endpoints, and data fields.                                                                             | API, Endpoint, DataField                   |
-| **A2A Policies**      | Which principals can invoke each A2A agent.                                                                                          | Agent                                      |
-| **Custom Policies**   | Policies for resources not routed as MCP, API, Agent, or AI Model—internal applications, data assets, and bespoke resources. | Custom (user-defined)                      |
+| **MCP Policies**      | Access to MCP servers, their tools, prompts, and resources.                                                                          | `MCPServer`, `MCPTool`, `MCPPrompt`, `MCPResource` |
+| **AI Model Policies** | Access to AI providers and specific models, with cost and token usage constraints.                                                   | `LLMProvider`, `Model`                         |
+| **API Policies**      | Access to API proxies, their endpoints, and data fields.                                                                             | `API`, `Endpoint`, `DataField`                   |
+| **A2A Policies**      | Which principals can invoke each A2A agent.                                                                                          | `Agent`                                      |
+| **Custom Policies**   | Policies for resources not routed as MCP, API, Agent, or AI Model: internal applications, data assets, and bespoke resources. | Custom (user-defined)                      |
 
 ## Condition snippets
 
@@ -124,4 +124,4 @@ Authorization Management integrates with the API Gateway and AI Gateway as a sha
 
 ## Next steps
 
-* [Create authorization policies](../build/create-authorization-policies.md). Learn how to create, edit, and deploy policies for each service category.
+* [Create, update, and delete policies](../configure/create-update-delete-policies.md). Learn how to create, edit, and deploy policies for each service category.

--- a/docs/gamma/4.13/.gitbook.yaml
+++ b/docs/gamma/4.13/.gitbook.yaml
@@ -3,3 +3,19 @@ root: ./
 structure:
   readme: README.md
   summary: SUMMARY.md
+
+redirects:
+ agent-management/edge-daemon: edge-management/get-started/README.md
+ agent-management/edge-daemon/connect-claude-code-to-daemon: edge-management/connect/README.md
+ agent-management/import/create-event-tools: agent-management/import/README.md
+ authorization-management/build: authorization-management/get-started/README.md
+ authorization-management/build/create-authorization-policies: authorization-management/configure/create-update-delete-policies.md
+ event-management/build/create-a-kafka-service: event-stream-management/build/create-a-kafka-service-with-a-registered-cluster.md
+ event-management/explorer: event-stream-management/get-started/README.md
+ event-management/explorer/create-kafka-topics: event-stream-management/get-started/README.md
+ event-management/explorer/inspect-kafka-messages: event-stream-management/get-started/README.md
+ event-management/explorer/manage-connections: event-stream-management/get-started/README.md
+ event-management/get-started: event-stream-management/get-started/README.md
+ event-management/get-started/create-your-first-kafka-topic: event-stream-management/get-started/README.md
+ event-management/get-started/event-management-overview: event-stream-management/get-started/event-stream-management-overview.md
+ platform-management/manage-the-platform: platform-management/overview.md

--- a/docs/gamma/4.13/authorization-management/get-started/authorization-management-overview.md
+++ b/docs/gamma/4.13/authorization-management/get-started/authorization-management-overview.md
@@ -6,7 +6,7 @@ noIndex: false
 
 # Authorization Management overview
 
-Authorization Management provides fine-grained, catalog-aware access control across all Gamma traffic types—APIs, MCP servers, AI models, agents, and custom resources. Policies are written in Gravitee Authorization Policy Language (GAPL), a subset of the Cedar policy language, and enforced at the wire level by Gamma's gateways.
+Authorization Management provides fine-grained, catalog-aware access control across all Gamma traffic types: APIs, MCP servers, AI models, agents, and custom resources. Policies are written in Gravitee Authorization Policy Language (GAPL), a subset of the Cedar policy language, and enforced at the wire level by Gamma's gateways.
 
 ## How it works
 
@@ -42,11 +42,11 @@ Authorization Management organizes policies into service-specific categories. Ea
 
 | Category              | What it governs                                                                                                                      | Entity types                               |
 | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------ |
-| **MCP Policies**      | Access to MCP servers, their tools, prompts, and resources.                                                                          | MCPServer, MCPTool, MCPPrompt, MCPResource |
-| **AI Model Policies** | Access to AI providers and specific models, with cost and token usage constraints.                                                   | LLMProvider, Model                         |
-| **API Policies**      | Access to API proxies, their endpoints, and data fields.                                                                             | API, Endpoint, DataField                   |
-| **A2A Policies**      | Which principals can invoke each A2A agent.                                                                                          | Agent                                      |
-| **Custom Policies**   | Policies for resources not routed as MCP, API, Agent, or AI Model—internal applications, data assets, and bespoke resources. | Custom (user-defined)                      |
+| **MCP Policies**      | Access to MCP servers, their tools, prompts, and resources.                                                                          | `MCPServer`, `MCPTool`, `MCPPrompt`, `MCPResource` |
+| **AI Model Policies** | Access to AI providers and specific models, with cost and token usage constraints.                                                   | `LLMProvider`, `Model`                         |
+| **API Policies**      | Access to API proxies, their endpoints, and data fields.                                                                             | `API`, `Endpoint`, `DataField`                   |
+| **A2A Policies**      | Which principals can invoke each A2A agent.                                                                                          | `Agent`                                      |
+| **Custom Policies**   | Policies for resources not routed as MCP, API, Agent, or AI Model: internal applications, data assets, and bespoke resources. | Custom (user-defined)                      |
 
 ## Condition snippets
 
@@ -124,4 +124,4 @@ Authorization Management integrates with the API Gateway and AI Gateway as a sha
 
 ## Next steps
 
-* [Create authorization policies](../build/create-authorization-policies.md). Learn how to create, edit, and deploy policies for each service category.
+* [Create, update, and delete policies](../configure/create-update-delete-policies.md). Learn how to create, edit, and deploy policies for each service category.


### PR DESCRIPTION
Jira tickets: 

- https://gravitee.atlassian.net/browse/DOC-1832 
- https://gravitee.atlassian.net/browse/DOC-1831

## Redirect map

| Legacy URL (under `/gravitee-gamma/`) | Target file |
| --- | --- |
| `agent-management/edge-daemon` | `edge-management/get-started/README.md` |
| `agent-management/edge-daemon/connect-claude-code-to-daemon` | `edge-management/connect/README.md` (successor page `edge-management/connect-claude-code-to-daemon.md` is still `hidden: true`; retarget when it publishes) |
| `agent-management/import/create-event-tools` | `agent-management/import/README.md` (page removed; Import section index is the nearest surface) |
| `authorization-management/build` | `authorization-management/get-started/README.md` |
| `authorization-management/build/create-authorization-policies` | `authorization-management/configure/create-update-delete-policies.md` |
| `event-management/build/create-a-kafka-service` | `event-stream-management/build/create-a-kafka-service-with-a-registered-cluster.md` |
| `event-management/explorer` (and `/manage-connections`, `/create-kafka-topics`, `/inspect-kafka-messages`) | `event-stream-management/get-started/README.md` (Explorer section removed from docs) |
| `event-management/get-started` | `event-stream-management/get-started/README.md` |
| `event-management/get-started/create-your-first-kafka-topic` | `event-stream-management/get-started/README.md` (page removed) |
| `event-management/get-started/event-management-overview` | `event-stream-management/get-started/event-stream-management-overview.md` |
| `platform-management/manage-the-platform` | `platform-management/overview.md` |

## Also in this PR

- `authorization-management/get-started/authorization-management-overview.md` (both versions): the Next steps link pointed at the removed `../build/create-authorization-policies.md` and is repointed to `../configure/create-update-delete-policies.md` with the target page's title as link text.
- Style debt on that same page, flagged by the local Vale hook: the GAPL entity-type identifiers in the Policy categories table (`MCPServer`, `MCPTool`, `MCPPrompt`, `MCPResource`, `LLMProvider`, `LLMModel`, `API`, `Endpoint`, `DataField`) are now backticked, and em dashes are replaced with colons or a sentence split. Vale on the page: 8 hits before, 0 errors and 0 warnings after (2 suggestions remain: one pre-existing long sentence, one false positive on the `);` line inside the GAPL code fence).
