### PR TITLE
docs(gamma): add meta descriptions across API Management 4.12 and 4.13

### DIFF
--- a/docs/gamma/4.12/api-management/build/README.md
+++ b/docs/gamma/4.12/api-management/build/README.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Create and configure API proxies in Gamma with security plans, policies, and advanced runtime settings. Start with the build task you need.
 ---
 
 # Build

--- a/docs/gamma/4.12/api-management/build/api-products.md
+++ b/docs/gamma/4.12/api-management/build/api-products.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: API Products bundle multiple API proxies into one consumer-facing product with shared plans. Learn when to use them and how to create one.
 ---
 
 # Create API Products

--- a/docs/gamma/4.12/api-management/build/configure-your-api-product/README.md
+++ b/docs/gamma/4.12/api-management/build/configure-your-api-product/README.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Attach APIs, create plans, manage consumers and team access, and choose where an API Product deploys. Start with the area you need to configure.
 ---
 
 # Configure API products

--- a/docs/gamma/4.12/api-management/build/configure-your-api-product/api-product-configuration-reference.md
+++ b/docs/gamma/4.12/api-management/build/configure-your-api-product/api-product-configuration-reference.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Every API product property, the flag that decides which APIs can be bundled, and the plan types a product supports. Browse the full reference.
 ---
 
 # API product configuration reference

--- a/docs/gamma/4.12/api-management/build/configure-your-api-product/configure-product-deployment.md
+++ b/docs/gamma/4.12/api-management/build/configure-your-api-product/configure-product-deployment.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Assign sharding tags to an API Product so only the API Gateway instances that advertise a matching tag load it. Follow the steps on the Deployment tab.
 ---
 
 # Configure product deployment

--- a/docs/gamma/4.12/api-management/build/configure-your-api-product/manage-api-products-with-the-management-api.md
+++ b/docs/gamma/4.12/api-management/build/configure-your-api-product/manage-api-products-with-the-management-api.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Create an API product, attach APIs, add and publish plans, and deploy it over the v2 Management API. Follow the full lifecycle with request examples.
 ---
 
 # Manage API products with the Management API

--- a/docs/gamma/4.12/api-management/build/configure-your-api-product/manage-members-and-ownership.md
+++ b/docs/gamma/4.12/api-management/build/configure-your-api-product/manage-members-and-ownership.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Add members, attach groups, change roles, and transfer ownership of an API product. Follow the steps to manage access from the User Permissions tab.
 ---
 
 # Manage members and ownership

--- a/docs/gamma/4.12/api-management/build/configure-your-api-product/manage-product-apis.md
+++ b/docs/gamma/4.12/api-management/build/configure-your-api-product/manage-product-apis.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Attach and detach API proxies from an API Product so subscribers reach every API it bundles. Follow the steps to manage them on the APIs tab.
 ---
 
 # Manage product APIs

--- a/docs/gamma/4.12/api-management/build/configure-your-api-proxy/README.md
+++ b/docs/gamma/4.12/api-management/build/configure-your-api-proxy/README.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Refine an API proxy from the detail workspace, which groups configuration into seven sidebar sections. Start with the setting you need to change.
 ---
 
 # Configure your API proxy

--- a/docs/gamma/4.12/api-management/build/configure-your-api-proxy/apply-security-policies.md
+++ b/docs/gamma/4.12/api-management/build/configure-your-api-proxy/apply-security-policies.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Policies are rules the API Gateway evaluates on every request and response, on top of security plans. Learn how the policy chain runs and how to apply one.
 ---
 
 # Apply security policies

--- a/docs/gamma/4.12/api-management/build/configure-your-api-proxy/broadcast-messages-to-consumers.md
+++ b/docs/gamma/4.12/api-management/build/configure-your-api-proxy/broadcast-messages-to-consumers.md
@@ -1,9 +1,7 @@
 ---
-description: >-
-  Send one-way announcements about changes or maintenance to the consumers of
-  an API proxy.
 hidden: false
 noIndex: false
+description: Send a one-way announcement to the consumers of an API proxy about a change, an update, or a maintenance window. Follow the steps to compose one.
 ---
 
 # Broadcast messages to consumers

--- a/docs/gamma/4.12/api-management/build/configure-your-api-proxy/configure-api-properties.md
+++ b/docs/gamma/4.12/api-management/build/configure-your-api-proxy/configure-api-properties.md
@@ -1,9 +1,7 @@
 ---
