### PR TITLE
docs(gamma): add meta descriptions across Authorization Management 4.12 and 4.13

### DIFF
--- a/docs/gamma/4.12/authorization-management/authz-gateway-sync.md
+++ b/docs/gamma/4.12/authorization-management/authz-gateway-sync.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Gamma compiles deployed authorization policies into an AuthZEN representation the API Gateway evaluates locally. Learn how sync and isolation work.
 ---
 
 # AuthZEN PDP synchronization

--- a/docs/gamma/4.12/authorization-management/configure/README.md
+++ b/docs/gamma/4.12/authorization-management/configure/README.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Create, update, and delete authorization policies, write custom ones, and work from API and MCP examples. Start with the task you need.
 ---
 
 # Configure

--- a/docs/gamma/4.12/authorization-management/configure/ai-policy-example.md
+++ b/docs/gamma/4.12/authorization-management/configure/ai-policy-example.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Control which teams reach which AI models with policy examples for token budgets, cost ceilings, and guardrails. Adapt an example to your own models.
 ---
 
 # AI policy example

--- a/docs/gamma/4.12/authorization-management/configure/api-policy-examples.md
+++ b/docs/gamma/4.12/authorization-management/configure/api-policy-examples.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Govern API proxies, endpoints, and data fields with policy examples for scopes, rate limits, and tenant isolation. Adapt an example to your own APIs.
 ---
 
 # API policy examples

--- a/docs/gamma/4.12/authorization-management/configure/create-update-delete-policies.md
+++ b/docs/gamma/4.12/authorization-management/configure/create-update-delete-policies.md
@@ -1,7 +1,7 @@
 ---
-description: Reference for the Authorization Management policy editor, covering how to create, update, deploy, and delete GAPL policies.
 hidden: false
 noIndex: false
+description: Reference for the Authorization Management policy editor, covering how to create, name, build, deploy, and delete a policy. Browse the full reference.
 ---
 
 # Create, update, and delete policies

--- a/docs/gamma/4.12/authorization-management/configure/custom-policies/README.md
+++ b/docs/gamma/4.12/authorization-management/configure/custom-policies/README.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Custom policies govern resources outside the MCP, API, Agent, AI Model, and Event categories. Start with the overview, then create your first one.
 ---
 
 # Custom policies

--- a/docs/gamma/4.12/authorization-management/configure/custom-policies/create-a-custom-policy.md
+++ b/docs/gamma/4.12/authorization-management/configure/custom-policies/create-a-custom-policy.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Create an authorization policy for resources not routed through the MCP, API, Agent, AI Model, or Event categories. Follow the steps to build one.
 ---
 
 # Create a custom policy

--- a/docs/gamma/4.12/authorization-management/configure/custom-policies/custom-policies-overview.md
+++ b/docs/gamma/4.12/authorization-management/configure/custom-policies/custom-policies-overview.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Custom policies protect internal applications, data assets, and bespoke resources. Learn how they differ from service policies and when to use them.
 ---
 
 # Custom policies overview

--- a/docs/gamma/4.12/authorization-management/configure/mcp-policy-examples.md
+++ b/docs/gamma/4.12/authorization-management/configure/mcp-policy-examples.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Govern MCP servers, tools, and prompts with policy examples for group access, time windows, and device trust. Adapt an example to your own servers.
 ---
 
 # MCP policy examples

--- a/docs/gamma/4.12/authorization-management/evaluate/README.md
+++ b/docs/gamma/4.12/authorization-management/evaluate/README.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Run the policy engine on a Gravitee Gateway or a sidecar, and follow how policies sync and what analytics come back. Start with your runtime.
 ---
 
 # Evaluate

--- a/docs/gamma/4.12/authorization-management/evaluate/analytics-sent-to-control-plane.md
+++ b/docs/gamma/4.12/authorization-management/evaluate/analytics-sent-to-control-plane.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: The observability data that Policy Decision Point gateways send back to the Gravitee control plane. Learn what is collected and where it appears.
 ---
 
 # Analytics sent to the control plane

