### PR TITLE
docs(gamma): add meta descriptions across Platform and Edge Management 4.12 and 4.13

### DIFF
--- a/docs/gamma/4.12/edge-management/connect-claude-code-to-daemon.md
+++ b/docs/gamma/4.12/edge-management/connect-claude-code-to-daemon.md
@@ -1,6 +1,7 @@
 ---
 hidden: true
 noIndex: true
+description: Route Claude Code traffic through the Edge Daemon for local policy enforcement and central observability. Follow the steps to set the variable.
 ---
 
 # Connect Claude Code to the Edge Daemon

--- a/docs/gamma/4.12/edge-management/connect/README.md
+++ b/docs/gamma/4.12/edge-management/connect/README.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Connect your edge environments and tools to the Gamma Edge Daemon, from the proxy APIs to fleet deployment. Start with the task you need.
 ---
 
 # Connect

--- a/docs/gamma/4.12/edge-management/connect/configure-edge-ingress.md
+++ b/docs/gamma/4.12/edge-management/connect/configure-edge-ingress.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Expose the Edge Reactor port on Kubernetes so Edge Daemons on employee devices reach the AI Gateway. Follow the steps to enable ingress in Helm.
 ---
 
 # Configure Edge Ingress

--- a/docs/gamma/4.12/edge-management/connect/configure-edge-management.md
+++ b/docs/gamma/4.12/edge-management/connect/configure-edge-management.md
@@ -1,7 +1,5 @@
 ---
-description: >-
-  How to configure the Edge Management settings, proxy routes, and shadow AI
-  monitoring in the Gamma console.
+description: Set the Gateway URLs, proxy routes, and shadow AI monitoring for Edge Management in one place. Follow the steps to create and save a configuration.
 ---
 
 # Configure Edge Management

--- a/docs/gamma/4.12/edge-management/connect/configure-kandji-daemon.md
+++ b/docs/gamma/4.12/edge-management/connect/configure-kandji-daemon.md
@@ -1,5 +1,5 @@
 ---
-description: How to deploy the Edge Daemon to your macOS device fleet using Kandji MDM.
+description: Deploy the Edge Daemon across your macOS fleet with Kandji, using the script the console generates. Follow the steps to create the Custom App.
 ---
 
 # Configure Kandji to deploy the Edge Daemon

--- a/docs/gamma/4.12/edge-management/connect/proxy-api-reference.md
+++ b/docs/gamma/4.12/edge-management/connect/proxy-api-reference.md
@@ -1,7 +1,7 @@
 ---
-description: Reference for the LLM Proxy and HTTP proxy APIs in APIM that handle traffic intercepted by the Edge Daemon.
 hidden: false
 noIndex: false
+description: The LLM Proxy and HTTP proxy APIs that receive the traffic an Edge Daemon forwards, and the plan they must expose. Browse the full reference.
 ---
  
 # Proxy API reference

--- a/docs/gamma/4.12/edge-management/get-started/README.md
+++ b/docs/gamma/4.12/edge-management/get-started/README.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Edge Management in Gamma, starting with what the Edge Daemon does on employee devices and how it fits the platform. Start with the overview.
 ---
 
 # Get started

--- a/docs/gamma/4.12/edge-management/get-started/edge-management-overview.md
+++ b/docs/gamma/4.12/edge-management/get-started/edge-management-overview.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: The Edge Daemon observes AI traffic on employee devices, enforces local policy, and forwards it to the AI Gateway. Learn how it routes traffic.
 ---
 
 # Edge Daemon

--- a/docs/gamma/4.12/edge-management/observe/README.md
+++ b/docs/gamma/4.12/edge-management/observe/README.md
@@ -1,6 +1,7 @@
 ---
 hidden: true
 noIndex: true
+description: Monitor the traffic the Edge Daemon captures and proxies, from shadow AI usage to policy enforcement outcomes. Start with the view you need to see.
 ---
 
 # Observe

--- a/docs/gamma/4.12/edge-management/observe/monitor-proxied-traffic.md
+++ b/docs/gamma/4.12/edge-management/observe/monitor-proxied-traffic.md
@@ -1,6 +1,7 @@
 ---
 hidden: true
 noIndex: true
+description: Inspect traffic routed through the Edge Daemon, with request details, applied policies, and enforcement outcomes. Learn what the console shows.
 ---
 
 # Monitor your proxied traffic

--- a/docs/gamma/4.12/edge-management/observe/monitor-shadow-ai-traffic.md
+++ b/docs/gamma/4.12/edge-management/observe/monitor-shadow-ai-traffic.md
@@ -1,7 +1,7 @@
 ---
-description: Use the Gamma console to review AI service requests that occur outside governed channels.
 hidden: true
 noIndex: true
+description: Surface AI service requests happening outside governed channels so you can assess the risk. Learn how to bring that traffic under policy control.
 ---
 
 # Monitor your shadow AI traffic

--- a/docs/gamma/4.12/platform-management/configure-access-management.md
+++ b/docs/gamma/4.12/platform-management/configure-access-management.md
@@ -1,5 +1,6 @@
 ---
 noIndex: false
