### PR TITLE
docs(gko): document multi-domain TLS on a single Gateway

### DIFF
--- a/docs/gko/4.12/SUMMARY.md
+++ b/docs/gko/4.12/SUMMARY.md
@@ -59,6 +59,7 @@
 * [Gateway API](guides/gateway-api/README.md)
   * [HTTPRoute](guides/gateway-api/httproute.md)
   * [Configure TLS with cert-manager](guides/gateway-api/tls-with-cert-manager.md)
+  * [Configure multi-domain TLS on a Gateway](guides/gateway-api/multi-domain-tls.md)
   * [Configure DNS with external-dns](guides/gateway-api/dns-with-external-dns.md)
 
 ## REFERENCE

--- a/docs/gko/4.12/guides/gateway-api/README.md
+++ b/docs/gko/4.12/guides/gateway-api/README.md
@@ -199,6 +199,7 @@ spec:
 
 * [HTTPRoute](httproute.md): Configure path-based routing, header matching, traffic splitting, redirects, URL rewrites, and header modification.
 * [Configure TLS with cert-manager](tls-with-cert-manager.md): Configure TLS certificate provisioning for Gateway HTTPS listeners.
+* [Configure multi-domain TLS on a Gateway](multi-domain-tls.md): Serve several domains from one Gateway, each with its own TLS certificate.
 * [Configure DNS with external-dns](dns-with-external-dns.md): Configure DNS record creation for Gateway Services.
 * [GatewayClassParameters](../../overview/custom-resource-definitions/gatewayclassparameters.md): Configure Gravitee-specific Gateway API settings including Kubernetes deployment options and autoscaling.
 * [KafkaRoute](../../overview/custom-resource-definitions/kafkaroute.md): (experimental) Route Kafka traffic through the Gateway (requires Enterprise license).