--- a/docs/gamma/4.12/authorization-management/evaluate/configure-gravitee-gateway-as-runtime.md
+++ b/docs/gamma/4.12/authorization-management/evaluate/configure-gravitee-gateway-as-runtime.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Register a Gravitee Gateway as a Policy Decision Point so authorization decisions are evaluated at the wire level. Follow the steps to register one.
 ---
 
 # Configure the Gravitee Gateway as a runtime

--- a/docs/gamma/4.12/authorization-management/evaluate/configure-sidecar-as-runtime.md
+++ b/docs/gamma/4.12/authorization-management/evaluate/configure-sidecar-as-runtime.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Deploy the Policy Decision Point as a sidecar beside your application for latency-sensitive or air-gapped environments. Follow the steps to deploy it.
 ---
 
 # Configure a sidecar as runtime

--- a/docs/gamma/4.12/authorization-management/evaluate/policy-syncs.md
+++ b/docs/gamma/4.12/authorization-management/evaluate/policy-syncs.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: How authorization policies travel from the control plane to your runtime gateways, and how long it takes. Learn to read and monitor sync status.
 ---
 
 # Policy syncs

--- a/docs/gamma/4.12/authorization-management/get-started/README.md
+++ b/docs/gamma/4.12/authorization-management/get-started/README.md
@@ -1,7 +1,7 @@
 ---
-description: Lists the Authorization Management get-started guides, covering the product overview, your first user, your first imported resource, and your first policy.
 hidden: false
 noIndex: false
+description: Authorization Management in Gamma, from the product overview to your first user, first imported resource, and first policy. Start with the overview.
 ---
 
 # Get started

--- a/docs/gamma/4.12/authorization-management/get-started/authorization-management-overview.md
+++ b/docs/gamma/4.12/authorization-management/get-started/authorization-management-overview.md
@@ -1,7 +1,7 @@
 ---
-description: Learn how Authorization Management enforces fine-grained, catalog-aware access control across Gamma traffic using GAPL policies.
 hidden: false
 noIndex: false
+description: Authorization Management enforces fine-grained, catalog-aware access control across API, MCP, AI model, and agent traffic. Learn how the pieces connect.
 ---
 
 # Authorization Management overview

--- a/docs/gamma/4.12/authorization-management/get-started/create-your-first-policy.md
+++ b/docs/gamma/4.12/authorization-management/get-started/create-your-first-policy.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Create and deploy your first authorization policy in the visual editor to get a permit rule enforced at runtime. Follow the steps to build one.
 ---
 
 # Create your first policy

--- a/docs/gamma/4.12/authorization-management/get-started/create-your-first-user.md
+++ b/docs/gamma/4.12/authorization-management/get-started/create-your-first-user.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Create a local principal in Authorization Management so the policy engine has an identity to evaluate. Follow the steps to add your first one.
 ---
 
 # Create your first user

--- a/docs/gamma/4.12/authorization-management/get-started/import-your-first-resource-from-agent-catalog.md
+++ b/docs/gamma/4.12/authorization-management/get-started/import-your-first-resource-from-agent-catalog.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Import a resource from the AI Catalog so every policy refers to one canonical Entity ID. Follow the quickstart to import your first item.
 ---
 
 # Import your first resource from the AI Catalog

--- a/docs/gamma/4.12/authorization-management/manage/README.md
+++ b/docs/gamma/4.12/authorization-management/manage/README.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Manage the principals, resources, actions, and schemas that your authorization policies are written against. Start with the entity type you need.
 ---
 
 # Manage

--- a/docs/gamma/4.12/authorization-management/manage/actions/README.md
+++ b/docs/gamma/4.12/authorization-management/manage/actions/README.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Actions are the verbs your policies grant or forbid. Create one, and see how action Entity IDs are named and scoped. Start by creating an action.
 ---
 
 # Manage actions

--- a/docs/gamma/4.12/authorization-management/manage/actions/action-naming-and-scope.md
+++ b/docs/gamma/4.12/authorization-management/manage/actions/action-naming-and-scope.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: How action Entity IDs are structured and how the policy engine resolves them against policy types and resource scopes. Browse the naming reference.
 ---
 
 # Action naming and scope