+description: Connect the Gamma console to a Gravitee Access Management instance so you can sync its domains. Follow the steps to configure the connection.
 ---
 
 # Configure Access Management

--- a/docs/gamma/4.12/platform-management/configure-openapi-viewer.md
+++ b/docs/gamma/4.12/platform-management/configure-openapi-viewer.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Choose which viewer the Gamma console and Developer Portal use to render OpenAPI specifications. Follow the steps to change the default viewer.
 ---
 
 # Configure OpenAPI viewer

--- a/docs/gamma/4.12/platform-management/gamma-release-notes.md
+++ b/docs/gamma/4.12/platform-management/gamma-release-notes.md
@@ -1,3 +1,7 @@
+---
+description: Everything in the first Gravitee Gamma release, across Agent, API, Authorization, Edge, and Event Stream Management. Browse the highlights.
+---
+
 # Gamma Release Notes
 
 ## Release Date: June 26, 2026

--- a/docs/gamma/4.12/platform-management/get-started/README.md
+++ b/docs/gamma/4.12/platform-management/get-started/README.md
@@ -1,7 +1,7 @@
 ---
 hidden: false
 noIndex: false
-description: Choose between the new-user and existing-user paths for getting started with Gamma.
+description: Choose the Gamma getting-started path that fits you, whether you are new to Gravitee or activating Gamma on an existing installation. Start here.
 ---
 
 # Get started

--- a/docs/gamma/4.12/platform-management/get-started/get-started-for-existing-users/README.md
+++ b/docs/gamma/4.12/platform-management/get-started/get-started-for-existing-users/README.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Already running Gravitee? Activate Gamma on your existing installation instead of installing from scratch. Choose the path for how you run it.
 ---
 # Get started for existing users
 

--- a/docs/gamma/4.12/platform-management/get-started/get-started-for-existing-users/activate-gamma-with-docker-compose.md
+++ b/docs/gamma/4.12/platform-management/get-started/get-started-for-existing-users/activate-gamma-with-docker-compose.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Activate Gamma on an existing Docker Compose installation of Gravitee by moving to the Gamma build. Follow the steps to enable and verify it.
 ---
 # Activate Gamma with Docker Compose
 

--- a/docs/gamma/4.12/platform-management/get-started/get-started-for-existing-users/activate-gamma-with-kubernetes-helm.md
+++ b/docs/gamma/4.12/platform-management/get-started/get-started-for-existing-users/activate-gamma-with-kubernetes-helm.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Activate Gamma on an existing Kubernetes deployment of Gravitee with the Helm chart. Follow the steps to move to the Gamma build and enable it.
 ---
 # Activate Gamma with Kubernetes (Helm)
 

--- a/docs/gamma/4.12/platform-management/get-started/get-started-for-new-users/README.md
+++ b/docs/gamma/4.12/platform-management/get-started/get-started-for-new-users/README.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: New to Gravitee and want to run Gamma? Choose between Gravitee Next-Gen Cloud and installing it yourself. Compare the two paths and pick one.
 ---
 # Get started for new users
 

--- a/docs/gamma/4.12/platform-management/get-started/get-started-for-new-users/fully-self-hosted-with-docker.md
+++ b/docs/gamma/4.12/platform-management/get-started/get-started-for-new-users/fully-self-hosted-with-docker.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Run a full Gamma platform yourself with Docker, bringing up the consoles, Gateway, and datastores on one host. Choose the Docker guide that fits.
 ---
 # Fully self-hosted installation with Docker
 

--- a/docs/gamma/4.12/platform-management/get-started/get-started-for-new-users/fully-self-hosted-with-vanilla-kubernetes.md
+++ b/docs/gamma/4.12/platform-management/get-started/get-started-for-new-users/fully-self-hosted-with-vanilla-kubernetes.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Run a full Gamma platform yourself on Kubernetes with the Gravitee Helm chart. Choose the guide for your cluster and the ingress it needs.
 ---
 # Fully self-hosted installation with Vanilla Kubernetes
 

--- a/docs/gamma/4.12/platform-management/install/README.md
+++ b/docs/gamma/4.12/platform-management/install/README.md
@@ -1,7 +1,7 @@
 ---
-description: Choose between a self-hosted and a hybrid Gamma installation.
 hidden: false
 noIndex: false
+description: Choose between a self-hosted Gamma installation, where you run everything, and a hybrid one, where Gravitee hosts the control plane. Pick your model.
 ---
 # Install
 

--- a/docs/gamma/4.12/platform-management/install/hybrid-installation-guides/README.md
+++ b/docs/gamma/4.12/platform-management/install/hybrid-installation-guides/README.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: In a hybrid Gamma deployment, Gravitee hosts the control plane and you run the Gateway. Choose a Docker or Kubernetes deployment method.
 ---
 # Hybrid installation guides
 

--- a/docs/gamma/4.12/platform-management/install/hybrid-installation-guides/docker/README.md
+++ b/docs/gamma/4.12/platform-management/install/hybrid-installation-guides/docker/README.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: A hybrid Gateway on one host talks to a Gravitee Cloud control plane. Compare the Docker Compose and Docker CLI methods and what each one runs.
 ---
 # Docker
 