--- a/docs/gko/4.12/guides/gateway-api/multi-domain-tls.md
+++ b/docs/gko/4.12/guides/gateway-api/multi-domain-tls.md
@@ -1,0 +1,164 @@
+# Configure multi-domain TLS on a Gateway
+
+## Overview
+
+A single `Gateway` resource serves HTTPS traffic for several domains on the same port. Define one HTTPS listener per domain, each with its own hostname and TLS certificate. GKO configures the deployed Gravitee Gateway to present each listener's certificate to its matching domain using Server Name Indication (SNI).
+
+{% hint style="info" %}
+Multi-domain TLS requires GKO 4.12.11 or later. In earlier releases, only one certificate applies to each port: the certificate of the first accepted listener on that port.
+{% endhint %}
+
+### How it works
+
+The multi-domain TLS flow works as follows:
+
+1. You define several HTTPS listeners on the same port, each with a distinct hostname and its own `certificateRefs` entry.
+2. GKO validates that each referenced Secret exists and contains PEM-encoded `tls.crt` and `tls.key` data.
+3. GKO mounts each listener's certificate Secret into the Gateway pod as a read-only volume and enables SNI on the deployed Gravitee Gateway.
+4. When a client opens a TLS connection, the Gravitee Gateway reads the requested server name and presents the certificate whose domain matches it. When no certificate matches the requested server name, the Gateway presents a fallback certificate from the configured set.
+
+## Prerequisites
+
+Before configuring multi-domain TLS, verify the following:
+
+* Install GKO with the Gateway API controller enabled. See [Gateway API](README.md) for setup instructions.
+* Verify a `GatewayClass` and `GatewayClassParameters` resource exist.
+* Create a TLS Secret per domain, containing PEM-encoded `tls.crt` and `tls.key` data. To provision the certificates automatically, see [Configure TLS with cert-manager](tls-with-cert-manager.md).
+
+## Define one HTTPS listener per domain
+
+Each listener declares its own `hostname` and references its own TLS certificate. The following `Gateway` serves `api.example.com` and `portal.example.com` on port 443:
+
+{% code lineNumbers="true" %}
+```yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gravitee-gateway
+spec:
+  gatewayClassName: gravitee-gateway
+  listeners:
+    - name: api
+      port: 443
+      protocol: HTTPS
+      hostname: api.example.com
+      tls:
+        certificateRefs:
+          - group: ""
+            kind: Secret
+            name: api-example-com-tls
+    - name: portal
+      port: 443
+      protocol: HTTPS
+      hostname: portal.example.com
+      tls:
+        certificateRefs:
+          - group: ""
+            kind: Secret
+            name: portal-example-com-tls
+```
+{% endcode %}
+
+The following rules apply to listeners that share a port:
+
+* Give each listener a distinct hostname. Two listeners with the same port and the same hostname conflict, and GKO rejects both.
+* Use the same protocol for every listener on the port. Two listeners with the same port and different protocols conflict, and GKO rejects both.
+* Reference exactly one certificate per listener. GKO rejects a listener with zero or several `certificateRefs` entries.
+* Reference a Secret in another namespace only when a `ReferenceGrant` in that namespace permits it. Without a `ReferenceGrant`, GKO rejects the listener.
+
+{% hint style="info" %}
+When a port has a single TLS listener, SNI isn't enabled and the Gateway serves that listener's certificate directly from the referenced Secret.
+{% endhint %}
+
+## Attach routes to each domain
+
+Declare each domain in the `hostnames` field of the `HTTPRoute` that serves it:
+
+{% code lineNumbers="true" %}
+```yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: api-route
+spec:
+  parentRefs:
+  - name: gravitee-gateway
+    kind: Gateway
+    group: gateway.networking.k8s.io
+    namespace: default
+  hostnames:
+    - api.example.com
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - kind: Service
+          group: ""
+          name: api-backend
+          namespace: default
+          port: 8080
+```
+{% endcode %}
+
+To bind a route to a single listener instead, set `sectionName` in the route's `parentRefs` entry to the listener name. A route without a `hostnames` field that targets a listener through `sectionName` serves the hostname of that listener.
+
+## Verification
+
+To verify multi-domain TLS is working as expected, follow these steps:
+
+1. Check that the Gateway is programmed and has an address:
+
+    ```sh
+    kubectl get gateway gravitee-gateway
+    ```
+
+    This command results in the following output:
+
+    ```
+    NAME               CLASS              ADDRESS        PROGRAMMED   AGE
+    gravitee-gateway   gravitee-gateway   203.0.113.10   True         2m
+    ```
+
+2. Check that every listener is accepted:
+
+    ```sh
+    kubectl get gateway gravitee-gateway \
+      -o jsonpath='{range .status.listeners[*]}{.name}{": "}{.conditions[?(@.type=="Accepted")].status}{"\n"}{end}'
+    ```
+
+    This command results in the following output:
+
+    ```
+    api: True
+    portal: True
+    ```
+
+3. Retrieve the Gateway address:
+
+    ```sh
+    GATEWAY_IP=$(kubectl get gateway gravitee-gateway -o jsonpath='{.status.addresses[0].value}')
+    ```
+
+4. Confirm each domain is served with its own certificate:
+
+    ```sh
+    echo | openssl s_client -connect "$GATEWAY_IP":443 \
+      -servername api.example.com 2>/dev/null \
+      | openssl x509 -noout -subject
+    ```
+
+    ```sh
+    echo | openssl s_client -connect "$GATEWAY_IP":443 \
+      -servername portal.example.com 2>/dev/null \
+      | openssl x509 -noout -subject
+    ```
+
+    The first command prints the subject of the `api.example.com` certificate, and the second command prints the subject of the `portal.example.com` certificate.
+
+## What's next
+
+* [Configure TLS with cert-manager](tls-with-cert-manager.md): Provision and renew the per-domain certificates automatically.
+* [Configure DNS with external-dns](dns-with-external-dns.md): Configure DNS record creation for Gateway Services.
+* [HTTPRoute](httproute.md): Configure path-based routing, header matching, traffic splitting, redirects, URL rewrites, and header modification.

--- a/docs/gko/4.12/releases-and-changelog/release-notes/gko-4.12.md
+++ b/docs/gko/4.12/releases-and-changelog/release-notes/gko-4.12.md
@@ -32,7 +32,7 @@ GKO now relies on Automation API. Helm Charts users need to configure ingress co
 You need to:
 
 * enable it
-* configure hosts & tls
+* configure `hosts` & `tls`
 {% endhint %}
 
 ### Automation API schema changes