--- a/docs/gamma/4.12/authorization-management/manage/actions/create-an-action.md
+++ b/docs/gamma/4.12/authorization-management/manage/actions/create-an-action.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Define the verbs your policies grant or forbid by creating an action entity that statements reference. Follow the steps on the Actions page.
 ---
 
 # Create an action

--- a/docs/gamma/4.12/authorization-management/manage/principals/README.md
+++ b/docs/gamma/4.12/authorization-management/manage/principals/README.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Sync principals from Access Management, create local ones, and give them attributes and relationships. Start with how your identities arrive.
 ---
 
 # Manage principals

--- a/docs/gamma/4.12/authorization-management/manage/principals/add-attributes-to-principals.md
+++ b/docs/gamma/4.12/authorization-management/manage/principals/add-attributes-to-principals.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Attach custom metadata to a principal, such as department or device trust, so policies test more than identity. Follow the steps to add attributes.
 ---
 
 # Add attributes to principals

--- a/docs/gamma/4.12/authorization-management/manage/principals/build-principal-relationships.md
+++ b/docs/gamma/4.12/authorization-management/manage/principals/build-principal-relationships.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Link principals into parent-child hierarchies so that one policy can match every user in a group. Follow the steps to set and edit parents.
 ---
 
 # Build principal relationships

--- a/docs/gamma/4.12/authorization-management/manage/principals/create-a-local-principal.md
+++ b/docs/gamma/4.12/authorization-management/manage/principals/create-a-local-principal.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Create a principal directly in Authorization Management when the identity is not synced or imported. Follow the steps on the Entities page.
 ---
 
 # Create a local principal

--- a/docs/gamma/4.12/authorization-management/manage/principals/sync-principals-from-access-management.md
+++ b/docs/gamma/4.12/authorization-management/manage/principals/sync-principals-from-access-management.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Synchronize users and groups from Gravitee Access Management so policies can reference your identity directory. Follow the steps to run a sync.
 ---
 
 # Sync principals from Access Management

--- a/docs/gamma/4.12/authorization-management/manage/resources/README.md
+++ b/docs/gamma/4.12/authorization-management/manage/resources/README.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Import resources from the Catalog, create local ones, and give them attributes and relationships. Start with where your resources come from.
 ---
 
 # Manage resources

--- a/docs/gamma/4.12/authorization-management/manage/resources/add-attributes-to-resources.md
+++ b/docs/gamma/4.12/authorization-management/manage/resources/add-attributes-to-resources.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Attach custom metadata to a resource, such as sensitivity or ownership, so policy conditions can test it. Follow the steps to add attributes.
 ---
 
 # Add attributes to resources

--- a/docs/gamma/4.12/authorization-management/manage/resources/build-resource-relationships.md
+++ b/docs/gamma/4.12/authorization-management/manage/resources/build-resource-relationships.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Establish parent-child hierarchies between resources so one policy covers a server and all of its tools. Follow the steps to set parents.
 ---
 
 # Build resource relationships

--- a/docs/gamma/4.12/authorization-management/manage/resources/create-a-local-resource.md
+++ b/docs/gamma/4.12/authorization-management/manage/resources/create-a-local-resource.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Create a resource entity for the internal applications, data assets, and custom tools the AI Catalog does not hold. Follow the steps to add one.
 ---
 
 # Create a local resource

--- a/docs/gamma/4.12/authorization-management/manage/resources/import-resources-from-catalog.md
+++ b/docs/gamma/4.12/authorization-management/manage/resources/import-resources-from-catalog.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Import resource entities from the AI Catalog into Authorization Management across all three categories. Follow the steps to browse and select them.
 ---
 
 # Import resources from the Catalog

--- a/docs/gamma/4.12/authorization-management/manage/schemas/README.md
+++ b/docs/gamma/4.12/authorization-management/manage/schemas/README.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: The schema declares the entity types, relationships, and actions your policies are written against. Start with how a schema is generated.
 ---
 
 # Manage schemas

