### PR TITLE
AGENT-DRAFT: APIM-14587 — Conditional Updates for Plans

### DIFF
--- a/docs/apim/4.13/.version-overrides
+++ b/docs/apim/4.13/.version-overrides
@@ -16,3 +16,4 @@ create-and-configure-apis/apply-policies/policy-reference/generate-jwt.md
 release-information/breaking-changes-and-deprecations.md
 # Datadog request count tags (APIM 4.13.0 feature, APIM-14012)
 analyze-and-monitor-apis/reporters/datadog-reporter.md
+secure-and-expose-apis/plans/conditional-updates-for-plans.md

--- a/docs/apim/4.13/release-information/breaking-changes-and-deprecations.md
+++ b/docs/apim/4.13/release-information/breaking-changes-and-deprecations.md
@@ -15,6 +15,14 @@ Here are the breaking changes for versions 4.X of Gravitee and versions 3.X of G
 
 Here are the breaking changes from versions 4.X of Gravitee.
 
+#### 4.13.0
+
+**Management API v1 plan read operations reject V4 and Federated APIs**
+
+From 4.13.0, the Management API v1 plan read operations don't support V4 or Federated APIs. A request for a plan that belongs to a V4 or Federated API now returns `400 Bad Request`. Plan reads for V1 and V2 APIs are unaffected.
+
+If you have clients or scripts that read plans of V4 or Federated APIs through the Management API v1, update them to call the Management API v2 plan endpoints at `/management/v2/environments/{envId}/apis/{apiId}/plans/{planId}` before you upgrade.
+
 #### 4.12.0
 
 **JSON Validation policy: response error keys corrected**
@@ -78,7 +86,6 @@ When you upgrade to APIM 4.11, any APIs and documentation pages that you publish
 **New Developer Portal subscriptions require published API pages**
 
 When you upgrade to APIM 4.11, an API accepts subscriptions through the New Developer Portal only after you publish the API's pages. To enable subscriptions to an API, publish the API's pages through the **Navigation items** section of the New Developer Portal settings.
-
 
 #### 4.10.0
 

--- a/docs/apim/4.13/release-information/release-notes/apim-4.13.md
+++ b/docs/apim/4.13/release-information/release-notes/apim-4.13.md
@@ -30,6 +30,7 @@ documentation.gravitee.io links for other versions.
 * Branded senders apply a different **From** address and subject prefix to notification emails for each recipient domain, configurable per Organization and Environment.
 * The new `#jsonEscape` Expression Language function escapes a value so it can be safely inserted into a JSON document or JSON string literal, for example in a response template body.
 * The Generate JWT policy adds optional `x5t` and `x5t#S256` certificate thumbprint headers to generated JWTs, for downstream systems that select the validation certificate by thumbprint.
+* Management API v1 plan read operations now reject V4 and Federated APIs with `400 Bad Request`, directing those requests to the Management API v2 plan endpoints.
 
 ## New Features
 
@@ -71,3 +72,9 @@ documentation.gravitee.io links for other versions.
 * The `x509CertificateChain` option now works with the `INLINE` and `PEM` key resolvers. The policy builds the `x5c` header from the certificates included in the key material, ordered from the signing certificate outward, and drops certificates that don't link into the chain.
 * The policy now parses key material that bundles certificates together with the private key.
 * For the `INLINE` and `PEM` key resolvers, if no certificate in the key material matches the signing key, the policy omits the `x5c` header and signs the token anyway, logging a warning when the key material is loaded.
+
+#### **Management API v1 Plan Read Operations Restricted to V1 and V2 APIs**
+
+* Management API v1 plan read operations don't support V4 or Federated APIs and now return `400 Bad Request` for those requests instead of an incomplete plan representation.
+* Use the Management API v2 plan endpoints to read plans for V4 and Federated APIs.
+* Plan reads for V1 and V2 APIs are unaffected and continue to work through the Management API v1 endpoints.

--- a/docs/apim/4.13/secure-and-expose-apis/plans/conditional-updates-for-plans.md
+++ b/docs/apim/4.13/secure-and-expose-apis/plans/conditional-updates-for-plans.md
@@ -29,6 +29,8 @@ Optimistic concurrency control prevents lost updates when multiple clients modif
 * The `API_PLAN[UPDATE]` permission on the API (required for plan PATCH operations)
 * A plan with a non-null `updatedAt` timestamp (plans without this field will not return ETag or Last-Modified headers)
 
+Management API v1 plan read operations don't support V4 or Federated APIs and reject those requests with `400 Bad Request`. Use the Management API v2 plan endpoints instead. Plan reads for V1 and V2 APIs are unaffected.
+
 ## Managing Plan Updates
 
 ### Conditional Header Emission


### PR DESCRIPTION
Automated update: apim-14587

Product: apim
Version: 4.13

---

## Release deliverables (Step 0)

- ✅ Release notes entry added to `docs/apim/4.13/release-information/release-notes/apim-4.13.md` under **Improvements**: Management API v1 Plan Read Operations Restricted to V1 and V2 APIs
- \u2705 Breaking change entry added to `docs/apim/4.13/release-information/breaking-changes-and-deprecations.md` under **4.13.0**: Management API v1 plan read operations reject V4 and Federated APIs
- \u2705 Added 1 entry to `docs/apim/4.13/.version-overrides`: `secure-and-expose-apis/plans/conditional-updates-for-plans.md`

## Publishability gate

**Verdict: WARN**
- Duplicate headings detected (scope-naive check)



> Only lines this PR **adds** are judged. Pre-existing page content is never touched
> and never counted, so an already-dirty page is not penalised for debt it inherited.
> Removed items are gone from the committed file. Review items are left in place for
> you to decide on, because a blocked run produces no PR at all.