-description: >-
-  Define static or dynamic key/value properties that policies read at runtime,
-  and encrypt sensitive values.
 hidden: false
 noIndex: false
+description: Define static or dynamic key/value properties that policies read at runtime through the Expression Language. Follow the steps to add and encrypt them.
 ---
 
 # Configure API properties

--- a/docs/gamma/4.12/api-management/build/configure-your-api-proxy/configure-api-resources.md
+++ b/docs/gamma/4.12/api-management/build/configure-your-api-proxy/configure-api-resources.md
@@ -1,9 +1,7 @@
 ---
-description: >-
-  Create API-level resources, such as caches and OAuth providers, that policies
-  reference at runtime.
 hidden: false
 noIndex: false
+description: Create API-level resources such as caches and OAuth providers that this API's policies reference at runtime. Follow the steps to add and manage them.
 ---
 
 # Configure API resources

--- a/docs/gamma/4.12/api-management/build/configure-your-api-proxy/configure-backend-security.md
+++ b/docs/gamma/4.12/api-management/build/configure-your-api-proxy/configure-backend-security.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Endpoint groups define where the API Gateway routes requests, with load balancing, timeouts, and TLS. Follow the steps to create a group and add endpoints.
 ---
 
 # Configure endpoints

--- a/docs/gamma/4.12/api-management/build/configure-your-api-proxy/configure-cors.md
+++ b/docs/gamma/4.12/api-management/build/configure-your-api-proxy/configure-cors.md
@@ -1,9 +1,7 @@
 ---
-description: >-
-  Allow browsers on other origins to call your API by configuring
-  cross-origin resource sharing.
 hidden: false
 noIndex: false
+description: Let browsers on other origins call your API by enabling cross-origin resource sharing and setting the allowed origins. Follow the steps to configure it.
 ---
 
 # Configure CORS

--- a/docs/gamma/4.12/api-management/build/configure-your-api-proxy/configure-deployment.md
+++ b/docs/gamma/4.12/api-management/build/configure-your-api-proxy/configure-deployment.md
@@ -1,9 +1,7 @@
 ---
-description: >-
-  Choose which gateway instances load an API definition by assigning sharding
-  tags.
 hidden: false
 noIndex: false
+description: Choose which API Gateway instances load an API definition by assigning sharding tags. Follow the steps on the Deployment Configuration page.
 ---
 
 # Configure deployment

--- a/docs/gamma/4.12/api-management/build/configure-your-api-proxy/configure-entrypoints.md
+++ b/docs/gamma/4.12/api-management/build/configure-your-api-proxy/configure-entrypoints.md
@@ -1,9 +1,7 @@
 ---
-description: >-
-  Change the context paths of an API proxy, or switch to virtual hosts, from
-  the Entrypoints page.
 hidden: false
 noIndex: false
+description: Change the context paths consumers use to reach an API proxy, or switch to virtual hosts. Follow the steps on the Entrypoints page to update them.
 ---
 
 # Configure entrypoints

--- a/docs/gamma/4.12/api-management/build/configure-your-api-proxy/configure-failover.md
+++ b/docs/gamma/4.12/api-management/build/configure-your-api-proxy/configure-failover.md
@@ -1,9 +1,7 @@
 ---
-description: >-
-  Turn on automatic retries with a circuit breaker so slow or failing backend
-  endpoints don't take your API down.
 hidden: false
 noIndex: false
+description: Turn on automatic retries with a circuit breaker so a slow or failing backend doesn't take your API down. Follow the steps to tune the thresholds.
 ---
 
 # Configure failover

--- a/docs/gamma/4.12/api-management/build/configure-your-api-proxy/configure-flow-execution.md
+++ b/docs/gamma/4.12/api-management/build/configure-your-api-proxy/configure-flow-execution.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Choose whether the API Gateway runs every matching policy flow or only the closest match. Follow the steps to set the flow execution mode.
 ---
 
 # Control how policy flows are matched to requests

--- a/docs/gamma/4.12/api-management/build/configure-your-api-proxy/configure-logging-and-tracing.md
+++ b/docs/gamma/4.12/api-management/build/configure-your-api-proxy/configure-logging-and-tracing.md
@@ -1,9 +1,7 @@
 ---
-description: >-
-  Control which request and response data an API proxy reports for logs and
-  analytics, and turn on OpenTelemetry tracing.
 hidden: false
 noIndex: false
