### PR TITLE
docs(gamma): add meta descriptions across Event Stream Management 4.12 and 4.13

### DIFF
--- a/docs/gamma/4.12/event-stream-management/build/README.md
+++ b/docs/gamma/4.12/event-stream-management/build/README.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Create and configure governed Kafka Services and Virtual Clusters on top of your registered Kafka infrastructure. Start with the service you need.
 ---
 
 # Build

--- a/docs/gamma/4.12/event-stream-management/build/create-a-kafka-service-with-a-registered-cluster.md
+++ b/docs/gamma/4.12/event-stream-management/build/create-a-kafka-service-with-a-registered-cluster.md
@@ -1,5 +1,5 @@
 ---
-description: Create a Kafka Service in Event Stream Management and bind it to a connection on a registered Kafka cluster.
+description: Create a Kafka Service bound to a connection on a registered Kafka cluster, with security plans and policies. Follow the steps in the creation wizard.
 ---
 
 # Create a Kafka service with a registered cluster

--- a/docs/gamma/4.12/event-stream-management/build/create-a-kafka-service-with-a-virtual-cluster.md
+++ b/docs/gamma/4.12/event-stream-management/build/create-a-kafka-service-with-a-virtual-cluster.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Create a Kafka Service backed by a Virtual Cluster to govern a federated multi-cluster Kafka environment. Follow the steps to build it in the wizard.
 ---
 
 # Create a Kafka service with a Virtual Cluster

--- a/docs/gamma/4.12/event-stream-management/build/establish-a-virtual-cluster.md
+++ b/docs/gamma/4.12/event-stream-management/build/establish-a-virtual-cluster.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Federate multiple Kafka backends into one endpoint by establishing a Virtual Cluster. Follow the steps to choose a topology and compose the backends.
 ---
 
 # Establish a Virtual Cluster

--- a/docs/gamma/4.12/event-stream-management/build/kafka-virtual-cluster-runtime-behavior-reference.md
+++ b/docs/gamma/4.12/event-stream-management/build/kafka-virtual-cluster-runtime-behavior-reference.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: What a deployed Virtual Cluster does on the Event Gateway, from lifecycle states to topic routing and consumer groups. Browse the full reference.
 ---
 # Virtual Cluster runtime behavior
 

--- a/docs/gamma/4.12/event-stream-management/build/kafka-virtual-clusters-overview.md
+++ b/docs/gamma/4.12/event-stream-management/build/kafka-virtual-clusters-overview.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: A Virtual Cluster presents several Kafka backends to clients as one endpoint. Learn the key concepts, Mesh mode, and the limitations that apply.
 ---
 # Virtual Clusters overview
 

--- a/docs/gamma/4.12/event-stream-management/get-started/README.md
+++ b/docs/gamma/4.12/event-stream-management/get-started/README.md
@@ -1,7 +1,7 @@
 ---
-description: Introductory pages for Event Stream Management in Gamma, covering the product overview and the quickstarts for clusters, Kafka services, and Virtual Clusters.
 hidden: false
 noIndex: false
+description: Event Stream Management in Gamma, from the product overview to the quickstarts for clusters, Kafka Services, and Virtual Clusters. Start where you need.
 ---
 
 # Get started

--- a/docs/gamma/4.12/event-stream-management/get-started/create-your-first-kafka-service.md
+++ b/docs/gamma/4.12/event-stream-management/get-started/create-your-first-kafka-service.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Create a governed Kafka Service in the Gamma console with a standalone endpoint and a keyless plan. Follow the quickstart to get one running.
 ---
 # Create your first Kafka service
 

--- a/docs/gamma/4.12/event-stream-management/get-started/create-your-first-virtual-cluster.md
+++ b/docs/gamma/4.12/event-stream-management/get-started/create-your-first-virtual-cluster.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Federate two Registered Clusters into a single unified endpoint with a Virtual Cluster. Follow the quickstart to compose and create one.
 ---
 # Create your first Virtual Cluster
 

--- a/docs/gamma/4.12/event-stream-management/get-started/event-stream-management-overview.md
+++ b/docs/gamma/4.12/event-stream-management/get-started/event-stream-management-overview.md
@@ -1,5 +1,5 @@
 ---
-description: Overview of Event Stream Management, the Gamma product line for governing Kafka clusters, event-driven data flows, and streaming infrastructure.
+description: Event Stream Management governs Kafka clusters, event-driven data flows, and streaming infrastructure. Learn what it does and how it fits Gamma.
 ---
 
 # Event Stream Management overview

