### PR TITLE
docs(apim): remove payload-validation claims and refresh Anthropic model IDs

### DIFF
--- a/docs/apim/4.12/ai-agent-management/llm-proxy/accepted-request-formats.md
+++ b/docs/apim/4.12/ai-agent-management/llm-proxy/accepted-request-formats.md
@@ -8,7 +8,7 @@ This means you can point an OpenAI, Anthropic, or Gemini SDK at the same LLM Pro
 This page covers the formats you can send requests **in**, on the client side. For how the LLM Proxy maps a request **out** to each backend provider (Gemini, Bedrock, OpenAI, Anthropic, and Vertex AI), see the provider details on the [LLM proxy](README.md) overview page. The **Vertex AI** provider connects to Google Cloud's Gemini Enterprise Agent Platform (formerly Vertex AI).
 {% endhint %}
 
-The LLM Proxy validates every request body against a JSON schema for the matched format before it forwards or normalizes the request. An invalid or empty body returns a `400` response with an OpenAI-style error object. A supported path called with an unsupported HTTP method returns `405`.
+The LLM Proxy doesn't validate the request body. It matches the request to a client format, normalizes it if needed, and forwards it. Bodies that are empty, malformed, or missing fields are passed through to the provider, which returns its own error. A supported path called with an unsupported HTTP method returns `405`.
 
 ## Supported endpoints
 
@@ -25,13 +25,13 @@ The LLM Proxy matches an inbound request to a client format based on the request
 | Gemini generate content | `/v1beta/models/{model}:generateContent` | `POST` |
 | Gemini streaming generate content | `/v1beta/models/{model}:streamGenerateContent` | `POST` |
 
-A request that sets `Content-Encoding: zstd` is decompressed automatically before validation. This support exists for clients such as the Codex CLI. The LLM Proxy doesn't decompress other content encodings.
+A request that sets `Content-Encoding: zstd` is decompressed automatically before the body is read. This support exists for clients such as the Codex CLI. The LLM Proxy doesn't decompress other content encodings.
 
 ## OpenAI format
 
-OpenAI is the LLM Proxy's internal format, so OpenAI requests don't need normalization. The LLM Proxy validates the body against the OpenAI schema for the endpoint and forwards it, applying only the targeted changes described below.
+OpenAI is the LLM Proxy's internal format, so OpenAI requests don't need normalization. The LLM Proxy forwards the body, applying only the targeted changes described below.
 
-Each OpenAI endpoint validates the body against a fixed set of fields. `model` and `messages` are required for `/chat/completions`. `model` and `input` are required for `/responses` and `/embeddings`. These endpoints don't allow unknown top-level fields, so a request that includes a field outside the OpenAI specification returns a `400` response.
+Send the fields the provider expects: `model` and `messages` for `/chat/completions`, and `model` and `input` for `/responses` and `/embeddings`. The LLM Proxy doesn't reject unknown top-level fields, so a field outside the OpenAI specification is forwarded to the provider, which decides whether to accept it.
 
 ### Chat completions
 