+description: Control which request and response data an API proxy reports to logs and analytics, and turn on OpenTelemetry tracing. Follow the steps to configure it.
 ---
 
 # Configure logging and tracing

--- a/docs/gamma/4.12/api-management/build/configure-your-api-proxy/configure-notifications.md
+++ b/docs/gamma/4.12/api-management/build/configure-your-api-proxy/configure-notifications.md
@@ -1,9 +1,7 @@
 ---
-description: >-
-  Send console, email, or webhook notifications when API events occur, such as
-  deployments or subscription changes.
 hidden: false
 noIndex: false
+description: Send console, email, or webhook alerts when API events occur, such as a deployment or a subscription change. Follow the steps to add a notification.
 ---
 
 # Configure notifications

--- a/docs/gamma/4.12/api-management/build/configure-your-api-proxy/establish-consumer-access.md
+++ b/docs/gamma/4.12/api-management/build/configure-your-api-proxy/establish-consumer-access.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Applications, subscriptions, and API keys control how consumers discover and authenticate with your API. Learn how to review and approve a request.
 ---
 
 # Establish consumer access

--- a/docs/gamma/4.12/api-management/build/configure-your-api-proxy/manage-general-settings.md
+++ b/docs/gamma/4.12/api-management/build/configure-your-api-proxy/manage-general-settings.md
@@ -1,9 +1,7 @@
 ---
-description: >-
-  Edit the name, version, metadata, and images of an API proxy, and control its
-  runtime state from the General page.
 hidden: false
 noIndex: false
+description: Edit the name, version, metadata, and images of an API proxy, and start, stop, or delete it. Follow the steps on the General page to update them.
 ---
 
 # Manage general settings

--- a/docs/gamma/4.12/api-management/build/configure-your-api-proxy/manage-user-permissions.md
+++ b/docs/gamma/4.12/api-management/build/configure-your-api-proxy/manage-user-permissions.md
@@ -1,9 +1,7 @@
 ---
-description: >-
-  Add members, attach groups, change roles, and transfer primary ownership of
-  an API proxy.
 hidden: false
 noIndex: false
+description: Add direct members, attach groups, and transfer primary ownership of an API proxy. Follow the steps on the User Permissions page to manage access.
 ---
 
 # Manage user permissions

--- a/docs/gamma/4.12/api-management/build/configure-your-api-proxy/review-deployment-history.md
+++ b/docs/gamma/4.12/api-management/build/configure-your-api-proxy/review-deployment-history.md
@@ -1,9 +1,7 @@
 ---
-description: >-
-  Compare deployed versions of an API definition and roll back to an earlier
-  one.
 hidden: false
 noIndex: false
+description: Compare two deployed versions of an API definition and roll back to an earlier one. Follow the steps to inspect the history and restore a version.
 ---
 
 # Review deployment history

--- a/docs/gamma/4.12/api-management/build/create-an-api-proxy.md
+++ b/docs/gamma/4.12/api-management/build/create-an-api-proxy.md
@@ -1,9 +1,7 @@
 ---
-description: >-
-  Create an API proxy in the Gamma console with the from-scratch wizard or a
-  quick-start template, then review the proxy Overview page.
 hidden: false
 noIndex: false
+description: Create an API proxy in the Gamma console with the from-scratch wizard or a quick-start template. Follow the steps through each wizard option.
 ---
 
 # Create an API proxy

--- a/docs/gamma/4.12/api-management/build/secure-your-api-proxy.md
+++ b/docs/gamma/4.12/api-management/build/secure-your-api-proxy.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Attach a Keyless, API Key, JWT, OAuth2, or mTLS plan to control how consumers authenticate to an API proxy. Follow the steps to add one and deploy it.
 ---
 
 # Secure your API proxy

--- a/docs/gamma/4.12/api-management/build/shared-policy-groups.md
+++ b/docs/gamma/4.12/api-management/build/shared-policy-groups.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: A shared policy group configures a set of policies once and reuses them across APIs and flows. Follow the steps to attach one in the Policy Studio.
 ---
 
 # Reuse policies with shared policy groups

--- a/docs/gamma/4.12/api-management/get-started/README.md
+++ b/docs/gamma/4.12/api-management/get-started/README.md
@@ -1,7 +1,7 @@
 ---
 hidden: false
 noIndex: false