--- a/docs/gamma/4.12/event-stream-management/get-started/register-your-first-cluster.md
+++ b/docs/gamma/4.12/event-stream-management/get-started/register-your-first-cluster.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Register your first Kafka cluster in the Gamma console and add its first connection. Follow the quickstart to create and deploy the cluster.
 ---
 # Register your first cluster
 

--- a/docs/gamma/4.12/event-stream-management/import/README.md
+++ b/docs/gamma/4.12/event-stream-management/import/README.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Register your existing Kafka infrastructure with Gamma so it can be governed, monitored, and composed into services. Start by registering a cluster.
 ---
 # Import
 

--- a/docs/gamma/4.12/event-stream-management/import/register-your-kafka-clusters.md
+++ b/docs/gamma/4.12/event-stream-management/import/register-your-kafka-clusters.md
@@ -1,7 +1,7 @@
 ---
-description: How to register an existing Kafka cluster with Gamma so it can be deployed and used by Kafka Services and Virtual Clusters.
 hidden: false
 noIndex: false
+description: Register an existing Kafka cluster with Gamma so Kafka Services and Virtual Clusters can be built on it. Follow the steps to register and deploy one.
 ---
 
 # Register your Kafka clusters

--- a/docs/gamma/4.13/event-stream-management/build/README.md
+++ b/docs/gamma/4.13/event-stream-management/build/README.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Create and configure governed Kafka Services and Virtual Clusters on top of your registered Kafka infrastructure. Start with the service you need.
 ---
 
 # Build

--- a/docs/gamma/4.13/event-stream-management/build/create-a-kafka-service-with-a-registered-cluster.md
+++ b/docs/gamma/4.13/event-stream-management/build/create-a-kafka-service-with-a-registered-cluster.md
@@ -1,7 +1,7 @@
 ---
-description: Create a Kafka Service in Event Stream Management and bind it to a connection on a registered Kafka cluster.
 hidden: false
 noIndex: false
+description: Create a Kafka Service bound to a connection on a registered Kafka cluster, with security plans and policies. Follow the steps in the creation wizard.
 ---
 
 # Create a Kafka service with a registered cluster

--- a/docs/gamma/4.13/event-stream-management/build/create-a-kafka-service-with-a-virtual-cluster.md
+++ b/docs/gamma/4.13/event-stream-management/build/create-a-kafka-service-with-a-virtual-cluster.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Create a Kafka Service backed by a Virtual Cluster to govern a federated multi-cluster Kafka environment. Follow the steps to build it in the wizard.
 ---
 
 # Create a Kafka service with a Virtual Cluster

--- a/docs/gamma/4.13/event-stream-management/build/duplicate-a-kafka-service.md
+++ b/docs/gamma/4.13/event-stream-management/build/duplicate-a-kafka-service.md
@@ -1,7 +1,7 @@
 ---
-description: Create a copy of an existing Kafka Service with a new name, version, and listener host prefix.
 hidden: false
 noIndex: false
+description: Copy an existing Kafka Service with a new name, version, and listener host prefix instead of rebuilding it. Follow the steps to duplicate one.
 ---
 
 # Duplicate a Kafka service

--- a/docs/gamma/4.13/event-stream-management/build/establish-a-virtual-cluster.md
+++ b/docs/gamma/4.13/event-stream-management/build/establish-a-virtual-cluster.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Federate multiple Kafka backends into one endpoint by establishing a Virtual Cluster. Follow the steps to choose a topology and compose the backends.
 ---
 
 # Establish a Virtual Cluster

--- a/docs/gamma/4.13/event-stream-management/build/kafka-virtual-cluster-runtime-behavior-reference.md
+++ b/docs/gamma/4.13/event-stream-management/build/kafka-virtual-cluster-runtime-behavior-reference.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: What a deployed Virtual Cluster does on the Event Gateway, from lifecycle states to topic routing and consumer groups. Browse the full reference.
 ---
 # Virtual Cluster runtime behavior
 

--- a/docs/gamma/4.13/event-stream-management/build/kafka-virtual-clusters-overview.md
+++ b/docs/gamma/4.13/event-stream-management/build/kafka-virtual-clusters-overview.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: A Virtual Cluster presents several Kafka backends to clients as one endpoint. Learn the key concepts, Mesh mode, and the limitations that apply.
 ---
 # Virtual Clusters overview
 

--- a/docs/gamma/4.13/event-stream-management/get-started/README.md
+++ b/docs/gamma/4.13/event-stream-management/get-started/README.md
@@ -1,7 +1,7 @@
 ---
-description: Introductory pages for Event Stream Management in Gamma, covering the product overview and the quickstarts for clusters, Kafka services, and Virtual Clusters.
 hidden: false
 noIndex: false