--- a/docs/gamma/4.12/platform-management/install/hybrid-installation-guides/docker/docker-cli.md
+++ b/docs/gamma/4.12/platform-management/install/hybrid-installation-guides/docker/docker-cli.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Start a hybrid Gamma Gateway container by container with the Docker CLI, creating the network and Redis first. Follow the steps to run it.
 ---
 # Run a hybrid Gamma Gateway with Docker CLI
 

--- a/docs/gamma/4.12/platform-management/install/hybrid-installation-guides/docker/docker-compose.md
+++ b/docs/gamma/4.12/platform-management/install/hybrid-installation-guides/docker/docker-compose.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Define a hybrid Gamma Gateway in a compose file and an env file, then bring it up in one command. Follow the steps to write and run them.
 ---
 # Run a hybrid Gamma Gateway with Docker Compose
 

--- a/docs/gamma/4.12/platform-management/install/hybrid-installation-guides/kubernetes/README.md
+++ b/docs/gamma/4.12/platform-management/install/hybrid-installation-guides/kubernetes/README.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Deploy a hybrid Gamma Gateway with the Gravitee Helm chart on EKS, AKS, OpenShift, or vanilla Kubernetes. Choose the guide for your cluster.
 ---
 # Kubernetes
 

--- a/docs/gamma/4.12/platform-management/install/hybrid-installation-guides/kubernetes/aws-eks.md
+++ b/docs/gamma/4.12/platform-management/install/hybrid-installation-guides/kubernetes/aws-eks.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Install a hybrid Gamma Gateway on AWS EKS, configuring the load balancer controller for Auto Mode or standard clusters. Follow the steps to deploy.
 ---
 # Install a hybrid Gamma Gateway on AWS EKS
 

--- a/docs/gamma/4.12/platform-management/install/hybrid-installation-guides/kubernetes/azure-aks.md
+++ b/docs/gamma/4.12/platform-management/install/hybrid-installation-guides/kubernetes/azure-aks.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Install a hybrid Gamma Gateway on Azure AKS behind an NGINX ingress controller. Follow the steps to create the namespace and deploy the chart.
 ---
 # Install a hybrid Gamma Gateway on Azure AKS
 

--- a/docs/gamma/4.12/platform-management/install/hybrid-installation-guides/kubernetes/openshift.md
+++ b/docs/gamma/4.12/platform-management/install/hybrid-installation-guides/kubernetes/openshift.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Install a hybrid Gamma Gateway on OpenShift, from creating the project to running Redis. Follow the steps to deploy it with the Helm chart.
 ---
 # Install a hybrid Gamma Gateway on OpenShift
 

--- a/docs/gamma/4.12/platform-management/install/hybrid-installation-guides/kubernetes/vanilla-kubernetes.md
+++ b/docs/gamma/4.12/platform-management/install/hybrid-installation-guides/kubernetes/vanilla-kubernetes.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Install a hybrid Gamma Gateway on a vanilla Kubernetes cluster with the Gravitee Helm chart. Follow the steps to deploy the Gateway and Redis.
 ---
 # Install a hybrid Gamma Gateway on Vanilla Kubernetes
 

--- a/docs/gamma/4.12/platform-management/install/self-hosted-installation-guides/README.md
+++ b/docs/gamma/4.12/platform-management/install/self-hosted-installation-guides/README.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: A self-hosted Gamma installation runs every component in your own infrastructure. Choose a Docker or Kubernetes deployment method to begin.
 ---
 # Self-hosted installation guides
 

--- a/docs/gamma/4.12/platform-management/install/self-hosted-installation-guides/docker/README.md
+++ b/docs/gamma/4.12/platform-management/install/self-hosted-installation-guides/docker/README.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Every Gamma component on one host, from MongoDB and Elasticsearch to the consoles. Compare the Docker Compose and Docker CLI methods before you start.
 ---
 # Docker
 

--- a/docs/gamma/4.12/platform-management/install/self-hosted-installation-guides/docker/docker-cli.md
+++ b/docs/gamma/4.12/platform-management/install/self-hosted-installation-guides/docker/docker-cli.md
@@ -1,3 +1,7 @@
+---
+description: Install a fully self-hosted Gamma platform on one host with the Docker CLI. Follow the steps to run the datastores, Gateway, and consoles.
+---
+
 # Docker CLI
 
 {% hint style="warning" %}

--- a/docs/gamma/4.12/platform-management/install/self-hosted-installation-guides/docker/docker-compose.md
+++ b/docs/gamma/4.12/platform-management/install/self-hosted-installation-guides/docker/docker-compose.md
@@ -1,3 +1,7 @@
+---
+description: Install a fully self-hosted Gamma platform on one host with Docker Compose. Follow the steps to write the compose file and add a license key.
+---
+
 # Docker Compose
 
 {% hint style="warning" %}