-description: Start here to learn what API Management does in Gamma and to create your first API proxy.
+description: API Management in Gamma, from the overview of its key concepts to the quickstart that builds your first API proxy. Start with the page you need.
 ---
 
 # Get started

--- a/docs/gamma/4.12/api-management/get-started/api-management-overview.md
+++ b/docs/gamma/4.12/api-management/get-started/api-management-overview.md
@@ -1,5 +1,5 @@
 ---
-description: Explains what API Management does within Gamma, its key capabilities, and how it connects to the other Gamma product lines.
+description: API Management governs REST, GraphQL, gRPC, and WebSocket traffic through API proxies. Learn what it does and how it fits the Gamma platform.
 ---
 
 # API Management overview

--- a/docs/gamma/4.12/api-management/get-started/create-your-first-api.md
+++ b/docs/gamma/4.12/api-management/get-started/create-your-first-api.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Create a keyless API proxy in the Gamma console, deploy it to the API Gateway, and verify it with a test request. Follow the quickstart to build one.
 ---
 
 # Create your first API

--- a/docs/gamma/4.12/api-management/observe/README.md
+++ b/docs/gamma/4.12/api-management/observe/README.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Monitor, troubleshoot, and audit your API traffic with dashboards, usage metrics, health checks, and logs. Start with what you need to see.
 ---
 
 # Observe

--- a/docs/gamma/4.12/api-management/observe/api-dashboard.md
+++ b/docs/gamma/4.12/api-management/observe/api-dashboard.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: The Gamma homepage dashboard shows per-module metrics, quick actions, and guidance for empty states. Learn what each metric and quick action does.
 ---
 
 # Dashboard and metrics

--- a/docs/gamma/4.12/api-management/observe/monitor-api-usage.md
+++ b/docs/gamma/4.12/api-management/observe/monitor-api-usage.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Track request volume, latency distribution, error rates, and top consumers for an API proxy. Follow the steps to open the observability dashboard.
 ---
 
 # Monitor API usage

--- a/docs/gamma/4.12/api-management/observe/monitor-endpoint-health.md
+++ b/docs/gamma/4.12/api-management/observe/monitor-endpoint-health.md
@@ -1,5 +1,6 @@
 ---
 noIndex: false
+description: Track backend endpoint availability, response times, and failed health checks for an API. Follow the steps to open the Health Check Dashboard.
 ---
 
 # Monitor endpoint health

--- a/docs/gamma/4.12/api-management/observe/review-audit-logs.md
+++ b/docs/gamma/4.12/api-management/observe/review-audit-logs.md
@@ -1,8 +1,7 @@
 ---
-description: >-
-  Trace who changed what, and when, on an API proxy with its audit trail.
 hidden: false
 noIndex: false
+description: Trace who changed what, and when, on an API proxy with its audit trail. Follow the steps to read and filter the events on the Audit Logs page.
 ---
 
 # Review audit logs

--- a/docs/gamma/4.12/api-management/observe/view-api-logs.md
+++ b/docs/gamma/4.12/api-management/observe/view-api-logs.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Inspect individual request logs and full request traces for an API proxy in the Trace Explorer. Follow the steps to open logs and traces.
 ---
 
 # View API logs

--- a/docs/gamma/4.13/api-management/build/README.md
+++ b/docs/gamma/4.13/api-management/build/README.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Create and configure API proxies in Gamma with security plans, policies, and advanced runtime settings. Start with the build task you need.
 ---
 
 # Build

--- a/docs/gamma/4.13/api-management/build/api-products.md
+++ b/docs/gamma/4.13/api-management/build/api-products.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: API Products bundle multiple API proxies into one consumer-facing product with shared plans. Learn when to use them and how to create one.
 ---
 
 # Create API Products

--- a/docs/gamma/4.13/api-management/build/configure-your-api-product/README.md
+++ b/docs/gamma/4.13/api-management/build/configure-your-api-product/README.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Attach APIs, create plans, manage consumers and team access, and choose where an API Product deploys. Start with the area you need to configure.
 ---
 
 # Configure API products

--- a/docs/gamma/4.13/api-management/build/configure-your-api-product/api-product-configuration-reference.md
+++ b/docs/gamma/4.13/api-management/build/configure-your-api-product/api-product-configuration-reference.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Every API product property, the flag that decides which APIs can be bundled, and the plan types a product supports. Browse the full reference.
 ---
 
 # API product configuration reference