+description: Event Stream Management in Gamma, from the product overview to the quickstarts for clusters, Kafka Services, and Virtual Clusters. Start where you need.
 ---
 
 # Get started

--- a/docs/gamma/4.13/event-stream-management/get-started/create-your-first-kafka-service.md
+++ b/docs/gamma/4.13/event-stream-management/get-started/create-your-first-kafka-service.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Create a governed Kafka Service in the Gamma console with a standalone endpoint and a keyless plan. Follow the quickstart to get one running.
 ---
 # Create your first Kafka service
 

--- a/docs/gamma/4.13/event-stream-management/get-started/create-your-first-virtual-cluster.md
+++ b/docs/gamma/4.13/event-stream-management/get-started/create-your-first-virtual-cluster.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Federate two Registered Clusters into a single unified endpoint with a Virtual Cluster. Follow the quickstart to compose and create one.
 ---
 # Create your first Virtual Cluster
 

--- a/docs/gamma/4.13/event-stream-management/get-started/event-stream-management-overview.md
+++ b/docs/gamma/4.13/event-stream-management/get-started/event-stream-management-overview.md
@@ -1,7 +1,7 @@
 ---
-description: Overview of Event Stream Management, the Gamma product line for governing Kafka clusters, event-driven data flows, and streaming infrastructure.
 hidden: false
 noIndex: false
+description: Event Stream Management governs Kafka clusters, event-driven data flows, and streaming infrastructure. Learn what it does and how it fits Gamma.
 ---
 # Event Stream Management overview
 

--- a/docs/gamma/4.13/event-stream-management/get-started/register-your-first-cluster.md
+++ b/docs/gamma/4.13/event-stream-management/get-started/register-your-first-cluster.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Register your first Kafka cluster in the Gamma console and add its first connection. Follow the quickstart to create and deploy the cluster.
 ---
 # Register your first cluster
 

--- a/docs/gamma/4.13/event-stream-management/import/README.md
+++ b/docs/gamma/4.13/event-stream-management/import/README.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Register your existing Kafka infrastructure with Gamma so it can be governed, monitored, and composed into services. Start by registering a cluster.
 ---
 # Import
 

--- a/docs/gamma/4.13/event-stream-management/import/register-your-kafka-clusters.md
+++ b/docs/gamma/4.13/event-stream-management/import/register-your-kafka-clusters.md
@@ -1,7 +1,7 @@
 ---
-description: How to register an existing Kafka cluster with Gamma so it can be deployed and used by Kafka Services and Virtual Clusters.
 hidden: false
 noIndex: false
+description: Register an existing Kafka cluster with Gamma so Kafka Services and Virtual Clusters can be built on it. Follow the steps to register and deploy one.
 ---
 
 # Register your Kafka clusters


### PR DESCRIPTION
Applies the meta description spec to every page under `event-stream-management` in `docs/gamma/4.12` and `docs/gamma/4.13` — 13 and 14 pages, 27 files. Third in the series, after #2181 (Agent Management) and #2187 (API Management).

Follows `style-guide/06-document-types-and-templates/meta-descriptions.md` and the procedure in `ai-tools/meta-description-skill.md`: 120–160 characters, the reader's search term placed early in approved Gravitee terminology, an imperative clause naming an on-page action to close, and unique within the space.

## What changed

| | Pages |
| --- | ---: |
| Had no description, now have one | 9 |
| Had a description that failed the spec, rewritten | 5 |

Of the five existing descriptions, two were too short (94 and 108 characters) and three were in range but opened with an artifact or summary phrase — "Introductory pages for…", "Overview of…", "How to register…" — and none closed with a call to action.

Every description now lands in the 135–155 target band. Checked programmatically for length, markdown or HTML characters, year numbers, artifact openers, and duplicates — including against the Agent Management and API Management descriptions already merged, since all three sections publish into the same space.

Only the frontmatter `description` line is touched. Every added line in the diff is a `description:` line — no page-body changes.

## Notes for review

- **Terminology checked up front** against `product-naming.md`, `terminology-and-glossary.md`, `rejected-terms.md`, and `spelling-and-approved-vocabulary.md`. No bare abbreviations, no rejected terms, no product-name casing errors.
- **"Event Gateway" follows the page bodies.** The glossary refers to a "Kafka Gateway" for the Native Kafka API, but every page in this section calls the runtime the Event Gateway, so the descriptions use that. Worth a decision if the two names are meant to converge.
- **Versions are in sync.** `duplicate-a-kafka-service.md` exists only in 4.13. The other two pages that differ do so only in frontmatter, so they share one description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