--- a/docs/gamma/4.12/platform-management/install/self-hosted-installation-guides/kubernetes/README.md
+++ b/docs/gamma/4.12/platform-management/install/self-hosted-installation-guides/kubernetes/README.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Run the full Gamma stack on Kubernetes with the Gravitee Helm chart, datastores included. Pick the guide that matches the cluster you operate.
 ---
 # Kubernetes
 

--- a/docs/gamma/4.12/platform-management/install/self-hosted-installation-guides/kubernetes/aws-eks.md
+++ b/docs/gamma/4.12/platform-management/install/self-hosted-installation-guides/kubernetes/aws-eks.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Run the full Gamma stack on AWS EKS, with the load balancer controller plus the MongoDB and Elasticsearch datastores. Follow the steps to deploy it.
 ---
 # Install Gamma on AWS EKS
 

--- a/docs/gamma/4.12/platform-management/install/self-hosted-installation-guides/kubernetes/azure-aks.md
+++ b/docs/gamma/4.12/platform-management/install/self-hosted-installation-guides/kubernetes/azure-aks.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Run the full Gamma stack on Azure AKS behind an NGINX ingress controller. Follow the steps to create the namespace and install every component.
 ---
 # Install Gamma on Azure AKS
 

--- a/docs/gamma/4.12/platform-management/install/self-hosted-installation-guides/kubernetes/openshift.md
+++ b/docs/gamma/4.12/platform-management/install/self-hosted-installation-guides/kubernetes/openshift.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Install a fully self-hosted Gamma platform on OpenShift, with MongoDB and Elasticsearch. Follow the steps to deploy it with the Helm chart.
 ---
 # Install Gamma on OpenShift
 

--- a/docs/gamma/4.12/platform-management/install/self-hosted-installation-guides/kubernetes/vanilla-kubernetes.md
+++ b/docs/gamma/4.12/platform-management/install/self-hosted-installation-guides/kubernetes/vanilla-kubernetes.md
@@ -1,3 +1,7 @@
+---
+description: Install a fully self-hosted Gamma platform on a vanilla Kubernetes cluster. Follow the steps to deploy every component with the Helm chart.
+---
+
 # Vanilla Kubernetes
 
 {% hint style="warning" %}

--- a/docs/gamma/4.12/platform-management/manage-applications.md
+++ b/docs/gamma/4.12/platform-management/manage-applications.md
@@ -1,9 +1,7 @@
 ---
-description: >-
-  View, create, and manage the consumer applications that subscribe to your API
-  plans from the Applications page in the Gamma console.
 hidden: false
 noIndex: false
+description: View, create, and manage the consumer applications that subscribe to your API plans. Follow the steps to work with them on the Applications page.
 ---
 
 # Manage applications

--- a/docs/gamma/4.12/platform-management/manage-resources.md
+++ b/docs/gamma/4.12/platform-management/manage-resources.md
@@ -1,6 +1,7 @@
 ---
 hidden: true
 noIndex: true
+description: Resources are shared components that API proxies reference at runtime, such as caches and OAuth2 providers. Learn what the planned capability covers.
 ---
 
 # Manage resources

--- a/docs/gamma/4.12/platform-management/overview.md
+++ b/docs/gamma/4.12/platform-management/overview.md
@@ -1,8 +1,5 @@
 ---
-description: >-
-  Gravitee Gamma unifies API Management, Event Stream Management, Agent
-  Management, and Authorization Management under a shared catalog, authorization
-  engine, and enforcement architecture.
+description: Gravitee Gamma governs, secures, and observes API, event stream, and AI agent traffic from one platform. Learn why it exists and how it works.
 ---
 
 # Overview

--- a/docs/gamma/4.13/edge-management/connect-claude-code-to-daemon.md
+++ b/docs/gamma/4.13/edge-management/connect-claude-code-to-daemon.md
@@ -1,6 +1,7 @@
 ---
 hidden: true
 noIndex: true
+description: Route Claude Code traffic through the Edge Daemon for local policy enforcement and central observability. Follow the steps to set the variable.
 ---
 
 # Connect Claude Code to the Edge Daemon

--- a/docs/gamma/4.13/edge-management/connect/README.md
+++ b/docs/gamma/4.13/edge-management/connect/README.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Connect your edge environments and tools to the Gamma Edge Daemon, from the proxy APIs to fleet deployment. Start with the task you need.
 ---
 
 # Connect

--- a/docs/gamma/4.13/edge-management/connect/configure-edge-ingress.md
+++ b/docs/gamma/4.13/edge-management/connect/configure-edge-ingress.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Expose the Edge Reactor port on Kubernetes so Edge Daemons on employee devices reach the AI Gateway. Follow the steps to enable ingress in Helm.
 ---
 
 # Configure Edge Ingress

--- a/docs/gamma/4.13/edge-management/connect/configure-edge-management.md
+++ b/docs/gamma/4.13/edge-management/connect/configure-edge-management.md
@@ -1,7 +1,7 @@
 ---
 hidden: false
 noIndex: false
-description: How to configure the Edge Management settings, proxy routes, and shadow AI monitoring in the Gamma console.
+description: Set the Gateway URLs, proxy routes, and shadow AI monitoring for Edge Management in one place. Follow the steps to create and save a configuration.
 ---
 
 # Configure Edge Management