@@ -56,15 +56,15 @@ From GKO 4.12.11, a `Gateway` resource that sets `spec.infrastructure.parameters
 
 #### Full support of webhook APIs
 
-&#x20;The `Subscription` CRD now accepts a `consumerConfiguration`  object, allowing to configure an entrypoint and webhook configuration ( `callbackUrl`, `auth`, `headers`, `ssl`...).
+&#x20;The `Subscription` CRD now accepts a `consumerConfiguration`  object, allowing to configure an entrypoint and webhook configuration ( `callbackUrl`, `auth`, `headers`, `ssl`, and more).
 
 #### **Dictionary Management**&#x20;
 
 * New Dictionary CRD allow to manage Dictionaries declaratively in association with the `ManagementContext` CRD
-* Supports both MANUAL dictionaries (static key-value pairs) and DYNAMIC dictionaries (auto-refreshing data from external HTTP endpoints with JOLT transformations).
+* Supports both MANUAL dictionaries (static key-value pairs) and DYNAMIC dictionaries (data refreshed automatically from external HTTP endpoints with JOLT transformations).
 * Dictionary deployment states control gateway availability: deployed MANUAL dictionaries expose data to policies, while started DYNAMIC dictionaries enable scheduled polling.
 *
-* Requires `ENVIRONMENT_DICTIONARY` permissions with `CREATE`, `UPDATE`, `DELETE`, and `READ` actions; dynamic dictionaries require a reachable HTTP endpoint and a valid JOLT specification.
+* Requires `ENVIRONMENT_DICTIONARY` permissions with `CREATE`, `UPDATE`, `DELETE`, and `READ` actions. Dynamic dictionaries require a reachable HTTP endpoint and a valid JOLT specification.
 
 #### Next-generation Developer Portal structure and Document Management
 
@@ -79,10 +79,11 @@ From GKO 4.12.11, a `Gateway` resource that sets `spec.infrastructure.parameters
 From GKO 4.12.11, the Gateway API controller builds against Kubernetes Gateway API v1.6.1 and installs the v1.6.1 standard channel CRDs. Releases up to 4.12.10 build against Gateway API v1.4.1. GKO passes every core and extended test in the `GATEWAY-HTTP` conformance profile. The [Gateway API implementations page](https://gateway-api.sigs.k8s.io/implementations/) lists GKO as a conformant implementation. The upgrade adds the following:
 
 * `HTTPRoute` resources support method matching, host rewrite through `URLRewrite`, backend request header modification on rules that declare a single `backendRef`, and backend Services that advertise `appProtocol: kubernetes.io/h2c`. For details, see [HTTPRoute](../../guides/gateway-api/httproute.md).
+* A `Gateway` resource accepts several HTTPS listeners on the same port, each with its own hostname and TLS certificate, and the deployed Gateway uses Server Name Indication (SNI) to present the certificate matching the requested domain. In releases up to 4.12.10, a port serves only the certificate of the first accepted listener on that port. For details, see [Configure multi-domain TLS on a Gateway](../../guides/gateway-api/multi-domain-tls.md).
 * The `spec.tls.frontend` field of a `Gateway` resource configures client certificate validation for HTTPS listeners, with a default configuration and per-port overrides. The CA bundle comes from a ConfigMap that contains a `ca.crt` key, and the deployed Gateway then requires client certificates on the configured port.
 * Labels and annotations set under `spec.infrastructure` of a `Gateway` resource propagate to the ServiceAccount, Deployment, pod template, and Service that GKO creates for the Gateway.
 * The `gatewayAPI.controller.matchAcrossRoutes` Helm option merges HTTPRoute resources with overlapping context paths on the same Gateway into a single API definition, so matching works across routes. The option is disabled by default. For details, see [Install with Helm](../../getting-started/installation/install-with-helm.md).
 
 ## Bug Fixes
 
-* Updating ApiV4Definition to change plan generalConditions to a new page HRID causes reconciliation failure (HTTP 500) [#11327](https://github.com/gravitee-io/issues/issues/11327)
+* Updating ApiV4Definition to change plan `generalConditions` to a new page HRID causes reconciliation failure (HTTP 500) [#11327](https://github.com/gravitee-io/issues/issues/11327)

--- a/docs/gko/4.13/.version-overrides
+++ b/docs/gko/4.13/.version-overrides
@@ -11,4 +11,5 @@ releases-and-changelog/release-notes/gko-4.13.md
 guides/gateway-api/README.md
 guides/gateway-api/httproute.md
 guides/gateway-api/tls-with-cert-manager.md
+guides/gateway-api/multi-domain-tls.md
 getting-started/installation/install-with-helm.md

--- a/docs/gko/4.13/SUMMARY.md
+++ b/docs/gko/4.13/SUMMARY.md
@@ -59,6 +59,7 @@
 * [Gateway API](guides/gateway-api/README.md)
   * [HTTPRoute](guides/gateway-api/httproute.md)
   * [Configure TLS with cert-manager](guides/gateway-api/tls-with-cert-manager.md)
+  * [Configure multi-domain TLS on a Gateway](guides/gateway-api/multi-domain-tls.md)
   * [Configure DNS with external-dns](guides/gateway-api/dns-with-external-dns.md)
 
 ## REFERENCE

--- a/docs/gko/4.13/guides/gateway-api/README.md
+++ b/docs/gko/4.13/guides/gateway-api/README.md
@@ -195,6 +195,7 @@ spec:
 
 * [HTTPRoute](httproute.md): Configure path-based routing, header matching, traffic splitting, redirects, URL rewrites, and header modification.
 * [Configure TLS with cert-manager](tls-with-cert-manager.md): Configure TLS certificate provisioning for Gateway HTTPS listeners.
+* [Configure multi-domain TLS on a Gateway](multi-domain-tls.md): Serve several domains from one Gateway, each with its own TLS certificate.
 * [Configure DNS with external-dns](dns-with-external-dns.md): Configure DNS record creation for Gateway Services.
 * [GatewayClassParameters](../../overview/custom-resource-definitions/gatewayclassparameters.md): Configure Gravitee-specific Gateway API settings including Kubernetes deployment options and autoscaling.
 * [KafkaRoute](../../overview/custom-resource-definitions/kafkaroute.md): (experimental) Route Kafka traffic through the Gateway (requires Enterprise license).

--- a/docs/gko/4.13/guides/gateway-api/multi-domain-tls.md
+++ b/docs/gko/4.13/guides/gateway-api/multi-domain-tls.md
@@ -1,0 +1,160 @@
+# Configure multi-domain TLS on a Gateway
+
+## Overview
+
+A single `Gateway` resource serves HTTPS traffic for several domains on the same port. Define one HTTPS listener per domain, each with its own hostname and TLS certificate. GKO configures the deployed Gravitee Gateway to present each listener's certificate to its matching domain using Server Name Indication (SNI).
+
+### How it works
+
+The multi-domain TLS flow works as follows:
+
+1. You define several HTTPS listeners on the same port, each with a distinct hostname and its own `certificateRefs` entry.
+2. GKO validates that each referenced Secret exists and contains PEM-encoded `tls.crt` and `tls.key` data.
+3. GKO mounts each listener's certificate Secret into the Gateway pod as a read-only volume and enables SNI on the deployed Gravitee Gateway.
+4. When a client opens a TLS connection, the Gravitee Gateway reads the requested server name and presents the certificate whose domain matches it. When no certificate matches the requested server name, the Gateway presents a fallback certificate from the configured set.
+
+## Prerequisites
+
+Before configuring multi-domain TLS, verify the following:
+
+* Install GKO with the Gateway API controller enabled. See [Gateway API](README.md) for setup instructions.
+* Verify a `GatewayClass` and `GatewayClassParameters` resource exist.
+* Create a TLS Secret per domain, containing PEM-encoded `tls.crt` and `tls.key` data. To provision the certificates automatically, see [Configure TLS with cert-manager](tls-with-cert-manager.md).
+
+## Define one HTTPS listener per domain
+
+Each listener declares its own `hostname` and references its own TLS certificate. The following `Gateway` serves `api.example.com` and `portal.example.com` on port 443:
+
+{% code lineNumbers="true" %}
+```yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gravitee-gateway
+spec:
+  gatewayClassName: gravitee-gateway
+  listeners:
+    - name: api
+      port: 443
+      protocol: HTTPS
+      hostname: api.example.com
+      tls:
+        certificateRefs:
+          - group: ""
+            kind: Secret
+            name: api-example-com-tls
+    - name: portal
+      port: 443
+      protocol: HTTPS
+      hostname: portal.example.com
+      tls:
+        certificateRefs:
+          - group: ""
+            kind: Secret
+            name: portal-example-com-tls
+```
+{% endcode %}
+
+The following rules apply to listeners that share a port:
+
+* Give each listener a distinct hostname. Two listeners with the same port and the same hostname conflict, and GKO rejects both.
+* Use the same protocol for every listener on the port. Two listeners with the same port and different protocols conflict, and GKO rejects both.
+* Reference exactly one certificate per listener. GKO rejects a listener with zero or several `certificateRefs` entries.
+* Reference a Secret in another namespace only when a `ReferenceGrant` in that namespace permits it. Without a `ReferenceGrant`, GKO rejects the listener.
+
+{% hint style="info" %}
+When a port has a single TLS listener, SNI isn't enabled and the Gateway serves that listener's certificate directly from the referenced Secret.
+{% endhint %}
+
+## Attach routes to each domain
+
+Declare each domain in the `hostnames` field of the `HTTPRoute` that serves it:
+
+{% code lineNumbers="true" %}
+```yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: api-route
+spec:
+  parentRefs:
+  - name: gravitee-gateway
+    kind: Gateway
+    group: gateway.networking.k8s.io
+    namespace: default
+  hostnames:
+    - api.example.com
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - kind: Service
+          group: ""
+          name: api-backend
+          namespace: default
+          port: 8080
+```
+{% endcode %}
+
+To bind a route to a single listener instead, set `sectionName` in the route's `parentRefs` entry to the listener name. A route without a `hostnames` field that targets a listener through `sectionName` serves the hostname of that listener.
+
+## Verification
+
+To verify multi-domain TLS is working as expected, follow these steps:
+
+1. Check that the Gateway is programmed and has an address:
+
+    ```sh
+    kubectl get gateway gravitee-gateway
+    ```
+
+    This command results in the following output:
+
+    ```
+    NAME               CLASS              ADDRESS        PROGRAMMED   AGE
+    gravitee-gateway   gravitee-gateway   203.0.113.10   True         2m
+    ```
+
+2. Check that every listener is accepted:
+
+    ```sh
+    kubectl get gateway gravitee-gateway \
+      -o jsonpath='{range .status.listeners[*]}{.name}{": "}{.conditions[?(@.type=="Accepted")].status}{"\n"}{end}'
+    ```
+
+    This command results in the following output:
+
+    ```
+    api: True
+    portal: True
+    ```
+
+3. Retrieve the Gateway address:
+
+    ```sh
+    GATEWAY_IP=$(kubectl get gateway gravitee-gateway -o jsonpath='{.status.addresses[0].value}')
+    ```
+
+4. Confirm each domain is served with its own certificate:
+
+    ```sh
+    echo | openssl s_client -connect "$GATEWAY_IP":443 \
+      -servername api.example.com 2>/dev/null \
+      | openssl x509 -noout -subject
+    ```
+
+    ```sh
+    echo | openssl s_client -connect "$GATEWAY_IP":443 \
+      -servername portal.example.com 2>/dev/null \
+      | openssl x509 -noout -subject
+    ```
+
+    The first command prints the subject of the `api.example.com` certificate, and the second command prints the subject of the `portal.example.com` certificate.
+
+## What's next
+
+* [Configure TLS with cert-manager](tls-with-cert-manager.md): Provision and renew the per-domain certificates automatically.
+* [Configure DNS with external-dns](dns-with-external-dns.md): Configure DNS record creation for Gateway Services.
+* [HTTPRoute](httproute.md): Configure path-based routing, header matching, traffic splitting, redirects, URL rewrites, and header modification.

--- a/docs/gko/4.13/releases-and-changelog/release-notes/gko-4.12.md
+++ b/docs/gko/4.13/releases-and-changelog/release-notes/gko-4.12.md
@@ -32,7 +32,7 @@ GKO now relies on Automation API. Helm Charts users need to configure ingress co
 You need to:
 
 * enable it
-* configure hosts & tls
+* configure `hosts` & `tls`
 {% endhint %}
 
 ### Gateway infrastructure parameters are rejected
@@ -52,15 +52,15 @@ From GKO 4.12.11, a `Gateway` resource that sets `spec.infrastructure.parameters
 
 #### Full support of webhook APIs
 
-&#x20;The `Subscription` CRD now accepts a `consumerConfiguration`  object, allowing to configure an entrypoint and webhook configuration ( `callbackUrl`, `auth`, `headers`, `ssl`...).
+&#x20;The `Subscription` CRD now accepts a `consumerConfiguration`  object, allowing to configure an entrypoint and webhook configuration ( `callbackUrl`, `auth`, `headers`, `ssl`, and more).
 
 #### **Dictionary Management**&#x20;
 
 * New Dictionary CRD allow to manage Dictionaries declaratively in association with the `ManagementContext` CRD
-* Supports both MANUAL dictionaries (static key-value pairs) and DYNAMIC dictionaries (auto-refreshing data from external HTTP endpoints with JOLT transformations).
+* Supports both MANUAL dictionaries (static key-value pairs) and DYNAMIC dictionaries (data refreshed automatically from external HTTP endpoints with JOLT transformations).
 * Dictionary deployment states control gateway availability: deployed MANUAL dictionaries expose data to policies, while started DYNAMIC dictionaries enable scheduled polling.
 *
-* Requires `ENVIRONMENT_DICTIONARY` permissions with `CREATE`, `UPDATE`, `DELETE`, and `READ` actions; dynamic dictionaries require a reachable HTTP endpoint and a valid JOLT specification.
+* Requires `ENVIRONMENT_DICTIONARY` permissions with `CREATE`, `UPDATE`, `DELETE`, and `READ` actions. Dynamic dictionaries require a reachable HTTP endpoint and a valid JOLT specification.
 
 #### Next-generation Developer Portal structure and Document Management
 
@@ -75,10 +75,11 @@ From GKO 4.12.11, a `Gateway` resource that sets `spec.infrastructure.parameters
 From GKO 4.12.11, the Gateway API controller builds against Kubernetes Gateway API v1.6.1 and installs the v1.6.1 standard channel CRDs. Releases up to 4.12.10 build against Gateway API v1.4.1. GKO passes every core and extended test in the `GATEWAY-HTTP` conformance profile. The [Gateway API implementations page](https://gateway-api.sigs.k8s.io/implementations/) lists GKO as a conformant implementation. The upgrade adds the following:
 
 * `HTTPRoute` resources support method matching, host rewrite through `URLRewrite`, backend request header modification on rules that declare a single `backendRef`, and backend Services that advertise `appProtocol: kubernetes.io/h2c`. For details, see [HTTPRoute](../../guides/gateway-api/httproute.md).
+* A `Gateway` resource accepts several HTTPS listeners on the same port, each with its own hostname and TLS certificate, and the deployed Gateway uses Server Name Indication (SNI) to present the certificate matching the requested domain. In releases up to 4.12.10, a port serves only the certificate of the first accepted listener on that port. For details, see [Configure multi-domain TLS on a Gateway](../../guides/gateway-api/multi-domain-tls.md).
 * The `spec.tls.frontend` field of a `Gateway` resource configures client certificate validation for HTTPS listeners, with a default configuration and per-port overrides. The CA bundle comes from a ConfigMap that contains a `ca.crt` key, and the deployed Gateway then requires client certificates on the configured port.
 * Labels and annotations set under `spec.infrastructure` of a `Gateway` resource propagate to the ServiceAccount, Deployment, pod template, and Service that GKO creates for the Gateway.
 * The `gatewayAPI.controller.matchAcrossRoutes` Helm option merges HTTPRoute resources with overlapping context paths on the same Gateway into a single API definition, so matching works across routes. The option is disabled by default. For details, see [Install with Helm](../../getting-started/installation/install-with-helm.md).
 
 ## Bug Fixes
 
-* Updating ApiV4Definition to change plan generalConditions to a new page HRID causes reconciliation failure (HTTP 500) [#11327](https://github.com/gravitee-io/issues/issues/11327)
+* Updating ApiV4Definition to change plan `generalConditions` to a new page HRID causes reconciliation failure (HTTP 500) [#11327](https://github.com/gravitee-io/issues/issues/11327)

--- a/vale/styles/config/vocabularies/docs/accept.txt
+++ b/vale/styles/config/vocabularies/docs/accept.txt
@@ -455,6 +455,7 @@ cert-manager
 controllerName
 parametersRef
 (?i)openssl
+s_client
 [Gg]ravitee\.io
 [Mm]inikube
 balancer's


### PR DESCRIPTION
## Summary

Feature-work docs for the **APIM-14549** epic (gateway API implementation gaps closure), fixVersion 4.13.0:

- JIRA ticket: https://gravitee.atlassian.net/browse/APIM-14549