--- a/docs/gamma/4.13/api-management/build/configure-your-api-product/configure-product-deployment.md
+++ b/docs/gamma/4.13/api-management/build/configure-your-api-product/configure-product-deployment.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Assign sharding tags to an API Product so only the API Gateway instances that advertise a matching tag load it. Follow the steps on the Deployment tab.
 ---
 
 # Configure product deployment

--- a/docs/gamma/4.13/api-management/build/configure-your-api-product/manage-api-products-with-the-management-api.md
+++ b/docs/gamma/4.13/api-management/build/configure-your-api-product/manage-api-products-with-the-management-api.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Create an API product, attach APIs, add and publish plans, and deploy it over the v2 Management API. Follow the full lifecycle with request examples.
 ---
 
 # Manage API products with the Management API

--- a/docs/gamma/4.13/api-management/build/configure-your-api-product/manage-members-and-ownership.md
+++ b/docs/gamma/4.13/api-management/build/configure-your-api-product/manage-members-and-ownership.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Add members, attach groups, change roles, and transfer ownership of an API product. Follow the steps to manage access from the User Permissions tab.
 ---
 
 # Manage members and ownership

--- a/docs/gamma/4.13/api-management/build/configure-your-api-product/manage-product-apis.md
+++ b/docs/gamma/4.13/api-management/build/configure-your-api-product/manage-product-apis.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Attach and detach API proxies from an API Product so subscribers reach every API it bundles. Follow the steps to manage them on the APIs tab.
 ---
 
 # Manage product APIs

--- a/docs/gamma/4.13/api-management/build/configure-your-api-proxy/README.md
+++ b/docs/gamma/4.13/api-management/build/configure-your-api-proxy/README.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Refine an API proxy from the detail workspace, which groups configuration into seven sidebar sections. Start with the setting you need to change.
 ---
 
 # Configure your API proxy

--- a/docs/gamma/4.13/api-management/build/configure-your-api-proxy/apply-security-policies.md
+++ b/docs/gamma/4.13/api-management/build/configure-your-api-proxy/apply-security-policies.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Policies are rules the API Gateway evaluates on every request and response, on top of security plans. Learn how the policy chain runs and how to apply one.
 ---
 
 # Apply security policies

--- a/docs/gamma/4.13/api-management/build/configure-your-api-proxy/broadcast-messages-to-consumers.md
+++ b/docs/gamma/4.13/api-management/build/configure-your-api-proxy/broadcast-messages-to-consumers.md
@@ -1,9 +1,7 @@
 ---
-description: >-
-  Send one-way announcements about changes or maintenance to the consumers of
-  an API proxy.
 hidden: false
 noIndex: false
+description: Send a one-way announcement to the consumers of an API proxy about a change, an update, or a maintenance window. Follow the steps to compose one.
 ---
 
 # Broadcast messages to consumers

--- a/docs/gamma/4.13/api-management/build/configure-your-api-proxy/configure-api-properties.md
+++ b/docs/gamma/4.13/api-management/build/configure-your-api-proxy/configure-api-properties.md
@@ -1,9 +1,7 @@
 ---
-description: >-
-  Define static or dynamic key/value properties that policies read at runtime,
-  and encrypt sensitive values.
 hidden: false
 noIndex: false
+description: Define static or dynamic key/value properties that policies read at runtime through the Expression Language. Follow the steps to add and encrypt them.
 ---
 
 # Configure API properties

--- a/docs/gamma/4.13/api-management/build/configure-your-api-proxy/configure-api-resources.md
+++ b/docs/gamma/4.13/api-management/build/configure-your-api-proxy/configure-api-resources.md
@@ -1,9 +1,7 @@
 ---
-description: >-
-  Create API-level resources, such as caches and OAuth providers, that policies
-  reference at runtime.
 hidden: false
 noIndex: false
+description: Create API-level resources such as caches and OAuth providers that this API's policies reference at runtime. Follow the steps to add and manage them.
 ---
 
 # Configure API resources

--- a/docs/gamma/4.13/api-management/build/configure-your-api-proxy/configure-backend-security.md
+++ b/docs/gamma/4.13/api-management/build/configure-your-api-proxy/configure-backend-security.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Endpoint groups define where the API Gateway routes requests, with load balancing, timeouts, and TLS. Follow the steps to create a group and add endpoints.
 ---
 
 # Configure endpoints