--- a/docs/gamma/4.13/edge-management/connect/configure-kandji-daemon.md
+++ b/docs/gamma/4.13/edge-management/connect/configure-kandji-daemon.md
@@ -1,7 +1,7 @@
 ---
 hidden: false
 noIndex: false
-description: How to deploy the Edge Daemon to your macOS device fleet using Kandji MDM.
+description: Deploy the Edge Daemon across your macOS fleet with Kandji, using the script the console generates. Follow the steps to create the Custom App.
 ---
 
 # Configure Kandji to deploy the Edge Daemon

--- a/docs/gamma/4.13/edge-management/connect/proxy-api-reference.md
+++ b/docs/gamma/4.13/edge-management/connect/proxy-api-reference.md
@@ -1,7 +1,7 @@
 ---
-description: Reference for the LLM Proxy and HTTP proxy APIs in APIM that handle traffic intercepted by the Edge Daemon.
 hidden: false
 noIndex: false
+description: The LLM Proxy and HTTP proxy APIs that receive the traffic an Edge Daemon forwards, and the plan they must expose. Browse the full reference.
 ---
  
 # Proxy API reference

--- a/docs/gamma/4.13/edge-management/get-started/README.md
+++ b/docs/gamma/4.13/edge-management/get-started/README.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Edge Management in Gamma, starting with what the Edge Daemon does on employee devices and how it fits the platform. Start with the overview.
 ---
 
 # Get started

--- a/docs/gamma/4.13/edge-management/get-started/edge-management-overview.md
+++ b/docs/gamma/4.13/edge-management/get-started/edge-management-overview.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: The Edge Daemon observes AI traffic on employee devices, enforces local policy, and forwards it to the AI Gateway. Learn how it routes traffic.
 ---
 
 # Edge Daemon

--- a/docs/gamma/4.13/edge-management/observe/README.md
+++ b/docs/gamma/4.13/edge-management/observe/README.md
@@ -1,6 +1,7 @@
 ---
 hidden: true
 noIndex: true
+description: Monitor the traffic the Edge Daemon captures and proxies, from shadow AI usage to policy enforcement outcomes. Start with the view you need to see.
 ---
 
 # Observe

--- a/docs/gamma/4.13/edge-management/observe/monitor-proxied-traffic.md
+++ b/docs/gamma/4.13/edge-management/observe/monitor-proxied-traffic.md
@@ -1,6 +1,7 @@
 ---
 hidden: true
 noIndex: true
+description: Inspect traffic routed through the Edge Daemon, with request details, applied policies, and enforcement outcomes. Learn what the console shows.
 ---
 
 # Monitor your proxied traffic

--- a/docs/gamma/4.13/edge-management/observe/monitor-shadow-ai-traffic.md
+++ b/docs/gamma/4.13/edge-management/observe/monitor-shadow-ai-traffic.md
@@ -1,7 +1,7 @@
 ---
-description: Use the Gamma console to review AI service requests that occur outside governed channels.
 hidden: true
 noIndex: true
+description: Surface AI service requests happening outside governed channels so you can assess the risk. Learn how to bring that traffic under policy control.
 ---
 
 # Monitor your shadow AI traffic

--- a/docs/gamma/4.13/platform-management/configure-access-management.md
+++ b/docs/gamma/4.13/platform-management/configure-access-management.md
@@ -1,5 +1,6 @@
 ---
 noIndex: false
+description: Connect the Gamma console to a Gravitee Access Management instance so you can sync its domains. Follow the steps to configure the connection.
 ---
 
 # Configure Access Management

--- a/docs/gamma/4.13/platform-management/configure-openapi-viewer.md
+++ b/docs/gamma/4.13/platform-management/configure-openapi-viewer.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Choose which viewer the Gamma console and Developer Portal use to render OpenAPI specifications. Follow the steps to change the default viewer.
 ---
 
 # Configure OpenAPI viewer

--- a/docs/gamma/4.13/platform-management/gamma-release-notes.md
+++ b/docs/gamma/4.13/platform-management/gamma-release-notes.md
@@ -1,3 +1,7 @@
+---
+description: What the Gamma 4.13 release adds across API Management, Event Stream Management, and the other modules. Browse the new features and changes.
+---
+
 # Gamma Release Notes
 
 ## 4.13 new features

--- a/docs/gamma/4.13/platform-management/get-started/README.md
+++ b/docs/gamma/4.13/platform-management/get-started/README.md
@@ -1,7 +1,7 @@
 ---
 hidden: false
 noIndex: false
-description: Choose between the new-user and existing-user paths for getting started with Gamma.
+description: Choose the Gamma getting-started path that fits you, whether you are new to Gravitee or activating Gamma on an existing installation. Start here.
 ---
 
 # Get started

--- a/docs/gamma/4.13/platform-management/get-started/get-started-for-existing-users/README.md
+++ b/docs/gamma/4.13/platform-management/get-started/get-started-for-existing-users/README.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Already running Gravitee? Activate Gamma on your existing installation instead of installing from scratch. Choose the path for how you run it.
 ---
 # Get started for existing users
 