@@ -65,7 +65,7 @@ If the backend returns a Chat Completions response (`"object": "chat.completion"
 
 ### Embeddings and models
 
-The `/embeddings` endpoint validates `model` and `input` and forwards the body unchanged. The `/models` endpoint is a `GET` request with no body, and the backend response is returned unchanged.
+The `/embeddings` endpoint forwards the body unchanged. The `/models` endpoint is a `GET` request with no body, and the backend response is returned unchanged.
 
 ## Anthropic Messages format
 

--- a/docs/apim/4.12/ai-agent-management/llm-proxy/accepted-request-formats.md
+++ b/docs/apim/4.12/ai-agent-management/llm-proxy/accepted-request-formats.md
@@ -1,8 +1,8 @@
 # Accepted request formats
 
-The Gravitee LLM Proxy accepts inbound requests in three client API formats: OpenAI, Anthropic Messages, and Gemini `generateContent`. OpenAI is the LLM Proxy's internal format, so OpenAI requests pass through with minimal change. Anthropic and Gemini requests are normalized to OpenAI Chat Completions format before the policy chain and the backend provider mapping run, and the response is converted back to the format the client used.
+The Gravitee LLM Proxy accepts inbound requests in three client API formats: OpenAI, Anthropic Messages, and Gemini `generateContent`. OpenAI is the LLM Proxy's internal format, so OpenAI requests pass through with minimal change. Anthropic and Gemini requests are normalized to OpenAI Chat Completions format before the policy chain and the backend provider mapping run. The response is then converted back to the format the client used.
 
-This means you can point an OpenAI, Anthropic, or Gemini SDK at the same LLM Proxy and get responses in that same format, regardless of which backend provider the LLM Proxy is configured to call.
+This means you can point an OpenAI, Anthropic, or Gemini SDK at the same LLM Proxy and get responses in that same format. The backend provider the LLM Proxy calls doesn't change the format you receive.
 
 {% hint style="info" %}
 This page covers the formats you can send requests **in**, on the client side. For how the LLM Proxy maps a request **out** to each backend provider (Gemini, Bedrock, OpenAI, Anthropic, and Vertex AI), see the provider details on the [LLM proxy](README.md) overview page. The **Vertex AI** provider connects to Google Cloud's Gemini Enterprise Agent Platform (formerly Vertex AI).
@@ -29,7 +29,7 @@ A request that sets `Content-Encoding: zstd` is decompressed automatically befor
 
 ## OpenAI format
 
-OpenAI is the LLM Proxy's internal format, so OpenAI requests don't need normalization. The LLM Proxy forwards the body, applying only the targeted changes described below.
+OpenAI is the LLM Proxy's internal format, so OpenAI requests don't need normalization. The LLM Proxy forwards the body, applying only the targeted changes described in the following sections.
 
 Send the fields the provider expects: `model` and `messages` for `/chat/completions`, and `model` and `input` for `/responses` and `/embeddings`. The LLM Proxy doesn't reject unknown top-level fields, so a field outside the OpenAI specification is forwarded to the provider, which decides whether to accept it.
 

--- a/docs/apim/4.12/ai-agent-management/llm-proxy/connect-claude-code-through-gravitee-llm-proxy.md
+++ b/docs/apim/4.12/ai-agent-management/llm-proxy/connect-claude-code-through-gravitee-llm-proxy.md
@@ -80,12 +80,12 @@ Claude Code sends Anthropic model IDs without a provider prefix. The LLM Proxy m
    * **Strict allowlist:** Select the **Alias** variant, and then add each model. Here is an example of adding each model:
 
      ```text
-     claude-sonnet-4-6
-     claude-opus-4-8
-     claude-haiku-4-5-20251001
+     claude-opus-5
+     claude-sonnet-5
+     claude-haiku-4-5
      ```
 
-A provider requires at least one model even when globbing is enabled. Add a seed model such as `claude-sonnet-4-6`.
+A provider requires at least one model even when globbing is enabled. Add a seed model such as `claude-sonnet-5`.
 
 Do not enable **Only use alias**. Claude Code sends real Anthropic model IDs, and **Only use alias** hides them behind aliases, so every request would be rejected.
 
@@ -198,7 +198,7 @@ Check that:
 * The requested model is explicitly added, or unregistered model globbing matches it.
 * **Only use alias** is disabled.
 * The API was redeployed after changing model governance.
-* Claude Code is sending the expected model ID, for example `claude-sonnet-4-6`.
+* Claude Code is sending the expected model ID, for example `claude-sonnet-5`.
 
 ### Anthropic authentication errors
 

--- a/docs/apim/4.13/ai-agent-management/llm-proxy/accepted-request-formats.md
+++ b/docs/apim/4.13/ai-agent-management/llm-proxy/accepted-request-formats.md
@@ -1,14 +1,14 @@
 # Accepted request formats
 
-The Gravitee LLM Proxy accepts inbound requests in three client API formats: OpenAI, Anthropic Messages, and Gemini `generateContent`. OpenAI is the LLM Proxy's internal format, so OpenAI requests pass through with minimal change. Anthropic and Gemini requests are normalized to OpenAI Chat Completions format before the policy chain and the backend provider mapping run, and the response is converted back to the format the client used.
+The Gravitee LLM Proxy accepts inbound requests in three client API formats: OpenAI, Anthropic Messages, and Gemini `generateContent`. OpenAI is the LLM Proxy's internal format, so OpenAI requests pass through with minimal change. Anthropic and Gemini requests are normalized to OpenAI Chat Completions format before the policy chain and the backend provider mapping run. The response is then converted back to the format the client used.
 
-This means you can point an OpenAI, Anthropic, or Gemini SDK at the same LLM Proxy and get responses in that same format, regardless of which backend provider the LLM Proxy is configured to call.
+This means you can point an OpenAI, Anthropic, or Gemini SDK at the same LLM Proxy and get responses in that same format. The backend provider the LLM Proxy calls doesn't change the format you receive.
 
 {% hint style="info" %}
 This page covers the formats you can send requests **in**, on the client side. For how the LLM Proxy maps a request **out** to each backend provider (Gemini, Bedrock, OpenAI, Anthropic, and Vertex AI), see the provider details on the [LLM proxy](README.md) overview page. The **Vertex AI** provider connects to Google Cloud's Gemini Enterprise Agent Platform (formerly Vertex AI).
 {% endhint %}
 
-The LLM Proxy validates every request body against a JSON schema for the matched format before it forwards or normalizes the request. An invalid or empty body returns a `400` response with an OpenAI-style error object. A supported path called with an unsupported HTTP method returns `405`.
+The LLM Proxy doesn't validate the request body. It matches the request to a client format, normalizes it if needed, and forwards it. Bodies that are empty, malformed, or missing fields are passed through to the provider, which returns its own error. A supported path called with an unsupported HTTP method returns `405`.
 
 ## Supported endpoints
 
@@ -25,13 +25,13 @@ The LLM Proxy matches an inbound request to a client format based on the request
 | Gemini generate content | `/v1beta/models/{model}:generateContent` | `POST` |
 | Gemini streaming generate content | `/v1beta/models/{model}:streamGenerateContent` | `POST` |
 
-A request that sets `Content-Encoding: zstd` is decompressed automatically before validation. This support exists for clients such as the Codex CLI. The LLM Proxy doesn't decompress other content encodings.
+A request that sets `Content-Encoding: zstd` is decompressed automatically before the body is read. This support exists for clients such as the Codex CLI. The LLM Proxy doesn't decompress other content encodings.
 
 ## OpenAI format
 
-OpenAI is the LLM Proxy's internal format, so OpenAI requests don't need normalization. The LLM Proxy validates the body against the OpenAI schema for the endpoint and forwards it, applying only the targeted changes described below.
+OpenAI is the LLM Proxy's internal format, so OpenAI requests don't need normalization. The LLM Proxy forwards the body, applying only the targeted changes described in the following sections.
 
-Each OpenAI endpoint validates the body against a fixed set of fields. `model` and `messages` are required for `/chat/completions`. `model` and `input` are required for `/responses` and `/embeddings`. These endpoints don't allow unknown top-level fields, so a request that includes a field outside the OpenAI specification returns a `400` response.
+Send the fields the provider expects: `model` and `messages` for `/chat/completions`, and `model` and `input` for `/responses` and `/embeddings`. The LLM Proxy doesn't reject unknown top-level fields, so a field outside the OpenAI specification is forwarded to the provider, which decides whether to accept it.
 
 ### Chat completions
 
@@ -65,7 +65,7 @@ If the backend returns a Chat Completions response (`"object": "chat.completion"
 
 ### Embeddings and models
 
-The `/embeddings` endpoint validates `model` and `input` and forwards the body unchanged. The `/models` endpoint is a `GET` request with no body, and the backend response is returned unchanged.
+The `/embeddings` endpoint forwards the body unchanged. The `/models` endpoint is a `GET` request with no body, and the backend response is returned unchanged.
 
 ## Anthropic Messages format
 

--- a/docs/apim/4.13/ai-agent-management/llm-proxy/connect-claude-code-through-gravitee-llm-proxy.md
+++ b/docs/apim/4.13/ai-agent-management/llm-proxy/connect-claude-code-through-gravitee-llm-proxy.md
@@ -80,12 +80,12 @@ Claude Code sends Anthropic model IDs without a provider prefix. The LLM Proxy m
    * **Strict allowlist:** Select the **Alias** variant, and then add each model. Here is an example of adding each model:
 
      ```text
-     claude-sonnet-4-6
-     claude-opus-4-8
-     claude-haiku-4-5-20251001
+     claude-opus-5
+     claude-sonnet-5
+     claude-haiku-4-5
      ```
 
-A provider requires at least one model even when globbing is enabled. Add a seed model such as `claude-sonnet-4-6`.
+A provider requires at least one model even when globbing is enabled. Add a seed model such as `claude-sonnet-5`.
 
 Do not enable **Only use alias**. Claude Code sends real Anthropic model IDs, and **Only use alias** hides them behind aliases, so every request would be rejected.
 
@@ -198,7 +198,7 @@ Check that:
 * The requested model is explicitly added, or unregistered model globbing matches it.
 * **Only use alias** is disabled.
 * The API was redeployed after changing model governance.
-* Claude Code is sending the expected model ID, for example `claude-sonnet-4-6`.
+* Claude Code is sending the expected model ID, for example `claude-sonnet-5`.
 
 ### Anthropic authentication errors
 


### PR DESCRIPTION
Two corrections to APIM 4.12 LLM Proxy pages, both verified against source.

## 1. `accepted-request-formats` documents a feature removed from the product

The page states the LLM Proxy validates every request body against a JSON schema and returns `400` on an invalid or empty body, on missing required fields, and on unknown top-level fields.

Commit `92eb847` (2026-05-15, *"feat: remove payload validation"*) in `gravitee-reactor-llm-proxy` deleted `llm-schemas.json` and `PayloadValidator.java`.

Verified:

- Neither file exists at HEAD.
- The entrypoint test is now named `should_passthrough_payloads_with_missing_fields`.
- `git tag --contains` puts the removal in **`3.0.0`** onward; **`2.10.4`** is the last release that validated.
- The gateway in a local Gamma stack loads **`llm-proxy [3.1.1]`** — past that line — so the shipped behaviour is passthrough.

**The feature was removed one version before the page describing it.** Readers are told to expect a `400` on requests that are in fact forwarded to the provider, which returns its own error.

Changes:
- Drop the schema-validation claim from the intro and the OpenAI section.
- Reword required-fields guidance as what the *provider* expects, not what the proxy enforces.
- Drop "validates `model` and `input`" from the embeddings paragraph.
- Keep the `405` claim — method matching is unrelated to body validation.

## 2. `connect-claude-code` pins previous-generation model IDs

`claude-sonnet-4-6`, `claude-opus-4-8`, and the dated alias `claude-haiku-4-5-20251001` → **`claude-opus-5`**, **`claude-sonnet-5`**, **`claude-haiku-4-5`**, in the allowlist example, the seed-model line, and the troubleshooting checklist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)