--- a/docs/gamma/4.13/api-management/build/configure-your-api-proxy/configure-cors.md
+++ b/docs/gamma/4.13/api-management/build/configure-your-api-proxy/configure-cors.md
@@ -1,9 +1,7 @@
 ---
-description: >-
-  Allow browsers on other origins to call your API by configuring
-  cross-origin resource sharing.
 hidden: false
 noIndex: false
+description: Let browsers on other origins call your API by enabling cross-origin resource sharing and setting the allowed origins. Follow the steps to configure it.
 ---
 
 # Configure CORS

--- a/docs/gamma/4.13/api-management/build/configure-your-api-proxy/configure-deployment.md
+++ b/docs/gamma/4.13/api-management/build/configure-your-api-proxy/configure-deployment.md
@@ -1,9 +1,7 @@
 ---
-description: >-
-  Choose which gateway instances load an API definition by assigning sharding
-  tags.
 hidden: false
 noIndex: false
+description: Choose which API Gateway instances load an API definition by assigning sharding tags. Follow the steps on the Deployment Configuration page.
 ---
 
 # Configure deployment

--- a/docs/gamma/4.13/api-management/build/configure-your-api-proxy/configure-entrypoints.md
+++ b/docs/gamma/4.13/api-management/build/configure-your-api-proxy/configure-entrypoints.md
@@ -1,9 +1,7 @@
 ---
-description: >-
-  Change the context paths of an API proxy, or switch to virtual hosts, from
-  the Entrypoints page.
 hidden: false
 noIndex: false
+description: Change the context paths consumers use to reach an API proxy, or switch to virtual hosts. Follow the steps on the Entrypoints page to update them.
 ---
 
 # Configure entrypoints

--- a/docs/gamma/4.13/api-management/build/configure-your-api-proxy/configure-failover.md
+++ b/docs/gamma/4.13/api-management/build/configure-your-api-proxy/configure-failover.md
@@ -1,9 +1,7 @@
 ---
-description: >-
-  Turn on automatic retries with a circuit breaker so slow or failing backend
-  endpoints don't take your API down.
 hidden: false
 noIndex: false
+description: Turn on automatic retries with a circuit breaker so a slow or failing backend doesn't take your API down. Follow the steps to tune the thresholds.
 ---
 
 # Configure failover

--- a/docs/gamma/4.13/api-management/build/configure-your-api-proxy/configure-flow-execution.md
+++ b/docs/gamma/4.13/api-management/build/configure-your-api-proxy/configure-flow-execution.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Choose whether the API Gateway runs every matching policy flow or only the closest match. Follow the steps to set the flow execution mode.
 ---
 
 # Control how policy flows are matched to requests

--- a/docs/gamma/4.13/api-management/build/configure-your-api-proxy/configure-logging-and-tracing.md
+++ b/docs/gamma/4.13/api-management/build/configure-your-api-proxy/configure-logging-and-tracing.md
@@ -1,9 +1,7 @@
 ---
-description: >-
-  Control which request and response data an API proxy reports for logs and
-  analytics, and turn on OpenTelemetry tracing.
 hidden: false
 noIndex: false
+description: Control which request and response data an API proxy reports to logs and analytics, and turn on OpenTelemetry tracing. Follow the steps to configure it.
 ---
 
 # Configure logging and tracing

--- a/docs/gamma/4.13/api-management/build/configure-your-api-proxy/configure-notifications.md
+++ b/docs/gamma/4.13/api-management/build/configure-your-api-proxy/configure-notifications.md
@@ -1,9 +1,7 @@
 ---
-description: >-
-  Send console, email, or webhook notifications when API events occur, such as
-  deployments or subscription changes.
 hidden: false
 noIndex: false
+description: Send console, email, or webhook alerts when API events occur, such as a deployment or a subscription change. Follow the steps to add a notification.
 ---
 
 # Configure notifications

--- a/docs/gamma/4.13/api-management/build/configure-your-api-proxy/establish-consumer-access.md
+++ b/docs/gamma/4.13/api-management/build/configure-your-api-proxy/establish-consumer-access.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Applications, subscriptions, and API keys control how consumers discover and authenticate with your API. Learn how to review and approve a request.
 ---
 
 # Establish consumer access