--- a/docs/gamma/4.13/platform-management/get-started/get-started-for-existing-users/activate-gamma-with-docker-compose.md
+++ b/docs/gamma/4.13/platform-management/get-started/get-started-for-existing-users/activate-gamma-with-docker-compose.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Activate Gamma on an existing Docker Compose installation of Gravitee by moving to the Gamma build. Follow the steps to enable and verify it.
 ---
 # Activate Gamma with Docker Compose
 

--- a/docs/gamma/4.13/platform-management/get-started/get-started-for-existing-users/activate-gamma-with-kubernetes-helm.md
+++ b/docs/gamma/4.13/platform-management/get-started/get-started-for-existing-users/activate-gamma-with-kubernetes-helm.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Activate Gamma on an existing Kubernetes deployment of Gravitee with the Helm chart. Follow the steps to move to the Gamma build and enable it.
 ---
 # Activate Gamma with Kubernetes (Helm)
 

--- a/docs/gamma/4.13/platform-management/get-started/get-started-for-new-users/README.md
+++ b/docs/gamma/4.13/platform-management/get-started/get-started-for-new-users/README.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: New to Gravitee and want to run Gamma? Choose between Gravitee Next-Gen Cloud and installing it yourself. Compare the two paths and pick one.
 ---
 # Get started for new users
 

--- a/docs/gamma/4.13/platform-management/get-started/get-started-for-new-users/fully-self-hosted-with-docker.md
+++ b/docs/gamma/4.13/platform-management/get-started/get-started-for-new-users/fully-self-hosted-with-docker.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Run a full Gamma platform yourself with Docker, bringing up the consoles, Gateway, and datastores on one host. Choose the Docker guide that fits.
 ---
 # Fully self-hosted installation with Docker
 

--- a/docs/gamma/4.13/platform-management/get-started/get-started-for-new-users/fully-self-hosted-with-vanilla-kubernetes.md
+++ b/docs/gamma/4.13/platform-management/get-started/get-started-for-new-users/fully-self-hosted-with-vanilla-kubernetes.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Run a full Gamma platform yourself on Kubernetes with the Gravitee Helm chart. Choose the guide for your cluster and the ingress it needs.
 ---
 # Fully self-hosted installation with Vanilla Kubernetes
 

--- a/docs/gamma/4.13/platform-management/install/README.md
+++ b/docs/gamma/4.13/platform-management/install/README.md
@@ -1,7 +1,7 @@
 ---
-description: Choose between a self-hosted and a hybrid Gamma installation.
 hidden: false
 noIndex: false
+description: Choose between a self-hosted Gamma installation, where you run everything, and a hybrid one, where Gravitee hosts the control plane. Pick your model.
 ---
 # Install
 

--- a/docs/gamma/4.13/platform-management/install/hybrid-installation-guides/README.md
+++ b/docs/gamma/4.13/platform-management/install/hybrid-installation-guides/README.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: In a hybrid Gamma deployment, Gravitee hosts the control plane and you run the Gateway. Choose a Docker or Kubernetes deployment method.
 ---
 # Hybrid installation guides
 

--- a/docs/gamma/4.13/platform-management/install/hybrid-installation-guides/docker/README.md
+++ b/docs/gamma/4.13/platform-management/install/hybrid-installation-guides/docker/README.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: A hybrid Gateway on one host talks to a Gravitee Cloud control plane. Compare the Docker Compose and Docker CLI methods and what each one runs.
 ---
 # Docker
 

--- a/docs/gamma/4.13/platform-management/install/hybrid-installation-guides/docker/docker-cli.md
+++ b/docs/gamma/4.13/platform-management/install/hybrid-installation-guides/docker/docker-cli.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Start a hybrid Gamma Gateway container by container with the Docker CLI, creating the network and Redis first. Follow the steps to run it.
 ---
 # Run a hybrid Gamma Gateway with Docker CLI
 

--- a/docs/gamma/4.13/platform-management/install/hybrid-installation-guides/docker/docker-compose.md
+++ b/docs/gamma/4.13/platform-management/install/hybrid-installation-guides/docker/docker-compose.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Define a hybrid Gamma Gateway in a compose file and an env file, then bring it up in one command. Follow the steps to write and run them.
 ---
 # Run a hybrid Gamma Gateway with Docker Compose
 

--- a/docs/gamma/4.13/platform-management/install/hybrid-installation-guides/kubernetes/README.md
+++ b/docs/gamma/4.13/platform-management/install/hybrid-installation-guides/kubernetes/README.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Deploy a hybrid Gamma Gateway with the Gravitee Helm chart on EKS, AKS, OpenShift, or vanilla Kubernetes. Choose the guide for your cluster.
 ---
 # Kubernetes
 

--- a/docs/gamma/4.13/platform-management/install/hybrid-installation-guides/kubernetes/aws-eks.md
+++ b/docs/gamma/4.13/platform-management/install/hybrid-installation-guides/kubernetes/aws-eks.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Install a hybrid Gamma Gateway on AWS EKS, configuring the load balancer controller for Auto Mode or standard clusters. Follow the steps to deploy.
 ---
 # Install a hybrid Gamma Gateway on AWS EKS
 