--- a/docs/gamma/4.12/authorization-management/manage/schemas/edit-your-schema.md
+++ b/docs/gamma/4.12/authorization-management/manage/schemas/edit-your-schema.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Modify an existing schema to add entity types, attributes, relationships, or actions. Follow the steps to edit, validate, and save your changes.
 ---
 
 # Edit your schema

--- a/docs/gamma/4.12/authorization-management/manage/schemas/schema-generation.md
+++ b/docs/gamma/4.12/authorization-management/manage/schemas/schema-generation.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: The schema is the contract your policies are written against, declaring entity types, relationships, and actions. Learn how it is generated and read.
 ---
 
 # Schema generation

--- a/docs/gamma/4.12/authorization-management/manage/schemas/validate-schema-changes.md
+++ b/docs/gamma/4.12/authorization-management/manage/schemas/validate-schema-changes.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: How the console validates a schema change before saving, and the errors to expect. Learn the validation pipeline and how to fix a failure.
 ---
 
 # Validate schema changes

--- a/docs/gamma/4.13/authorization-management/authz-gateway-sync.md
+++ b/docs/gamma/4.13/authorization-management/authz-gateway-sync.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Gamma compiles deployed authorization policies into an AuthZEN representation the API Gateway evaluates locally. Learn how sync and isolation work.
 ---
 
 # AuthZEN PDP synchronization

--- a/docs/gamma/4.13/authorization-management/configure/README.md
+++ b/docs/gamma/4.13/authorization-management/configure/README.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Create, update, and delete authorization policies, write custom ones, and work from API and MCP examples. Start with the task you need.
 ---
 
 # Configure

--- a/docs/gamma/4.13/authorization-management/configure/ai-policy-example.md
+++ b/docs/gamma/4.13/authorization-management/configure/ai-policy-example.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Control which teams reach which AI models with policy examples for token budgets, cost ceilings, and guardrails. Adapt an example to your own models.
 ---
 
 # AI policy example

--- a/docs/gamma/4.13/authorization-management/configure/api-policy-examples.md
+++ b/docs/gamma/4.13/authorization-management/configure/api-policy-examples.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Govern API proxies, endpoints, and data fields with policy examples for scopes, rate limits, and tenant isolation. Adapt an example to your own APIs.
 ---
 
 # API policy examples

--- a/docs/gamma/4.13/authorization-management/configure/create-update-delete-policies.md
+++ b/docs/gamma/4.13/authorization-management/configure/create-update-delete-policies.md
@@ -1,7 +1,7 @@
 ---
-description: Reference for the Authorization Management policy editor, covering how to create, update, deploy, and delete GAPL policies.
 hidden: false
 noIndex: false
+description: Reference for the Authorization Management policy editor, covering how to create, name, build, deploy, and delete a policy. Browse the full reference.
 ---
 
 # Create, update, and delete policies

--- a/docs/gamma/4.13/authorization-management/configure/custom-policies/README.md
+++ b/docs/gamma/4.13/authorization-management/configure/custom-policies/README.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Custom policies govern resources outside the MCP, API, Agent, AI Model, and Event categories. Start with the overview, then create your first one.
 ---
 
 # Custom policies

--- a/docs/gamma/4.13/authorization-management/configure/custom-policies/create-a-custom-policy.md
+++ b/docs/gamma/4.13/authorization-management/configure/custom-policies/create-a-custom-policy.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Create an authorization policy for resources not routed through the MCP, API, Agent, AI Model, or Event categories. Follow the steps to build one.
 ---
 
 # Create a custom policy

--- a/docs/gamma/4.13/authorization-management/configure/custom-policies/custom-policies-overview.md
+++ b/docs/gamma/4.13/authorization-management/configure/custom-policies/custom-policies-overview.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Custom policies protect internal applications, data assets, and bespoke resources. Learn how they differ from service policies and when to use them.
 ---
 
 # Custom policies overview

--- a/docs/gamma/4.13/authorization-management/configure/mcp-policy-examples.md
+++ b/docs/gamma/4.13/authorization-management/configure/mcp-policy-examples.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Govern MCP servers, tools, and prompts with policy examples for group access, time windows, and device trust. Adapt an example to your own servers.
 ---
 
 # MCP policy examples