--- a/docs/gamma/4.13/api-management/build/configure-your-api-proxy/manage-general-settings.md
+++ b/docs/gamma/4.13/api-management/build/configure-your-api-proxy/manage-general-settings.md
@@ -1,9 +1,7 @@
 ---
-description: >-
-  Edit the name, version, metadata, and images of an API proxy, and control its
-  runtime state from the General page.
 hidden: false
 noIndex: false
+description: Edit the name, version, metadata, and images of an API proxy, and start, stop, or delete it. Follow the steps on the General page to update them.
 ---
 
 # Manage general settings

--- a/docs/gamma/4.13/api-management/build/configure-your-api-proxy/manage-user-permissions.md
+++ b/docs/gamma/4.13/api-management/build/configure-your-api-proxy/manage-user-permissions.md
@@ -1,9 +1,7 @@
 ---
-description: >-
-  Add members, attach groups, change roles, and transfer primary ownership of
-  an API proxy.
 hidden: false
 noIndex: false
+description: Add direct members, attach groups, and transfer primary ownership of an API proxy. Follow the steps on the User Permissions page to manage access.
 ---
 
 # Manage user permissions

--- a/docs/gamma/4.13/api-management/build/configure-your-api-proxy/review-deployment-history.md
+++ b/docs/gamma/4.13/api-management/build/configure-your-api-proxy/review-deployment-history.md
@@ -1,9 +1,7 @@
 ---
-description: >-
-  Compare deployed versions of an API definition and roll back to an earlier
-  one.
 hidden: false
 noIndex: false
+description: Compare two deployed versions of an API definition and roll back to an earlier one. Follow the steps to inspect the history and restore a version.
 ---
 
 # Review deployment history

--- a/docs/gamma/4.13/api-management/build/create-an-api-proxy.md
+++ b/docs/gamma/4.13/api-management/build/create-an-api-proxy.md
@@ -1,9 +1,7 @@
 ---
-description: >-
-  Create an API proxy in the Gamma console with the from-scratch wizard or a
-  quick-start template, then review the proxy Overview page.
 hidden: false
 noIndex: false
+description: Create an API proxy in the Gamma console with the from-scratch wizard or a quick-start template. Follow the steps through each wizard option.
 ---
 
 # Create an API proxy

--- a/docs/gamma/4.13/api-management/build/import-an-api-proxy.md
+++ b/docs/gamma/4.13/api-management/build/import-an-api-proxy.md
@@ -1,9 +1,7 @@
 ---
-description: >-
-  Create an API proxy, or replace the configuration of an existing one, by
-  importing a Gravitee definition, an OpenAPI specification, or a WSDL document.
 hidden: false
 noIndex: false
+description: Create or replace an API proxy by importing a Gravitee definition, an OpenAPI specification, or a WSDL document. Follow the steps to import a file.
 ---
 
 # Import an API proxy

--- a/docs/gamma/4.13/api-management/build/secure-your-api-proxy.md
+++ b/docs/gamma/4.13/api-management/build/secure-your-api-proxy.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Attach a Keyless, API Key, JWT, OAuth2, or mTLS plan to control how consumers authenticate to an API proxy. Follow the steps to add one and deploy it.
 ---
 
 # Secure your API proxy

--- a/docs/gamma/4.13/api-management/build/shared-policy-groups.md
+++ b/docs/gamma/4.13/api-management/build/shared-policy-groups.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: A shared policy group configures a set of policies once and reuses them across APIs and flows. Follow the steps to attach one in the Policy Studio.
 ---
 
 # Reuse policies with shared policy groups

--- a/docs/gamma/4.13/api-management/get-started/README.md
+++ b/docs/gamma/4.13/api-management/get-started/README.md
@@ -1,7 +1,7 @@
 ---
 hidden: false
 noIndex: false
-description: Start here to learn what API Management does in Gamma and to create your first API proxy.
+description: API Management in Gamma, from the overview of its key concepts to the quickstart that builds your first API proxy. Start with the page you need.
 ---
 
 # Get started

--- a/docs/gamma/4.13/api-management/get-started/api-management-overview.md
+++ b/docs/gamma/4.13/api-management/get-started/api-management-overview.md
@@ -1,7 +1,7 @@
 ---
-description: Explains what API Management does within Gamma, its key capabilities, and how it connects to the other Gamma product lines.
 hidden: false
 noIndex: false
+description: API Management governs REST, GraphQL, gRPC, and WebSocket traffic through API proxies. Learn what it does and how it fits the Gamma platform.
 ---
 
 # API Management overview