--- a/docs/gamma/4.13/platform-management/install/hybrid-installation-guides/kubernetes/azure-aks.md
+++ b/docs/gamma/4.13/platform-management/install/hybrid-installation-guides/kubernetes/azure-aks.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Install a hybrid Gamma Gateway on Azure AKS behind an NGINX ingress controller. Follow the steps to create the namespace and deploy the chart.
 ---
 # Install a hybrid Gamma Gateway on Azure AKS
 

--- a/docs/gamma/4.13/platform-management/install/hybrid-installation-guides/kubernetes/openshift.md
+++ b/docs/gamma/4.13/platform-management/install/hybrid-installation-guides/kubernetes/openshift.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Install a hybrid Gamma Gateway on OpenShift, from creating the project to running Redis. Follow the steps to deploy it with the Helm chart.
 ---
 # Install a hybrid Gamma Gateway on OpenShift
 

--- a/docs/gamma/4.13/platform-management/install/hybrid-installation-guides/kubernetes/vanilla-kubernetes.md
+++ b/docs/gamma/4.13/platform-management/install/hybrid-installation-guides/kubernetes/vanilla-kubernetes.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Install a hybrid Gamma Gateway on a vanilla Kubernetes cluster with the Gravitee Helm chart. Follow the steps to deploy the Gateway and Redis.
 ---
 # Install a hybrid Gamma Gateway on Vanilla Kubernetes
 

--- a/docs/gamma/4.13/platform-management/install/self-hosted-installation-guides/README.md
+++ b/docs/gamma/4.13/platform-management/install/self-hosted-installation-guides/README.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: A self-hosted Gamma installation runs every component in your own infrastructure. Choose a Docker or Kubernetes deployment method to begin.
 ---
 # Self-hosted installation guides
 

--- a/docs/gamma/4.13/platform-management/install/self-hosted-installation-guides/docker/README.md
+++ b/docs/gamma/4.13/platform-management/install/self-hosted-installation-guides/docker/README.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Every Gamma component on one host, from MongoDB and Elasticsearch to the consoles. Compare the Docker Compose and Docker CLI methods before you start.
 ---
 # Docker
 

--- a/docs/gamma/4.13/platform-management/install/self-hosted-installation-guides/docker/docker-cli.md
+++ b/docs/gamma/4.13/platform-management/install/self-hosted-installation-guides/docker/docker-cli.md
@@ -1,3 +1,7 @@
+---
+description: Install a fully self-hosted Gamma platform on one host with the Docker CLI. Follow the steps to run the datastores, Gateway, and consoles.
+---
+
 # Docker CLI
 
 {% hint style="warning" %}

--- a/docs/gamma/4.13/platform-management/install/self-hosted-installation-guides/docker/docker-compose.md
+++ b/docs/gamma/4.13/platform-management/install/self-hosted-installation-guides/docker/docker-compose.md
@@ -1,3 +1,7 @@
+---
+description: Install a fully self-hosted Gamma platform on one host with Docker Compose. Follow the steps to write the compose file and add a license key.
+---
+
 # Docker Compose
 
 {% hint style="warning" %}

--- a/docs/gamma/4.13/platform-management/install/self-hosted-installation-guides/kubernetes/README.md
+++ b/docs/gamma/4.13/platform-management/install/self-hosted-installation-guides/kubernetes/README.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Run the full Gamma stack on Kubernetes with the Gravitee Helm chart, datastores included. Pick the guide that matches the cluster you operate.
 ---
 # Kubernetes
 

--- a/docs/gamma/4.13/platform-management/install/self-hosted-installation-guides/kubernetes/aws-eks.md
+++ b/docs/gamma/4.13/platform-management/install/self-hosted-installation-guides/kubernetes/aws-eks.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Run the full Gamma stack on AWS EKS, with the load balancer controller plus the MongoDB and Elasticsearch datastores. Follow the steps to deploy it.
 ---
 # Install Gamma on AWS EKS
 

--- a/docs/gamma/4.13/platform-management/install/self-hosted-installation-guides/kubernetes/azure-aks.md
+++ b/docs/gamma/4.13/platform-management/install/self-hosted-installation-guides/kubernetes/azure-aks.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Run the full Gamma stack on Azure AKS behind an NGINX ingress controller. Follow the steps to create the namespace and install every component.
 ---
 # Install Gamma on Azure AKS
 

--- a/docs/gamma/4.13/platform-management/install/self-hosted-installation-guides/kubernetes/openshift.md
+++ b/docs/gamma/4.13/platform-management/install/self-hosted-installation-guides/kubernetes/openshift.md
@@ -1,6 +1,7 @@
 ---
 hidden: false
 noIndex: false
+description: Install a fully self-hosted Gamma platform on OpenShift, with MongoDB and Elasticsearch. Follow the steps to deploy it with the Helm chart.
 ---
 # Install Gamma on OpenShift
 