--- a/docs/gamma/4.13/authorization-management/evaluate/README.md
+++ b/docs/gamma/4.13/authorization-management/evaluate/README.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Run the policy engine on a Gravitee Gateway or a sidecar, and follow how policies sync and what analytics come back. Start with your runtime.
 ---
 
 # Evaluate

--- a/docs/gamma/4.13/authorization-management/evaluate/analytics-sent-to-control-plane.md
+++ b/docs/gamma/4.13/authorization-management/evaluate/analytics-sent-to-control-plane.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: The observability data that Policy Decision Point gateways send back to the Gravitee control plane. Learn what is collected and where it appears.
 ---
 
 # Analytics sent to the control plane

--- a/docs/gamma/4.13/authorization-management/evaluate/configure-gravitee-gateway-as-runtime.md
+++ b/docs/gamma/4.13/authorization-management/evaluate/configure-gravitee-gateway-as-runtime.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Register a Gravitee Gateway as a Policy Decision Point so authorization decisions are evaluated at the wire level. Follow the steps to register one.
 ---
 
 # Configure the Gravitee Gateway as a runtime

--- a/docs/gamma/4.13/authorization-management/evaluate/configure-sidecar-as-runtime.md
+++ b/docs/gamma/4.13/authorization-management/evaluate/configure-sidecar-as-runtime.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Deploy the Policy Decision Point as a sidecar beside your application for latency-sensitive or air-gapped environments. Follow the steps to deploy it.
 ---
 
 # Configure a sidecar as runtime

--- a/docs/gamma/4.13/authorization-management/evaluate/policy-syncs.md
+++ b/docs/gamma/4.13/authorization-management/evaluate/policy-syncs.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: How authorization policies travel from the control plane to your runtime gateways, and how long it takes. Learn to read and monitor sync status.
 ---
 
 # Policy syncs

--- a/docs/gamma/4.13/authorization-management/get-started/README.md
+++ b/docs/gamma/4.13/authorization-management/get-started/README.md
@@ -1,7 +1,7 @@
 ---
-description: Lists the Authorization Management get-started guides, covering the product overview, your first user, your first imported resource, and your first policy.
 hidden: false
 noIndex: false
+description: Authorization Management in Gamma, from the product overview to your first user, first imported resource, and first policy. Start with the overview.
 ---
 
 # Get started

--- a/docs/gamma/4.13/authorization-management/get-started/authorization-management-overview.md
+++ b/docs/gamma/4.13/authorization-management/get-started/authorization-management-overview.md
@@ -1,7 +1,7 @@
 ---
-description: Learn how Authorization Management enforces fine-grained, catalog-aware access control across Gamma traffic using GAPL policies.
 hidden: false
 noIndex: false
+description: Authorization Management enforces fine-grained, catalog-aware access control across API, MCP, AI model, and agent traffic. Learn how the pieces connect.
 ---
 
 # Authorization Management overview

--- a/docs/gamma/4.13/authorization-management/get-started/create-your-first-policy.md
+++ b/docs/gamma/4.13/authorization-management/get-started/create-your-first-policy.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Create and deploy your first authorization policy in the visual editor to get a permit rule enforced at runtime. Follow the steps to build one.
 ---
 
 # Create your first policy

--- a/docs/gamma/4.13/authorization-management/get-started/create-your-first-user.md
+++ b/docs/gamma/4.13/authorization-management/get-started/create-your-first-user.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Create a local principal in Authorization Management so the policy engine has an identity to evaluate. Follow the steps to add your first one.
 ---
 
 # Create your first user

--- a/docs/gamma/4.13/authorization-management/get-started/import-your-first-resource-from-agent-catalog.md
+++ b/docs/gamma/4.13/authorization-management/get-started/import-your-first-resource-from-agent-catalog.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Import a resource from the AI Catalog so every policy refers to one canonical Entity ID. Follow the quickstart to import your first item.
 ---
 
 # Import your first resource from the AI Catalog