--- a/docs/gamma/4.13/api-management/get-started/create-your-first-api.md
+++ b/docs/gamma/4.13/api-management/get-started/create-your-first-api.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Create a keyless API proxy in the Gamma console, deploy it to the API Gateway, and verify it with a test request. Follow the quickstart to build one.
 ---
 
 # Create your first API

--- a/docs/gamma/4.13/api-management/observe/README.md
+++ b/docs/gamma/4.13/api-management/observe/README.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Monitor, troubleshoot, and audit your API traffic with dashboards, usage metrics, health checks, and logs. Start with what you need to see.
 ---
 
 # Observe

--- a/docs/gamma/4.13/api-management/observe/api-dashboard.md
+++ b/docs/gamma/4.13/api-management/observe/api-dashboard.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: The Gamma homepage dashboard shows per-module metrics, quick actions, and guidance for empty states. Learn what each metric and quick action does.
 ---
 
 # Dashboard and metrics

--- a/docs/gamma/4.13/api-management/observe/monitor-api-usage.md
+++ b/docs/gamma/4.13/api-management/observe/monitor-api-usage.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Track request volume, latency distribution, error rates, and top consumers for an API proxy. Follow the steps to open the observability dashboard.
 ---
 
 # Monitor API usage

--- a/docs/gamma/4.13/api-management/observe/monitor-endpoint-health.md
+++ b/docs/gamma/4.13/api-management/observe/monitor-endpoint-health.md
@@ -1,5 +1,6 @@
 ---
 noIndex: false
+description: Track backend endpoint availability, response times, and failed health checks for an API. Follow the steps to open the Health Check Dashboard.
 ---
 
 # Monitor endpoint health

--- a/docs/gamma/4.13/api-management/observe/review-audit-logs.md
+++ b/docs/gamma/4.13/api-management/observe/review-audit-logs.md
@@ -1,8 +1,7 @@
 ---
-description: >-
-  Trace who changed what, and when, on an API proxy with its audit trail.
 hidden: false
 noIndex: false
+description: Trace who changed what, and when, on an API proxy with its audit trail. Follow the steps to read and filter the events on the Audit Logs page.
 ---
 
 # Review audit logs

--- a/docs/gamma/4.13/api-management/observe/view-api-logs.md
+++ b/docs/gamma/4.13/api-management/observe/view-api-logs.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Inspect individual request logs and full request traces for an API proxy in the Trace Explorer. Follow the steps to open logs and traces.
 ---
 
 # View API logs


### PR DESCRIPTION
Applies the meta description spec to every page under `api-management` in `docs/gamma/4.12` and `docs/gamma/4.13` — 37 and 38 pages, 75 files. Follows on from #2181, which did the same for Agent Management.

Follows `style-guide/06-document-types-and-templates/meta-descriptions.md` and the procedure in `ai-tools/meta-description-skill.md`: 120–160 characters, the reader's search term placed early in approved Gravitee terminology, an imperative clause naming an on-page action to close, and unique within the space.

## What changed

| | Pages |
| --- | ---: |
| Had no description, now have one | 20 |
| Had a description that failed the spec, rewritten | 18 |

Almost all the rewrites were length failures — of the 18 existing descriptions, only `import-an-api-proxy.md` was already inside the 120–160 rule. The rest ran from 71 to 119 characters, short enough to waste the space a search engine gives them, and none closed with a call to action.

Every description now lands in the 135–155 target band. Checked programmatically for length, duplicates (including against the Agent Management descriptions in #2181), markdown or HTML characters, year numbers, and artifact openers.

Only the frontmatter `description` line is touched. Every added line in the diff is a `description:` line — no page-body changes.

## Notes for review

- **Terminology was checked up front this time**, against `product-naming.md`, `terminology-and-glossary.md`, `rejected-terms.md`, and `spelling-and-approved-vocabulary.md`. "API Gateway", "Expression Language", "Management API", "sharding tags", and the plan type names all use their approved forms, and no bare abbreviations appear.
- **Versions are in sync.** `import-an-api-proxy.md` exists only in 4.13. The other four pages that differ between versions differ only in a banner string, screenshot placeholders, and a cross-link — none of which change what the page is about — so they share one description.
- **`configure-backend-security.md` is titled "Configure endpoints".** Its description follows the H1 and the body, not the filename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