--- a/docs/gamma/4.13/platform-management/install/self-hosted-installation-guides/kubernetes/vanilla-kubernetes.md
+++ b/docs/gamma/4.13/platform-management/install/self-hosted-installation-guides/kubernetes/vanilla-kubernetes.md
@@ -1,3 +1,7 @@
+---
+description: Install a fully self-hosted Gamma platform on a vanilla Kubernetes cluster. Follow the steps to deploy every component with the Helm chart.
+---
+
 # Vanilla Kubernetes
 
 {% hint style="warning" %}

--- a/docs/gamma/4.13/platform-management/manage-applications.md
+++ b/docs/gamma/4.13/platform-management/manage-applications.md
@@ -1,9 +1,7 @@
 ---
-description: >-
-  View, create, and manage the consumer applications that subscribe to your API
-  plans from the Applications page in the Gamma console.
 hidden: false
 noIndex: false
+description: View, create, and manage the consumer applications that subscribe to your API plans. Follow the steps to work with them on the Applications page.
 ---
 
 # Manage applications

--- a/docs/gamma/4.13/platform-management/manage-entrypoints-and-sharding-tags.md
+++ b/docs/gamma/4.13/platform-management/manage-entrypoints-and-sharding-tags.md
@@ -1,10 +1,7 @@
 ---
-description: >-
-  Configure sharding tags, entrypoint mappings, and each environment's default
-  entrypoint values from the Entrypoints & Sharding Tags page in the Gamma
-  console.
 hidden: false
 noIndex: false
+description: Sharding tags route APIs to particular API Gateway instances, and entrypoint mappings set what the Developer Portal shows. Follow the steps to manage both.
 ---
 
 # Manage entrypoints and sharding tags

--- a/docs/gamma/4.13/platform-management/manage-resources.md
+++ b/docs/gamma/4.13/platform-management/manage-resources.md
@@ -1,6 +1,7 @@
 ---
 hidden: true
 noIndex: true
+description: Resources are shared components that API proxies reference at runtime, such as caches and OAuth2 providers. Learn what the planned capability covers.
 ---
 
 # Manage resources

--- a/docs/gamma/4.13/platform-management/overview.md
+++ b/docs/gamma/4.13/platform-management/overview.md
@@ -1,8 +1,5 @@
 ---
-description: >-
-  Gravitee Gamma unifies API Management, Event Stream Management, Agent
-  Management, and Authorization Management under a shared catalog, authorization
-  engine, and enforcement architecture.
+description: Gravitee Gamma governs, secures, and observes API, event stream, and AI agent traffic from one platform. Learn why it exists and how it works.
 ---
 
 # Overview


### PR DESCRIPTION
Applies the meta description spec to the last two gamma modules — `platform-management` (33 pages) and `edge-management` (11 pages) in both `docs/gamma/4.12` and `docs/gamma/4.13`, 87 files. **This completes the gamma modules**, after #2181 (Agent Management), #2187 (API Management), #2194 (Event Stream Management), and #2197 (Authorization Management).

Follows `style-guide/06-document-types-and-templates/meta-descriptions.md` and the procedure in `ai-tools/meta-description-skill.md`.

## What changed

| | Pages |
| --- | ---: |
| Had no description, now have one | 35 |
| Had a description that failed the spec, rewritten | 9 |

The two worst offenders were `overview.md` at 186 characters, well past the point a search engine truncates, and `install/README.md` at 61. Every description now lands in the 135–155 target band.

## Three things worth knowing

**1. Eight files had no frontmatter block at all**, so one was created holding only the description:

- `gamma-release-notes.md`
- `install/self-hosted-installation-guides/docker/docker-cli.md`
- `install/self-hosted-installation-guides/docker/docker-compose.md`
- `install/self-hosted-installation-guides/kubernetes/vanilla-kubernetes.md`

(each in both versions). Their body content is byte-identical before and after — verified by checksum, not by eye. Across the whole diff the only added lines are `description:` lines, the delimiters of those eight new blocks, and the blank line after each.

**2. The 16 installation guides are structurally parallel**, which is exactly where near-duplicate descriptions come from. I ran a similarity scan over every pair. Ten pairs came back above 0.80 — hybrid vs self-hosted variants of the same platform, and EKS vs AKS within each. Rather than swapping synonyms to game the check, each was rewritten to lead with what its own guide actually covers: Auto Mode versus standard clusters on EKS, the NGINX ingress controller on AKS, the network-and-Redis sequence for Docker CLI, the compose-and-env-file pair for Docker Compose. Highest remaining similarity is 0.79.

**3. Only one page needed version-specific text.** `gamma-release-notes.md` differs materially — 4.12 describes the first Gamma release, 4.13 leads with what 4.13 adds. `manage-entrypoints-and-sharding-tags.md` exists only in 4.13. Everything else is shared.

## Note for review

Five pages here are `hidden: true` + `noIndex: true` — `manage-resources.md` and four under `edge-management`. I gave them descriptions anyway: they carry real content, one already had a description, and they are ready if the pages are ever unhidden. Say the word if you would rather leave `noIndex` pages untouched and I will strip those five.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