--- a/docs/gamma/4.13/authorization-management/manage/README.md
+++ b/docs/gamma/4.13/authorization-management/manage/README.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Manage the principals, resources, actions, and schemas that your authorization policies are written against. Start with the entity type you need.
 ---
 
 # Manage

--- a/docs/gamma/4.13/authorization-management/manage/actions/README.md
+++ b/docs/gamma/4.13/authorization-management/manage/actions/README.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Actions are the verbs your policies grant or forbid. Create one, and see how action Entity IDs are named and scoped. Start by creating an action.
 ---
 
 # Manage actions

--- a/docs/gamma/4.13/authorization-management/manage/actions/action-naming-and-scope.md
+++ b/docs/gamma/4.13/authorization-management/manage/actions/action-naming-and-scope.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: How action Entity IDs are structured and how the policy engine resolves them against policy types and resource scopes. Browse the naming reference.
 ---
 
 # Action naming and scope

--- a/docs/gamma/4.13/authorization-management/manage/actions/create-an-action.md
+++ b/docs/gamma/4.13/authorization-management/manage/actions/create-an-action.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Define the verbs your policies grant or forbid by creating an action entity that statements reference. Follow the steps on the Actions page.
 ---
 
 # Create an action

--- a/docs/gamma/4.13/authorization-management/manage/principals/README.md
+++ b/docs/gamma/4.13/authorization-management/manage/principals/README.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Sync principals from Access Management, create local ones, and give them attributes and relationships. Start with how your identities arrive.
 ---
 
 # Manage principals

--- a/docs/gamma/4.13/authorization-management/manage/principals/add-attributes-to-principals.md
+++ b/docs/gamma/4.13/authorization-management/manage/principals/add-attributes-to-principals.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Attach custom metadata to a principal, such as department or device trust, so policies test more than identity. Follow the steps to add attributes.
 ---
 
 # Add attributes to principals

--- a/docs/gamma/4.13/authorization-management/manage/principals/build-principal-relationships.md
+++ b/docs/gamma/4.13/authorization-management/manage/principals/build-principal-relationships.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Link principals into parent-child hierarchies so that one policy can match every user in a group. Follow the steps to set and edit parents.
 ---
 
 # Build principal relationships

--- a/docs/gamma/4.13/authorization-management/manage/principals/create-a-local-principal.md
+++ b/docs/gamma/4.13/authorization-management/manage/principals/create-a-local-principal.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Create a principal directly in Authorization Management when the identity is not synced or imported. Follow the steps on the Entities page.
 ---
 
 # Create a local principal

--- a/docs/gamma/4.13/authorization-management/manage/principals/sync-principals-from-access-management.md
+++ b/docs/gamma/4.13/authorization-management/manage/principals/sync-principals-from-access-management.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Synchronize users and groups from Gravitee Access Management so policies can reference your identity directory. Follow the steps to run a sync.
 ---
 
 # Sync principals from Access Management

--- a/docs/gamma/4.13/authorization-management/manage/resources/README.md
+++ b/docs/gamma/4.13/authorization-management/manage/resources/README.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Import resources from the Catalog, create local ones, and give them attributes and relationships. Start with where your resources come from.
 ---
 
 # Manage resources

--- a/docs/gamma/4.13/authorization-management/manage/resources/add-attributes-to-resources.md
+++ b/docs/gamma/4.13/authorization-management/manage/resources/add-attributes-to-resources.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Attach custom metadata to a resource, such as sensitivity or ownership, so policy conditions can test it. Follow the steps to add attributes.
 ---
 
 # Add attributes to resources

--- a/docs/gamma/4.13/authorization-management/manage/resources/build-resource-relationships.md
+++ b/docs/gamma/4.13/authorization-management/manage/resources/build-resource-relationships.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Establish parent-child hierarchies between resources so one policy covers a server and all of its tools. Follow the steps to set parents.
 ---
 
 # Build resource relationships

--- a/docs/gamma/4.13/authorization-management/manage/resources/create-a-local-resource.md
+++ b/docs/gamma/4.13/authorization-management/manage/resources/create-a-local-resource.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Create a resource entity for the internal applications, data assets, and custom tools the AI Catalog does not hold. Follow the steps to add one.
 ---
 
 # Create a local resource

--- a/docs/gamma/4.13/authorization-management/manage/resources/import-resources-from-catalog.md
+++ b/docs/gamma/4.13/authorization-management/manage/resources/import-resources-from-catalog.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Import resource entities from the AI Catalog into Authorization Management across all three categories. Follow the steps to browse and select them.
 ---
 
 # Import resources from the Catalog

--- a/docs/gamma/4.13/authorization-management/manage/schemas/README.md
+++ b/docs/gamma/4.13/authorization-management/manage/schemas/README.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: The schema declares the entity types, relationships, and actions your policies are written against. Start with how a schema is generated.
 ---
 
 # Manage schemas

--- a/docs/gamma/4.13/authorization-management/manage/schemas/edit-your-schema.md
+++ b/docs/gamma/4.13/authorization-management/manage/schemas/edit-your-schema.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Modify an existing schema to add entity types, attributes, relationships, or actions. Follow the steps to edit, validate, and save your changes.
 ---
 
 # Edit your schema

--- a/docs/gamma/4.13/authorization-management/manage/schemas/schema-generation.md
+++ b/docs/gamma/4.13/authorization-management/manage/schemas/schema-generation.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: The schema is the contract your policies are written against, declaring entity types, relationships, and actions. Learn how it is generated and read.
 ---
 
 # Schema generation

--- a/docs/gamma/4.13/authorization-management/manage/schemas/validate-schema-changes.md
+++ b/docs/gamma/4.13/authorization-management/manage/schemas/validate-schema-changes.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: How the console validates a schema change before saving, and the errors to expect. Learn the validation pipeline and how to fix a failure.
 ---
 
 # Validate schema changes


### PR DESCRIPTION
Applies the meta description spec to `authorization-management` in `docs/gamma/4.12` and `docs/gamma/4.13` — 37 of 38 pages, 74 files. Fourth in the series, after #2181 (Agent Management), #2187 (API Management), and #2194 (Event Stream Management).

Follows `style-guide/06-document-types-and-templates/meta-descriptions.md` and the procedure in `ai-tools/meta-description-skill.md`: 120–160 characters, the reader's search term placed early in approved Gravitee terminology, an imperative clause naming an on-page action to close, and unique within the space.

## What changed

| | Pages |
| --- | ---: |
| Had no description, now have one | 34 |
| Had a description that failed the spec, rewritten | 3 |
| Skipped, reported below | 1 |

This section was the emptiest so far — only 3 of 38 pages carried a description at all. Two of those three used the bare abbreviation **GAPL**, the same violation fixed in Agent Management: `product-naming.md` permits an abbreviation only after the full name is introduced, and a meta description has no prior context. Both now read "authorization policies" instead. `PDP` got the same treatment, expanded to "Policy Decision Point".

Every description lands in the 135–155 target band. Checked programmatically for length, markdown or HTML characters, year numbers, artifact openers, YAML-breaking colons, product-name casing, bare abbreviations, and duplicates — including against all three previously merged sections, since they publish into the same space.

Only the frontmatter `description` line is touched. Every added line in the diff is a `description:` line.

## One page skipped, and why

`configure/authzen-pdp-synchronization.md` gets no description. It is an empty stub — an H1 with no body — marked `hidden: true` and `noIndex: true`. Two reasons to leave it alone:

1. The procedure's guardrail is explicit: report a stub rather than write a description from its file name.
2. A meta description does nothing for a page excluded from indexing.

**It looks like a content bug worth a separate fix.** Its H1, "AuthZEN PDP synchronization", is identical to `authz-gateway-sync.md`, which is the page that actually covers the subject — and despite `hidden: true`, the stub is still listed in `SUMMARY.md` at line 184. Either the stub should be deleted and its `SUMMARY.md` entry pointed at `authz-gateway-sync.md`, or it needs content. Happy to do either as a follow-up.

## Note for review

The two versions are byte-identical across this whole section, so every description applies to both and the 4.12 and 4.13 halves of the diff are mirror images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
