### PR TITLE
docs(apim): document timeout management and the Gateway error keys

### DIFF
--- a/docs/apim/4.12/SUMMARY.md
+++ b/docs/apim/4.12/SUMMARY.md
@@ -432,6 +432,7 @@
     * [Configure Gateway for OpenTelemetry Logs](analyze-and-monitor-apis/configure-gateway-for-opentelemetry-logs.md)
     * [Enable and Use OpenTelemetry Logs for APIs](analyze-and-monitor-apis/enable-and-use-opentelemetry-logs-for-apis.md)
   * [Execution Transparency Analytics](analyze-and-monitor-apis/execution-transparency-analytics.md)
+  * [Gateway Error Key Reference](analyze-and-monitor-apis/gateway-error-key-reference.md)
 * [Alert Engine](alert-engine/README.md)
   * [Architecture](alert-engine/overview/architecture.md)
   * [Integrations](alert-engine/overview/integrations.md)

--- a/docs/apim/4.12/SUMMARY.md
+++ b/docs/apim/4.12/SUMMARY.md
@@ -538,6 +538,7 @@
     * [JDBC](prepare-a-production-environment/repositories/jdbc.md)
     * [Redis](prepare-a-production-environment/repositories/redis.md)
   * [Configure your HTTP Server](prepare-a-production-environment/configure-your-http-server.md)
+  * [Timeout Management](prepare-a-production-environment/timeout-management.md)
   * [Sensitive Data Management](prepare-a-production-environment/sensitive-data-management/README.md)
     * [Configure Secrets](prepare-a-production-environment/sensitive-data-management/configure-secrets/README.md)
       * [Quick Start](prepare-a-production-environment/sensitive-data-management/configure-secrets/quick-start.md)

--- a/docs/apim/4.12/analyze-and-monitor-apis/execution-transparency-analytics.md
+++ b/docs/apim/4.12/analyze-and-monitor-apis/execution-transparency-analytics.md
@@ -285,6 +285,6 @@ The Gateway sets one of the following error keys when a request fails on a conne
 
 Keys that start with `GATEWAY_CLIENT_` indicate a backend-side fault. The fine-grained timeout keys carry `REQUEST_TIMEOUT` as a parent key, and the fine-grained connection keys carry `GATEWAY_CLIENT_CONNECTION_ERROR` as a parent key. Keys that start with `CLIENT_ABORTED_` indicate that the API consumer went away, and don't point to a backend problem.
 
-`GATEWAY_CLIENT_CONNECTION_POOL_EXHAUSTED` is the exception to that fallback. Its parent produces a `502`, so without a response template of its own it reaches the API consumer under the wrong status.
+`GATEWAY_CLIENT_CONNECTION_POOL_EXHAUSTED` is the exception to that fallback. Its status differs from its parent's, `503` against `502`, and a response template always dictates the status. A template configured on `GATEWAY_CLIENT_CONNECTION_ERROR`, or a `DEFAULT` one, therefore turns pool exhaustion into a `502`.
 
 For the keys the Gateway raises outside connectivity, such as routing, plan resolution, and request handling, see the [Gateway error key reference](gateway-error-key-reference.md).

--- a/docs/apim/4.12/analyze-and-monitor-apis/execution-transparency-analytics.md
+++ b/docs/apim/4.12/analyze-and-monitor-apis/execution-transparency-analytics.md
@@ -271,6 +271,7 @@ The Gateway sets one of the following error keys when a request fails on a conne
 | `REQUEST_TIMEOUT` | 504 | The Gateway-level `requestTimeout` elapsed before the response completed. |
 | `GATEWAY_CLIENT_CONNECT_TIMEOUT` | 504 | The connection to the backend didn't complete within the endpoint's connect timeout. |
 | `GATEWAY_CLIENT_READ_TIMEOUT` | 504 | The backend connection was established, but no response arrived within the endpoint's read timeout. |
+| `GATEWAY_CLIENT_CONNECTION_POOL_EXHAUSTED` | 503 | The connection pool and its wait queue are both full. The Gateway shed the load deliberately, and the request never reached the backend. |
 | `GATEWAY_CLIENT_CONNECTION_ERROR` | 502 | A backend connection failed for a reason not covered by a more specific key. |
 | `GATEWAY_CLIENT_CONNECTION_REFUSED` | 502 | The backend refused the connection. |
 | `GATEWAY_CLIENT_DNS_RESOLUTION_ERROR` | 502 | The backend hostname didn't resolve. |
@@ -283,3 +284,7 @@ The Gateway sets one of the following error keys when a request fails on a conne
 | `CLIENT_ABORTED_CHANNEL_CLOSED` | 499 | The API consumer closed the connection. |
 
 Keys that start with `GATEWAY_CLIENT_` indicate a backend-side fault. The fine-grained timeout keys carry `REQUEST_TIMEOUT` as a parent key, and the fine-grained connection keys carry `GATEWAY_CLIENT_CONNECTION_ERROR` as a parent key. Keys that start with `CLIENT_ABORTED_` indicate that the API consumer went away, and don't point to a backend problem.
+
+`GATEWAY_CLIENT_CONNECTION_POOL_EXHAUSTED` is the exception to that fallback. Its parent produces a `502`, so without a response template of its own it reaches the API consumer under the wrong status.
+
+For the keys the Gateway raises outside connectivity, such as routing, plan resolution, and request handling, see the [Gateway error key reference](gateway-error-key-reference.md).

--- a/docs/apim/4.12/analyze-and-monitor-apis/gateway-error-key-reference.md
+++ b/docs/apim/4.12/analyze-and-monitor-apis/gateway-error-key-reference.md
@@ -12,7 +12,7 @@ The Gateway records an error key on every request it fails. The key appears in t
 
 Two properties of these keys matter when you read them.
 
-**The status is a default.** A [response template](../create-and-configure-apis/configure-v4-apis/response-templates.md) configured for a key, or for its parent key, overrides it. A `502` below can reach the API consumer as a `500` when the API falls back to a `DEFAULT` template.
+**The status is a default.** A [response template](../create-and-configure-apis/configure-v4-apis/response-templates.md) configured for a key, or for its parent key, overrides it. A key listed here as a `502` can reach the API consumer as a `500` when the API falls back to a `DEFAULT` template.
 
 **Fine-grained keys carry a parent key.** When no response template targets the specific key, the Gateway falls back to the template configured for its parent. A fine-grained key without its own template still produces a sensible status.
 
@@ -20,17 +20,17 @@ Two properties of these keys matter when you read them.
 
 The Gateway raises these keys while it acts as an HTTP client towards the backend.
 
-<table><thead><tr><th width="80">Status</th><th width="330">Error key</th><th>What it means</th></tr></thead><tbody><tr><td>502</td><td><code>GATEWAY_CLIENT_CONNECTION_ERROR</code></td><td>Umbrella key. Any backend connection failure that matches no more specific case below.</td></tr><tr><td>502</td><td><code>GATEWAY_CLIENT_CONNECTION_REFUSED</code></td><td>The backend refused the TCP connection. Nothing listens on that port.</td></tr><tr><td>502</td><td><code>GATEWAY_CLIENT_DNS_RESOLUTION_ERROR</code></td><td>The backend hostname didn't resolve.</td></tr><tr><td>502</td><td><code>GATEWAY_CLIENT_UNREACHABLE</code></td><td>No network route to the backend host exists.</td></tr><tr><td>502</td><td><code>GATEWAY_CLIENT_TLS_HANDSHAKE_ERROR</code></td><td>The TLS handshake with the backend failed: certificate, protocol, or cipher mismatch.</td></tr><tr><td>502</td><td><code>GATEWAY_CLIENT_CONNECTION_RESET</code></td><td>The backend reset the connection with a TCP RST, or sent an HTTP/2 RST_STREAM.</td></tr><tr><td>502</td><td><code>GATEWAY_CLIENT_CONNECTION_CLOSED</code></td><td>The connection closed while a response was still expected. See the note below.</td></tr><tr><td><strong>503</strong></td><td><code>GATEWAY_CLIENT_CONNECTION_POOL_EXHAUSTED</code></td><td>The connection pool and its wait queue are both full. The Gateway sheds load on purpose, and the request never reached the backend. Retryable.</td></tr><tr><td>504</td><td><code>GATEWAY_CLIENT_CONNECT_TIMEOUT</code></td><td>No connection was obtained in time: pool saturation, slow DNS, or slow TCP connect. The request never reached the backend.</td></tr><tr><td>504</td><td><code>GATEWAY_CLIENT_READ_TIMEOUT</code></td><td>A connection was obtained and the request was sent, but the backend stayed silent for longer than <code>readTimeout</code>.</td></tr><tr><td>504</td><td><code>REQUEST_TIMEOUT</code></td><td>Umbrella key for the two timeouts above. Also the key of the Gateway-wide request timeout.</td></tr></tbody></table>
+<table><thead><tr><th width="80">Status</th><th width="330">Error key</th><th>What it means</th></tr></thead><tbody><tr><td>502</td><td><code>GATEWAY_CLIENT_CONNECTION_ERROR</code></td><td>Umbrella key. A backend connection failed for a reason that no more specific key covers.</td></tr><tr><td>502</td><td><code>GATEWAY_CLIENT_CONNECTION_REFUSED</code></td><td>The backend refused the TCP connection. Nothing listens on that port.</td></tr><tr><td>502</td><td><code>GATEWAY_CLIENT_DNS_RESOLUTION_ERROR</code></td><td>The backend hostname didn't resolve.</td></tr><tr><td>502</td><td><code>GATEWAY_CLIENT_UNREACHABLE</code></td><td>No network route to the backend host exists.</td></tr><tr><td>502</td><td><code>GATEWAY_CLIENT_TLS_HANDSHAKE_ERROR</code></td><td>The TLS handshake with the backend failed: certificate, protocol, or cipher mismatch.</td></tr><tr><td>502</td><td><code>GATEWAY_CLIENT_CONNECTION_RESET</code></td><td>The backend reset the connection with a TCP RST, or sent an HTTP/2 RST_STREAM.</td></tr><tr><td>502</td><td><code>GATEWAY_CLIENT_CONNECTION_CLOSED</code></td><td>The connection closed while a response was still expected. See the note that follows this table.</td></tr><tr><td>503</td><td><code>GATEWAY_CLIENT_CONNECTION_POOL_EXHAUSTED</code></td><td>The connection pool and its wait queue are both full, so the Gateway sheds the load deliberately. The request never reached the backend, and it can be retried.</td></tr><tr><td>504</td><td><code>GATEWAY_CLIENT_CONNECT_TIMEOUT</code></td><td>No connection was obtained in time: pool saturation, slow DNS, or slow TCP connect. The request never reached the backend.</td></tr><tr><td>504</td><td><code>GATEWAY_CLIENT_READ_TIMEOUT</code></td><td>A connection was obtained and the request was sent, but the backend stayed silent for longer than <code>readTimeout</code>.</td></tr><tr><td>504</td><td><code>REQUEST_TIMEOUT</code></td><td>Umbrella key for the two timeout keys. Also the key that the Gateway-wide request timeout produces.</td></tr></tbody></table>
 
 The two timeout keys carry `REQUEST_TIMEOUT` as their parent. Every other key in this table carries `GATEWAY_CLIENT_CONNECTION_ERROR`.
 
 {% hint style="warning" %}
-`GATEWAY_CLIENT_CONNECTION_POOL_EXHAUSTED` is the one key whose parent produces a different status. Without a template of its own, it falls back to `GATEWAY_CLIENT_CONNECTION_ERROR`, and reaches the consumer as a `502` rather than a `503`. Configure a template for this key when that distinction matters.
+`GATEWAY_CLIENT_CONNECTION_POOL_EXHAUSTED` is the one key whose status differs from its parent's: `503` against `502`. With no response template in play, it returns `503` as expected. But a template configured on `GATEWAY_CLIENT_CONNECTION_ERROR` — or a `DEFAULT` one — applies to it as well, and a template always dictates the status: pool exhaustion then reaches the consumer as `502`. Give this key a template of its own when the distinction matters.
 {% endhint %}
 
 ### On `GATEWAY_CLIENT_CONNECTION_CLOSED`
 
-This key is the one most often misread. It doesn't mean that the API consumer went away, and it doesn't mean that the Gateway timed out. It means the connection closed while the response was still incomplete in HTTP terms.
+This key is misread more often than any other. It doesn't mean that the API consumer went away, and it doesn't mean that the Gateway timed out. It means the connection closed while the response was still incomplete in HTTP terms.
 
 The common case on streaming APIs: the backend announces `Transfer-Encoding: chunked`, sends data, then closes without the terminating zero-length chunk. Any HTTP client sees the same thing. `curl` reports `transfer closed with outstanding read data remaining`.
 
@@ -54,7 +54,7 @@ The Gateway raises these keys when the **caller** goes away. It sets status `499
 
 The first three come from the HTTP layer of the Gateway, which classifies them from the underlying exception. The last two are a coarser fallback, used when nothing more precise was recorded.
 
-These keys never overlap with the backend keys above. An abort by the API consumer is always reported under a `CLIENT_ABORTED_` key, never as `GATEWAY_CLIENT_CONNECTION_CLOSED`.
+These keys never overlap with the backend connection keys. An abort by the API consumer is always reported under a `CLIENT_ABORTED_` key, never as `GATEWAY_CLIENT_CONNECTION_CLOSED`.
 
 ## Request handling and routing
 

--- a/docs/apim/4.12/analyze-and-monitor-apis/gateway-error-key-reference.md
+++ b/docs/apim/4.12/analyze-and-monitor-apis/gateway-error-key-reference.md
@@ -1,0 +1,88 @@
+---
+description: >-
+  Every error key the Gateway reports, with the status it produces, the message
+  it attaches, and what it actually means.
+---
+
+# Gateway error key reference
+
+## How to read this reference
+
+The Gateway records an error key on every request it fails. The key appears in the Error Key field of the log details, and in the Gateway analytics. This page lists the keys the Gateway itself produces. Policies and plugins add their own, as described in [Keys reported by policies](gateway-error-key-reference.md#keys-reported-by-policies).
+
+Two properties of these keys matter when you read them.
+
+**The status is a default.** A [response template](../create-and-configure-apis/configure-v4-apis/response-templates.md) configured for a key, or for its parent key, overrides it. A `502` below can reach the API consumer as a `500` when the API falls back to a `DEFAULT` template.
+
+**Fine-grained keys carry a parent key.** When no response template targets the specific key, the Gateway falls back to the template configured for its parent. A fine-grained key without its own template still produces a sensible status.
+
+## Backend connection failures
+
+The Gateway raises these keys while it acts as an HTTP client towards the backend.
+
+<table><thead><tr><th width="80">Status</th><th width="330">Error key</th><th>What it means</th></tr></thead><tbody><tr><td>502</td><td><code>GATEWAY_CLIENT_CONNECTION_ERROR</code></td><td>Umbrella key. Any backend connection failure that matches no more specific case below.</td></tr><tr><td>502</td><td><code>GATEWAY_CLIENT_CONNECTION_REFUSED</code></td><td>The backend refused the TCP connection. Nothing listens on that port.</td></tr><tr><td>502</td><td><code>GATEWAY_CLIENT_DNS_RESOLUTION_ERROR</code></td><td>The backend hostname didn't resolve.</td></tr><tr><td>502</td><td><code>GATEWAY_CLIENT_UNREACHABLE</code></td><td>No network route to the backend host exists.</td></tr><tr><td>502</td><td><code>GATEWAY_CLIENT_TLS_HANDSHAKE_ERROR</code></td><td>The TLS handshake with the backend failed: certificate, protocol, or cipher mismatch.</td></tr><tr><td>502</td><td><code>GATEWAY_CLIENT_CONNECTION_RESET</code></td><td>The backend reset the connection with a TCP RST, or sent an HTTP/2 RST_STREAM.</td></tr><tr><td>502</td><td><code>GATEWAY_CLIENT_CONNECTION_CLOSED</code></td><td>The connection closed while a response was still expected. See the note below.</td></tr><tr><td><strong>503</strong></td><td><code>GATEWAY_CLIENT_CONNECTION_POOL_EXHAUSTED</code></td><td>The connection pool and its wait queue are both full. The Gateway sheds load on purpose, and the request never reached the backend. Retryable.</td></tr><tr><td>504</td><td><code>GATEWAY_CLIENT_CONNECT_TIMEOUT</code></td><td>No connection was obtained in time: pool saturation, slow DNS, or slow TCP connect. The request never reached the backend.</td></tr><tr><td>504</td><td><code>GATEWAY_CLIENT_READ_TIMEOUT</code></td><td>A connection was obtained and the request was sent, but the backend stayed silent for longer than <code>readTimeout</code>.</td></tr><tr><td>504</td><td><code>REQUEST_TIMEOUT</code></td><td>Umbrella key for the two timeouts above. Also the key of the Gateway-wide request timeout.</td></tr></tbody></table>
+
+The two timeout keys carry `REQUEST_TIMEOUT` as their parent. Every other key in this table carries `GATEWAY_CLIENT_CONNECTION_ERROR`.
+
+{% hint style="warning" %}
+`GATEWAY_CLIENT_CONNECTION_POOL_EXHAUSTED` is the one key whose parent produces a different status. Without a template of its own, it falls back to `GATEWAY_CLIENT_CONNECTION_ERROR`, and reaches the consumer as a `502` rather than a `503`. Configure a template for this key when that distinction matters.
+{% endhint %}
+
+### On `GATEWAY_CLIENT_CONNECTION_CLOSED`
+
+This key is the one most often misread. It doesn't mean that the API consumer went away, and it doesn't mean that the Gateway timed out. It means the connection closed while the response was still incomplete in HTTP terms.
+
+The common case on streaming APIs: the backend announces `Transfer-Encoding: chunked`, sends data, then closes without the terminating zero-length chunk. Any HTTP client sees the same thing. `curl` reports `transfer closed with outstanding read data remaining`.
+
+A backend that closes *cleanly*, on a response with no announced length, produces **no error key at all**. Closing is a legitimate way to delimit the body in that case.
+
+{% hint style="warning" %}
+**Check your timeout settings before you blame the backend.**
+
+This key is also what you get when the Gateway closes the connection itself, on its own `idleTimeout`. The two are indistinguishable in the reporting: same key, same message, same status.
+
+The duration tells them apart. An `idleTimeout` produces the same duration every time, within a few milliseconds of the configured value. A genuine backend problem produces scattered durations.
+
+For the configuration that causes this, see [Timeout management](../prepare-a-production-environment/timeout-management.md#distinguish-a-backend-closure-from-an-idle-timeout).
+{% endhint %}
+
+## The API consumer aborted the request
+
+The Gateway raises these keys when the **caller** goes away. It sets status `499`, but only when no status has been sent yet. On a streamed response the status is already committed, usually `200`, so only the error key is recorded and the status stays as it was.
+
+<table><thead><tr><th width="80">Status</th><th width="330">Error key</th><th>Message</th></tr></thead><tbody><tr><td>499</td><td><code>CLIENT_ABORTED_CHANNEL_CLOSED</code></td><td>The client closed the connection</td></tr><tr><td>499</td><td><code>CLIENT_ABORTED_TCP_RESET</code></td><td>The client reset the connection</td></tr><tr><td>499</td><td><code>CLIENT_ABORTED_BROKEN_PIPE</code></td><td>The client closed the connection while the response was being written</td></tr><tr><td>499</td><td><code>CLIENT_ABORTED_DURING_REQUEST_ERROR</code></td><td>The request was aborted by the client before it was fully received</td></tr><tr><td>499</td><td><code>CLIENT_ABORTED_DURING_RESPONSE_ERROR</code></td><td>The response cannot be sent to the client because the client has aborted</td></tr></tbody></table>
+
+The first three come from the HTTP layer of the Gateway, which classifies them from the underlying exception. The last two are a coarser fallback, used when nothing more precise was recorded.
+
+These keys never overlap with the backend keys above. An abort by the API consumer is always reported under a `CLIENT_ABORTED_` key, never as `GATEWAY_CLIENT_CONNECTION_CLOSED`.
+
+## Request handling and routing
+
+<table><thead><tr><th width="80">Status</th><th width="330">Error key</th><th>What it means</th></tr></thead><tbody><tr><td>400</td><td><code>REQUEST_NULL_BYTE_REJECTED</code></td><td>The request contained a null byte, and was rejected before processing.</td></tr><tr><td>400</td><td><code>INVALID_HTTP_METHOD</code></td><td>The HTTP method isn't usable for this endpoint.</td></tr><tr><td>400</td><td><code>CORS_PREFLIGHT_FAILED</code></td><td>The CORS preflight request didn't satisfy the configured policy.</td></tr><tr><td>401</td><td><code>GATEWAY_PLAN_UNRESOLVABLE</code></td><td>No plan could be resolved for the request: missing or invalid credentials, or no matching subscription.</td></tr><tr><td>404</td><td><code>FLOW_EXECUTION_FLOW_MATCHED_FAILURE</code></td><td>No flow matched the request while flow matching was mandatory.</td></tr><tr><td>500</td><td><code>GATEWAY_POLICY_INTERNAL_ERROR</code></td><td>A policy failed unexpectedly while streaming.</td></tr><tr><td>503</td><td><code>NO_ENDPOINT_FOUND</code></td><td>The endpoint targeted by the request doesn't exist or isn't available. Often a dynamic routing target that matches no declared endpoint.</td></tr></tbody></table>
+
+## Responses with no error key
+
+Two cases produce a completed request that carries no key at all. Both are worth knowing when you build dashboards:
+
+* A normal success.
+* A backend that closed cleanly, on a response with no announced length. The response may be shorter than the API consumer expected, but nothing in HTTP terms was violated.
+
+## Keys reported by policies
+
+Policies and plugins report their own keys, in the same field. Their status and their message are defined by the policy, not by the Gateway. Custom keys set through an `interrupt` policy behave the same way.
+
+Common examples in a typical setup: `JWT_INVALID_TOKEN`, `JWT_JWKS_RESOLUTION_ERROR`, `OAS_VALIDATION_ERROR`, `TRANSFORM_HEADERS_FAILURE`, `REQUEST_VALIDATION_INVALID`, `RATE_LIMIT_TOO_MANY_REQUESTS`, and `QUOTA_TOO_MANY_REQUESTS`.
+
+## Use error keys in response templates
+
+Response templates match on the error key, which lets an API return its own payload for a given failure. Target the fine-grained key to handle one case, or the umbrella key to cover a family.
+
+{% hint style="info" %}
+On connection failures, the failure carries a key and a cause, but no message. In a response template, use `{#error.cause}` rather than `{#error.message}`, which is empty for these errors.
+{% endhint %}
+
+## Related pages
+
+* [Timeout management](../prepare-a-production-environment/timeout-management.md) — which timer produces which timeout key, and how to configure them.
+* [Execution transparency analytics](execution-transparency-analytics.md) — where these keys surface in the logs and the analytics.
+* [Response templates](../create-and-configure-apis/configure-v4-apis/response-templates.md) — how to map a key to a custom response.

--- a/docs/apim/4.12/prepare-a-production-environment/timeout-management.md
+++ b/docs/apim/4.12/prepare-a-production-environment/timeout-management.md
@@ -1,0 +1,273 @@
+---
+description: >-
+  How Gateway and endpoint timeouts interact, how each protocol behaves, and how
+  to configure them so that failures are reported accurately.
+---
+
+# Timeout management
+
+## Overview
+
+Timeouts apply at two independent scopes, and both run at the same time on every request:
+
+* **Gateway scope.** `http.requestTimeout` bounds the whole request, from the moment the Gateway receives it to the moment the response completes. It applies to every API deployed on that Gateway.
+* **Endpoint scope.** The HTTP client of each endpoint or endpoint group carries its own timeouts towards the backend: `connectTimeout`, `readTimeout`, `idleTimeout`, and `keepAliveTimeout`.
+
+The two scopes don't override each other. Whichever expires first interrupts the request. An endpoint `readTimeout` longer than `http.requestTimeout` never takes effect, and the reverse is also true.
+
+Timeouts can't be configured per plan. To apply different timeout behavior to different consumers, expose the backend through separate APIs with different endpoint configurations.
+
+<table><thead><tr><th width="190">Setting</th><th width="120">Scope</th><th width="110">Default (ms)</th><th>What it bounds</th></tr></thead><tbody><tr><td><code>http.requestTimeout</code></td><td>Gateway</td><td>30000</td><td>The complete request, until the response ends.</td></tr><tr><td><code>http.requestTimeoutGraceDelay</code></td><td>Gateway</td><td>30</td><td>The minimum execution window granted to the response phase.</td></tr><tr><td><code>connectTimeout</code></td><td>Endpoint</td><td>5000</td><td>Establishing the TCP connection to the backend.</td></tr><tr><td><code>readTimeout</code></td><td>Endpoint</td><td>10000</td><td>Inactivity during a request, and connection acquisition from the pool.</td></tr><tr><td><code>idleTimeout</code></td><td>Endpoint</td><td>60000</td><td>Inactivity on the connection itself, whether or not a request is in flight.</td></tr><tr><td><code>keepAliveTimeout</code></td><td>Endpoint</td><td>30000</td><td>How long an unused connection stays in the pool. HTTP/1.x only.</td></tr></tbody></table>
+
+You configure every one of these settings in milliseconds, at both scopes.
+
+The following diagram places each timer on the life of a single request, using the default values. The request arrives at second 0, the connection is obtained at second 5, and the response completes at second 12.
+
+```mermaid
+gantt
+    title Timer windows over one request, with the default values
+    dateFormat HH:mm:ss
+    axisFormat %M:%S
+    section Gateway
+    http.requestTimeout 30s              :done, req, 00:00:00, 30s
+    section Connection
+    connectTimeout 5s                    :crit, conn, 00:00:00, 5s
+    idleTimeout 60s                      :active, idle, 00:00:05, 60s
+    keepAliveTimeout 30s, back in pool   :active, ka, 00:00:12, 30s
+    section Request in flight
+    readTimeout 10s, reset by data       :crit, read, 00:00:05, 10s
+    Response complete                    :milestone, resp, 00:00:12, 0s
+```
+
+Two properties of this layout carry the rules that follow. Only `readTimeout` and `idleTimeout` overlap while the request is in flight, so they're the only pair that competes. `keepAliveTimeout` starts when the connection returns to the pool, which is why it never interacts with `readTimeout`.
+
+## How each setting behaves
+
+### Gateway request timeout
+
+`requestTimeout` caps the total time the Gateway spends on a request. The budget covers the backend response and the execution of response policies. When the setting is absent, the Gateway applies `30000` ms and logs a warning at startup. A value of `0` or less disables it.
+
+When it fires, the consumer receives a `504` with the error key `REQUEST_TIMEOUT`. Responses that consistently fail at exactly 30 seconds usually indicate that the default is in effect.
+
+`requestTimeoutGraceDelay` guarantees a minimum window for the response phase. When a request has already consumed most of its budget, the Gateway still grants at least this delay to the platform and response flows. The effective value is `Max(requestTimeoutGraceDelay, requestTimeout - apiElapsedTime)`.
+
+{% hint style="info" %}
+`requestTimeout` stops protecting the request once the response status and headers are committed. A streamed response is therefore bounded by the endpoint timeouts alone. See [Protocol behavior](timeout-management.md#protocol-behavior).
+{% endhint %}
+
+For the configuration syntax, see [Configure your HTTP server](configure-your-http-server.md#request-timeout-behavior).
+
+### Connect timeout
+
+`connectTimeout` bounds the establishment of the TCP connection to the backend, including the TLS handshake. When it fires, the consumer receives a `504` with the error key `GATEWAY_CLIENT_CONNECT_TIMEOUT`, and the message names the target host.
+
+{% hint style="warning" %}
+`connectTimeout` doesn't bound the acquisition of a connection **from the pool**. That wait is governed by `readTimeout`. A request queued behind a saturated pool therefore waits up to `readTimeout`, not up to `connectTimeout`. Both cases report `GATEWAY_CLIENT_CONNECT_TIMEOUT`, and the duration in the message tells them apart.
+{% endhint %}
+
+### Read timeout
+
+`readTimeout` is an **inactivity timer**, not a total budget for the request. It expires only when the backend sends nothing for the configured duration. Every chunk received resets it, so a response that keeps producing data isn't interrupted, however long it runs.
+
+The same value also governs the acquisition of a connection from the pool, as described above.
+
+When it fires, the consumer receives a `504` with the error key `GATEWAY_CLIENT_READ_TIMEOUT`, and the message names the timeout, the method, and the target.
+
+### Idle timeout
+
+`idleTimeout` is a **connection-level** timer. It closes the connection when no data is received or sent for the configured duration. It has no notion of a request in flight, so it applies whether the connection is idle in the pool or actively carrying a request.
+
+When it closes a connection that carries a request, the failure surfaces as a `502` with the error key `GATEWAY_CLIENT_CONNECTION_CLOSED`. A genuine backend disconnection produces the same key and the same message. See [Diagnose a timeout](timeout-management.md#diagnose-a-timeout).
+
+{% hint style="warning" %}
+`idleTimeout` is configured in milliseconds but applied in whole seconds. The remainder is discarded: `12200` ms becomes 12 seconds. Any value below `1000` ms becomes `0`, which **disables the timeout** instead of tightening it.
+{% endhint %}
+
+### Keep-alive timeout
+
+`keepAliveTimeout` determines how long a connection stays **unused in the pool** before it's evicted and closed. It never applies to a request in flight, so it doesn't interact with `readTimeout`.
+
+Two properties are worth knowing:
+
+* It applies to **HTTP/1.x only**. HTTP/2 connections are governed by `idleTimeout` alone.
+* When the backend returns a `Keep-Alive: timeout=N` header, the Gateway adopts that value for the connection, replacing the configured one. Backends that advertise their keep-alive timeout therefore align the Gateway automatically.
+
+Backends that close idle connections without advertising the header are the case to configure for. Set `keepAliveTimeout` below the backend's own keep-alive window, so that the pool retires connections before the backend drops them. A connection retired by the backend while the Gateway still considers it usable produces a `GATEWAY_CLIENT_CONNECTION_CLOSED` on the next request that borrows it.
+
+Like `idleTimeout`, this value is applied in whole seconds.
+
+## Configuration rules
+
+### Keep `readTimeout` shorter than `idleTimeout`
+
+This is the one inequality that governs correctness. Both timers run during a request in flight, and the shorter one always wins.
+
+* When `readTimeout` is the shorter, an unresponsive backend produces a `504` with `GATEWAY_CLIENT_READ_TIMEOUT` and a message naming the timeout, the method, and the target.
+* When `idleTimeout` is the shorter, it closes the connection first. `readTimeout` can never fire, and the failure is reported as `502 GATEWAY_CLIENT_CONNECTION_CLOSED` — a backend disconnection that didn't happen.
+
+The default values satisfy this rule. Inverting them changes the diagnosis rather than the behavior. The request fails at the same point either way, but the reported cause then points at the backend.
+
+### Keep `http.requestTimeout` above `readTimeout`
+
+The endpoint timeout produces the more precise diagnosis, so let it fire first. Set `http.requestTimeout` above `readTimeout` and below whatever the API consumers themselves tolerate.
+
+### Size `readTimeout` from the backend, not from the stream
+
+Because `readTimeout` measures inactivity, it doesn't need to accommodate the total duration of a long response. Set it from the p99 response time of the backend, plus margin. For streaming APIs, the constraint is on the heartbeat interval rather than the stream duration — see [Protocol behavior](timeout-management.md#protocol-behavior).
+
+### Bound the pool wait
+
+`maxConcurrentConnections` caps the pool. Requests that find it full wait for a slot, and that wait is bounded by `readTimeout`. A long `readTimeout` therefore has a second effect: each failing request holds a connection for that duration, which reduces the throughput the pool can sustain.
+
+## Protocol behavior
+
+The timer that actually governs a request depends on the protocol, and on whether the exchange is a single request-response or a long-lived stream.
+
+<table><thead><tr><th width="170">Protocol</th><th width="185">Governing timer</th><th>Notes</th></tr></thead><tbody><tr><td>HTTP/1.1</td><td><code>readTimeout</code></td><td>Reset by each chunk received. <code>idleTimeout</code> acts as the outer bound on the connection.</td></tr><tr><td>HTTP/2</td><td><code>readTimeout</code> per stream</td><td><code>idleTimeout</code> applies to the shared connection. <code>keepAliveTimeout</code> doesn't apply.</td></tr><tr><td>SSE and chunked streaming</td><td><code>readTimeout</code></td><td>Reset by each event or chunk. The heartbeat interval must stay below it.</td></tr><tr><td>WebSocket</td><td><code>idleTimeout</code></td><td><code>readTimeout</code> covers the handshake only. Reset by any traffic in either direction.</td></tr><tr><td>gRPC</td><td><code>readTimeout</code></td><td>Runs over HTTP/2. A timeout reaches the client as <code>UNAVAILABLE</code>.</td></tr></tbody></table>
+
+### HTTP/1.1
+
+One connection carries one request at a time. `readTimeout` bounds inactivity within the request, and `idleTimeout` bounds the connection itself. Once the response ends and the connection returns to the pool, `keepAliveTimeout` governs how long it's retained.
+
+### HTTP/2
+
+An HTTP/2 connection is multiplexed: several streams share it. This changes two things.
+
+* `readTimeout` still applies per request, so each stream carries its own inactivity timer.
+* `idleTimeout` applies to the **connection**, which means it's reset by traffic on any of its streams. A connection carrying one active stream stays alive for all the others. Conversely, when it does expire, every stream on that connection is affected.
+
+`keepAliveTimeout` has no effect on HTTP/2 connections.
+
+Two further settings size the connection pool. `http2MultiplexingLimit` caps the concurrent streams per connection, and defaults to `25` streams. `maxConcurrentConnections` caps the connections themselves, and the Gateway applies `100` connections when the setting is absent. The product of the two gives the maximum number of concurrent requests towards the backend, subject to the limit the server advertises in its own settings.
+
+{% hint style="info" %}
+The console can propose a different `maxConcurrentConnections` depending on the endpoint plugin, and the value it proposes is then stored in the API. Check the value your API carries rather than assuming the Gateway default.
+{% endhint %}
+
+### Server-sent events and chunked streaming
+
+A stream isn't bounded by `readTimeout` — only the gaps between its events are. A stream that keeps emitting data runs for as long as the backend keeps producing it, regardless of how short `readTimeout` is.
+
+The requirement is therefore:
+
+> heartbeat interval < `readTimeout`
+
+A short `readTimeout` doesn't break long-lived streams. It breaks streams that go quiet for longer than the timeout.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant C as API consumer
+    participant G as Gateway
+    participant B as Backend
+
+    C->>G: GET /events
+    G->>B: GET /events
+    B-->>G: 200, headers sent, stream opens
+    Note over G: readTimeout armed for 30s
+
+    alt Heartbeat shorter than readTimeout
+        loop Every 20s
+            B-->>G: event
+            Note over G: timer reset to 30s
+        end
+        B-->>G: stream ends at 100s
+        Note over C,G: complete response, never cut
+    else Backend silent for more than 30s
+        Note over G: readTimeout fires
+        G--xC: body ends early, under the 200 already committed
+    end
+```
+
+Before you lower `readTimeout`, confirm the heartbeat interval of each streaming backend. If one exceeds the value you plan to set, either shorten the heartbeat or give that API its own shared configuration with a longer `readTimeout` — still below its `idleTimeout`.
+
+{% hint style="warning" %}
+When a stream is cut after the response headers were committed, the status has already been sent. The consumer receives a truncated body under the status that was announced, usually `200`, and the failure appears in the metrics rather than in the status. Consider streamed responses as successful only when the payload is complete.
+{% endhint %}
+
+### WebSocket
+
+`readTimeout` covers the handshake only. Once the session is established, `readTimeout` no longer applies, and the connection is governed by `idleTimeout` alone.
+
+`idleTimeout` is reset by traffic in either direction, so an application-level ping keeps the session open. Set `idleTimeout` above the ping interval of the client or the backend, whichever is longer. A session that goes quiet for longer than `idleTimeout` is closed with a normal close frame.
+
+This is the one protocol where `idleTimeout` is the setting to tune rather than a safety net.
+
+### gRPC
+
+gRPC runs over HTTP/2, which the Gateway selects for these endpoints regardless of the configured version. The multiplexing behavior described in [HTTP/2](timeout-management.md#http-2) applies.
+
+`readTimeout` applies as it does to any HTTP request. When it fires, the `504` is translated by the gRPC layer, and the client observes the `UNAVAILABLE` status code rather than an HTTP status.
+
+## Start from the defaults
+
+The default values already satisfy the rules above. `readTimeout` at `10000` ms sits well below `idleTimeout` at `60000` ms, and the Gateway `requestTimeout` of `30000` ms sits above `readTimeout`. A backend that answers within ten seconds needs no timeout configuration at all.
+
+Change them when the backend is slower than the default `readTimeout`, in this order:
+
+1. Raise `readTimeout` to the p99 response time of the backend, plus margin.
+2. Raise `idleTimeout` if the new `readTimeout` comes close to it. Keep a clear gap between the two.
+3. Raise `http.requestTimeout` above the new `readTimeout`. The default of `30000` ms no longer clears a `readTimeout` set to `30000` ms.
+
+The following example configures an endpoint whose backend answers in about 25 seconds at the p99.
+
+{% code title="Endpoint shared configuration, for a backend slower than the default" %}
+```json
+{
+  "http": {
+    "connectTimeout": 5000,
+    "readTimeout": 30000,
+    "keepAliveTimeout": 30000,
+    "idleTimeout": 90000,
+    "maxConcurrentConnections": 100,
+    "keepAlive": true,
+    "pipelining": false,
+    "followRedirects": false,
+    "useCompression": true,
+    "version": "HTTP_1_1"
+  }
+}
+```
+{% endcode %}
+
+{% code title="gravitee.yml" %}
+```yaml
+http:
+  requestTimeout: 60000
+  requestTimeoutGraceDelay: 30
+```
+{% endcode %}
+
+`keepAliveTimeout` keeps its default here. It governs connections that sit unused in the pool, so a slow backend gives no reason to change it. Adjust it against the keep-alive window of the backend, as described in [Keep-alive timeout](timeout-management.md#keep-alive-timeout).
+
+The ordering carries the behavior, not the values. `readTimeout` stays the shortest, so it governs and produces the precise diagnosis. `idleTimeout` stays a safety net rather than the effective limit. `requestTimeout` stays above `readTimeout`, so the endpoint timeout fires first.
+
+## Diagnose a timeout
+
+The error key recorded in the API logs and analytics identifies which timer fired.
+
+<table><thead><tr><th width="330">Error key</th><th width="80">Status</th><th>What fired</th></tr></thead><tbody><tr><td><code>REQUEST_TIMEOUT</code></td><td>504</td><td>The Gateway-level <code>requestTimeout</code>.</td></tr><tr><td><code>GATEWAY_CLIENT_CONNECT_TIMEOUT</code></td><td>504</td><td>No connection was obtained in time: TCP establishment, or a wait on a saturated pool.</td></tr><tr><td><code>GATEWAY_CLIENT_READ_TIMEOUT</code></td><td>504</td><td>The connection was established, and the backend then went silent for longer than <code>readTimeout</code>.</td></tr><tr><td><code>GATEWAY_CLIENT_CONNECTION_CLOSED</code></td><td>502</td><td>The connection closed while a response was still expected. See the note below.</td></tr></tbody></table>
+
+For the complete list of connectivity error keys, see [Execution transparency analytics](../analyze-and-monitor-apis/execution-transparency-analytics.md#connectivity-and-timeout-error-keys).
+
+### Distinguish a backend closure from an idle timeout
+
+`GATEWAY_CLIENT_CONNECTION_CLOSED` covers two situations that report identically — the same key, the same `Connection was closed` message, and the same `502`:
+
+* The backend closed the connection while the response was incomplete.
+* The Gateway closed it on its own `idleTimeout`.
+
+The duration tells them apart. An `idleTimeout` produces the **same duration every time**, within a few milliseconds of the configured value. A genuine backend problem produces scattered durations. If your failures cluster tightly around your `idleTimeout`, and `readTimeout` is longer than it, the Gateway is the one closing the connection.
+
+Setting `readTimeout` below `idleTimeout` resolves the ambiguity: the same situation then surfaces as `GATEWAY_CLIENT_READ_TIMEOUT` with a `504` and a message naming the timeout, the method, and the target.
+
+{% hint style="info" %}
+On connection failures, the `ExecutionFailure` carries a key and a cause, but no message. In a response template, use `{#error.cause}` rather than `{#error.message}`, which is empty for these errors.
+{% endhint %}
+
+## Related pages
+
+* [Configure your HTTP server](configure-your-http-server.md) — the Gateway-side settings and their syntax.
+* [Endpoints](../create-and-configure-apis/configure-v4-apis/endpoints/README.md) — where the endpoint timeouts are configured in the console.
+* [Execution engine](../create-and-configure-apis/gravitee-api-definitions/execution-engine.md#timeout-management) — how the reactive engine applies the Gateway timeout across the request and response phases.
+* [Execution transparency analytics](../analyze-and-monitor-apis/execution-transparency-analytics.md#connectivity-and-timeout-error-keys) — the complete error key reference.

--- a/docs/apim/4.13/SUMMARY.md
+++ b/docs/apim/4.13/SUMMARY.md
@@ -539,6 +539,7 @@
     * [JDBC](prepare-a-production-environment/repositories/jdbc.md)
     * [Redis](prepare-a-production-environment/repositories/redis.md)
   * [Configure your HTTP Server](prepare-a-production-environment/configure-your-http-server.md)
+  * [Timeout Management](prepare-a-production-environment/timeout-management.md)
   * [Sensitive Data Management](prepare-a-production-environment/sensitive-data-management/README.md)
     * [Configure Secrets](prepare-a-production-environment/sensitive-data-management/configure-secrets/README.md)
       * [Quick Start](prepare-a-production-environment/sensitive-data-management/configure-secrets/quick-start.md)

--- a/docs/apim/4.13/SUMMARY.md
+++ b/docs/apim/4.13/SUMMARY.md
@@ -433,6 +433,7 @@
     * [Configure Gateway for OpenTelemetry Logs](analyze-and-monitor-apis/configure-gateway-for-opentelemetry-logs.md)
     * [Enable and Use OpenTelemetry Logs for APIs](analyze-and-monitor-apis/enable-and-use-opentelemetry-logs-for-apis.md)
   * [Execution Transparency Analytics](analyze-and-monitor-apis/execution-transparency-analytics.md)
+  * [Gateway Error Key Reference](analyze-and-monitor-apis/gateway-error-key-reference.md)
 * [Alert Engine](alert-engine/README.md)
   * [Architecture](alert-engine/overview/architecture.md)
   * [Integrations](alert-engine/overview/integrations.md)

--- a/docs/apim/4.13/analyze-and-monitor-apis/execution-transparency-analytics.md
+++ b/docs/apim/4.13/analyze-and-monitor-apis/execution-transparency-analytics.md
@@ -285,6 +285,6 @@ The Gateway sets one of the following error keys when a request fails on a conne
 
 Keys that start with `GATEWAY_CLIENT_` indicate a backend-side fault. The fine-grained timeout keys carry `REQUEST_TIMEOUT` as a parent key, and the fine-grained connection keys carry `GATEWAY_CLIENT_CONNECTION_ERROR` as a parent key. Keys that start with `CLIENT_ABORTED_` indicate that the API consumer went away, and don't point to a backend problem.
 
-`GATEWAY_CLIENT_CONNECTION_POOL_EXHAUSTED` is the exception to that fallback. Its parent produces a `502`, so without a response template of its own it reaches the API consumer under the wrong status.
+`GATEWAY_CLIENT_CONNECTION_POOL_EXHAUSTED` is the exception to that fallback. Its status differs from its parent's, `503` against `502`, and a response template always dictates the status. A template configured on `GATEWAY_CLIENT_CONNECTION_ERROR`, or a `DEFAULT` one, therefore turns pool exhaustion into a `502`.
 
 For the keys the Gateway raises outside connectivity, such as routing, plan resolution, and request handling, see the [Gateway error key reference](gateway-error-key-reference.md).

--- a/docs/apim/4.13/analyze-and-monitor-apis/execution-transparency-analytics.md
+++ b/docs/apim/4.13/analyze-and-monitor-apis/execution-transparency-analytics.md
@@ -271,6 +271,7 @@ The Gateway sets one of the following error keys when a request fails on a conne
 | `REQUEST_TIMEOUT` | 504 | The Gateway-level `requestTimeout` elapsed before the response completed. |
 | `GATEWAY_CLIENT_CONNECT_TIMEOUT` | 504 | The connection to the backend didn't complete within the endpoint's connect timeout. |
 | `GATEWAY_CLIENT_READ_TIMEOUT` | 504 | The backend connection was established, but no response arrived within the endpoint's read timeout. |
+| `GATEWAY_CLIENT_CONNECTION_POOL_EXHAUSTED` | 503 | The connection pool and its wait queue are both full. The Gateway shed the load deliberately, and the request never reached the backend. |
 | `GATEWAY_CLIENT_CONNECTION_ERROR` | 502 | A backend connection failed for a reason not covered by a more specific key. |
 | `GATEWAY_CLIENT_CONNECTION_REFUSED` | 502 | The backend refused the connection. |
 | `GATEWAY_CLIENT_DNS_RESOLUTION_ERROR` | 502 | The backend hostname didn't resolve. |
@@ -283,3 +284,7 @@ The Gateway sets one of the following error keys when a request fails on a conne
 | `CLIENT_ABORTED_CHANNEL_CLOSED` | 499 | The API consumer closed the connection. |
 
 Keys that start with `GATEWAY_CLIENT_` indicate a backend-side fault. The fine-grained timeout keys carry `REQUEST_TIMEOUT` as a parent key, and the fine-grained connection keys carry `GATEWAY_CLIENT_CONNECTION_ERROR` as a parent key. Keys that start with `CLIENT_ABORTED_` indicate that the API consumer went away, and don't point to a backend problem.
+
+`GATEWAY_CLIENT_CONNECTION_POOL_EXHAUSTED` is the exception to that fallback. Its parent produces a `502`, so without a response template of its own it reaches the API consumer under the wrong status.
+
+For the keys the Gateway raises outside connectivity, such as routing, plan resolution, and request handling, see the [Gateway error key reference](gateway-error-key-reference.md).

--- a/docs/apim/4.13/analyze-and-monitor-apis/gateway-error-key-reference.md
+++ b/docs/apim/4.13/analyze-and-monitor-apis/gateway-error-key-reference.md
@@ -12,7 +12,7 @@ The Gateway records an error key on every request it fails. The key appears in t
 
 Two properties of these keys matter when you read them.
 
-**The status is a default.** A [response template](../create-and-configure-apis/configure-v4-apis/response-templates.md) configured for a key, or for its parent key, overrides it. A `502` below can reach the API consumer as a `500` when the API falls back to a `DEFAULT` template.
+**The status is a default.** A [response template](../create-and-configure-apis/configure-v4-apis/response-templates.md) configured for a key, or for its parent key, overrides it. A key listed here as a `502` can reach the API consumer as a `500` when the API falls back to a `DEFAULT` template.
 
 **Fine-grained keys carry a parent key.** When no response template targets the specific key, the Gateway falls back to the template configured for its parent. A fine-grained key without its own template still produces a sensible status.
 
@@ -20,17 +20,17 @@ Two properties of these keys matter when you read them.
 
 The Gateway raises these keys while it acts as an HTTP client towards the backend.
 
-<table><thead><tr><th width="80">Status</th><th width="330">Error key</th><th>What it means</th></tr></thead><tbody><tr><td>502</td><td><code>GATEWAY_CLIENT_CONNECTION_ERROR</code></td><td>Umbrella key. Any backend connection failure that matches no more specific case below.</td></tr><tr><td>502</td><td><code>GATEWAY_CLIENT_CONNECTION_REFUSED</code></td><td>The backend refused the TCP connection. Nothing listens on that port.</td></tr><tr><td>502</td><td><code>GATEWAY_CLIENT_DNS_RESOLUTION_ERROR</code></td><td>The backend hostname didn't resolve.</td></tr><tr><td>502</td><td><code>GATEWAY_CLIENT_UNREACHABLE</code></td><td>No network route to the backend host exists.</td></tr><tr><td>502</td><td><code>GATEWAY_CLIENT_TLS_HANDSHAKE_ERROR</code></td><td>The TLS handshake with the backend failed: certificate, protocol, or cipher mismatch.</td></tr><tr><td>502</td><td><code>GATEWAY_CLIENT_CONNECTION_RESET</code></td><td>The backend reset the connection with a TCP RST, or sent an HTTP/2 RST_STREAM.</td></tr><tr><td>502</td><td><code>GATEWAY_CLIENT_CONNECTION_CLOSED</code></td><td>The connection closed while a response was still expected. See the note below.</td></tr><tr><td><strong>503</strong></td><td><code>GATEWAY_CLIENT_CONNECTION_POOL_EXHAUSTED</code></td><td>The connection pool and its wait queue are both full. The Gateway sheds load on purpose, and the request never reached the backend. Retryable.</td></tr><tr><td>504</td><td><code>GATEWAY_CLIENT_CONNECT_TIMEOUT</code></td><td>No connection was obtained in time: pool saturation, slow DNS, or slow TCP connect. The request never reached the backend.</td></tr><tr><td>504</td><td><code>GATEWAY_CLIENT_READ_TIMEOUT</code></td><td>A connection was obtained and the request was sent, but the backend stayed silent for longer than <code>readTimeout</code>.</td></tr><tr><td>504</td><td><code>REQUEST_TIMEOUT</code></td><td>Umbrella key for the two timeouts above. Also the key of the Gateway-wide request timeout.</td></tr></tbody></table>
+<table><thead><tr><th width="80">Status</th><th width="330">Error key</th><th>What it means</th></tr></thead><tbody><tr><td>502</td><td><code>GATEWAY_CLIENT_CONNECTION_ERROR</code></td><td>Umbrella key. A backend connection failed for a reason that no more specific key covers.</td></tr><tr><td>502</td><td><code>GATEWAY_CLIENT_CONNECTION_REFUSED</code></td><td>The backend refused the TCP connection. Nothing listens on that port.</td></tr><tr><td>502</td><td><code>GATEWAY_CLIENT_DNS_RESOLUTION_ERROR</code></td><td>The backend hostname didn't resolve.</td></tr><tr><td>502</td><td><code>GATEWAY_CLIENT_UNREACHABLE</code></td><td>No network route to the backend host exists.</td></tr><tr><td>502</td><td><code>GATEWAY_CLIENT_TLS_HANDSHAKE_ERROR</code></td><td>The TLS handshake with the backend failed: certificate, protocol, or cipher mismatch.</td></tr><tr><td>502</td><td><code>GATEWAY_CLIENT_CONNECTION_RESET</code></td><td>The backend reset the connection with a TCP RST, or sent an HTTP/2 RST_STREAM.</td></tr><tr><td>502</td><td><code>GATEWAY_CLIENT_CONNECTION_CLOSED</code></td><td>The connection closed while a response was still expected. See the note that follows this table.</td></tr><tr><td>503</td><td><code>GATEWAY_CLIENT_CONNECTION_POOL_EXHAUSTED</code></td><td>The connection pool and its wait queue are both full, so the Gateway sheds the load deliberately. The request never reached the backend, and it can be retried.</td></tr><tr><td>504</td><td><code>GATEWAY_CLIENT_CONNECT_TIMEOUT</code></td><td>No connection was obtained in time: pool saturation, slow DNS, or slow TCP connect. The request never reached the backend.</td></tr><tr><td>504</td><td><code>GATEWAY_CLIENT_READ_TIMEOUT</code></td><td>A connection was obtained and the request was sent, but the backend stayed silent for longer than <code>readTimeout</code>.</td></tr><tr><td>504</td><td><code>REQUEST_TIMEOUT</code></td><td>Umbrella key for the two timeout keys. Also the key that the Gateway-wide request timeout produces.</td></tr></tbody></table>
 
 The two timeout keys carry `REQUEST_TIMEOUT` as their parent. Every other key in this table carries `GATEWAY_CLIENT_CONNECTION_ERROR`.
 
 {% hint style="warning" %}
-`GATEWAY_CLIENT_CONNECTION_POOL_EXHAUSTED` is the one key whose parent produces a different status. Without a template of its own, it falls back to `GATEWAY_CLIENT_CONNECTION_ERROR`, and reaches the consumer as a `502` rather than a `503`. Configure a template for this key when that distinction matters.
+`GATEWAY_CLIENT_CONNECTION_POOL_EXHAUSTED` is the one key whose status differs from its parent's: `503` against `502`. With no response template in play, it returns `503` as expected. But a template configured on `GATEWAY_CLIENT_CONNECTION_ERROR` — or a `DEFAULT` one — applies to it as well, and a template always dictates the status: pool exhaustion then reaches the consumer as `502`. Give this key a template of its own when the distinction matters.
 {% endhint %}
 
 ### On `GATEWAY_CLIENT_CONNECTION_CLOSED`
 
-This key is the one most often misread. It doesn't mean that the API consumer went away, and it doesn't mean that the Gateway timed out. It means the connection closed while the response was still incomplete in HTTP terms.
+This key is misread more often than any other. It doesn't mean that the API consumer went away, and it doesn't mean that the Gateway timed out. It means the connection closed while the response was still incomplete in HTTP terms.
 
 The common case on streaming APIs: the backend announces `Transfer-Encoding: chunked`, sends data, then closes without the terminating zero-length chunk. Any HTTP client sees the same thing. `curl` reports `transfer closed with outstanding read data remaining`.
 
@@ -54,7 +54,7 @@ The Gateway raises these keys when the **caller** goes away. It sets status `499
 
 The first three come from the HTTP layer of the Gateway, which classifies them from the underlying exception. The last two are a coarser fallback, used when nothing more precise was recorded.
 
-These keys never overlap with the backend keys above. An abort by the API consumer is always reported under a `CLIENT_ABORTED_` key, never as `GATEWAY_CLIENT_CONNECTION_CLOSED`.
+These keys never overlap with the backend connection keys. An abort by the API consumer is always reported under a `CLIENT_ABORTED_` key, never as `GATEWAY_CLIENT_CONNECTION_CLOSED`.
 
 ## Request handling and routing
 

--- a/docs/apim/4.13/analyze-and-monitor-apis/gateway-error-key-reference.md
+++ b/docs/apim/4.13/analyze-and-monitor-apis/gateway-error-key-reference.md
@@ -1,0 +1,88 @@
+---
+description: >-
+  Every error key the Gateway reports, with the status it produces, the message
+  it attaches, and what it actually means.
+---
+
+# Gateway error key reference
+
+## How to read this reference
+
+The Gateway records an error key on every request it fails. The key appears in the Error Key field of the log details, and in the Gateway analytics. This page lists the keys the Gateway itself produces. Policies and plugins add their own, as described in [Keys reported by policies](gateway-error-key-reference.md#keys-reported-by-policies).
+
+Two properties of these keys matter when you read them.
+
+**The status is a default.** A [response template](../create-and-configure-apis/configure-v4-apis/response-templates.md) configured for a key, or for its parent key, overrides it. A `502` below can reach the API consumer as a `500` when the API falls back to a `DEFAULT` template.
+
+**Fine-grained keys carry a parent key.** When no response template targets the specific key, the Gateway falls back to the template configured for its parent. A fine-grained key without its own template still produces a sensible status.
+
+## Backend connection failures
+
+The Gateway raises these keys while it acts as an HTTP client towards the backend.
+
+<table><thead><tr><th width="80">Status</th><th width="330">Error key</th><th>What it means</th></tr></thead><tbody><tr><td>502</td><td><code>GATEWAY_CLIENT_CONNECTION_ERROR</code></td><td>Umbrella key. Any backend connection failure that matches no more specific case below.</td></tr><tr><td>502</td><td><code>GATEWAY_CLIENT_CONNECTION_REFUSED</code></td><td>The backend refused the TCP connection. Nothing listens on that port.</td></tr><tr><td>502</td><td><code>GATEWAY_CLIENT_DNS_RESOLUTION_ERROR</code></td><td>The backend hostname didn't resolve.</td></tr><tr><td>502</td><td><code>GATEWAY_CLIENT_UNREACHABLE</code></td><td>No network route to the backend host exists.</td></tr><tr><td>502</td><td><code>GATEWAY_CLIENT_TLS_HANDSHAKE_ERROR</code></td><td>The TLS handshake with the backend failed: certificate, protocol, or cipher mismatch.</td></tr><tr><td>502</td><td><code>GATEWAY_CLIENT_CONNECTION_RESET</code></td><td>The backend reset the connection with a TCP RST, or sent an HTTP/2 RST_STREAM.</td></tr><tr><td>502</td><td><code>GATEWAY_CLIENT_CONNECTION_CLOSED</code></td><td>The connection closed while a response was still expected. See the note below.</td></tr><tr><td><strong>503</strong></td><td><code>GATEWAY_CLIENT_CONNECTION_POOL_EXHAUSTED</code></td><td>The connection pool and its wait queue are both full. The Gateway sheds load on purpose, and the request never reached the backend. Retryable.</td></tr><tr><td>504</td><td><code>GATEWAY_CLIENT_CONNECT_TIMEOUT</code></td><td>No connection was obtained in time: pool saturation, slow DNS, or slow TCP connect. The request never reached the backend.</td></tr><tr><td>504</td><td><code>GATEWAY_CLIENT_READ_TIMEOUT</code></td><td>A connection was obtained and the request was sent, but the backend stayed silent for longer than <code>readTimeout</code>.</td></tr><tr><td>504</td><td><code>REQUEST_TIMEOUT</code></td><td>Umbrella key for the two timeouts above. Also the key of the Gateway-wide request timeout.</td></tr></tbody></table>
+
+The two timeout keys carry `REQUEST_TIMEOUT` as their parent. Every other key in this table carries `GATEWAY_CLIENT_CONNECTION_ERROR`.
+
+{% hint style="warning" %}
+`GATEWAY_CLIENT_CONNECTION_POOL_EXHAUSTED` is the one key whose parent produces a different status. Without a template of its own, it falls back to `GATEWAY_CLIENT_CONNECTION_ERROR`, and reaches the consumer as a `502` rather than a `503`. Configure a template for this key when that distinction matters.
+{% endhint %}
+
+### On `GATEWAY_CLIENT_CONNECTION_CLOSED`
+
+This key is the one most often misread. It doesn't mean that the API consumer went away, and it doesn't mean that the Gateway timed out. It means the connection closed while the response was still incomplete in HTTP terms.
+
+The common case on streaming APIs: the backend announces `Transfer-Encoding: chunked`, sends data, then closes without the terminating zero-length chunk. Any HTTP client sees the same thing. `curl` reports `transfer closed with outstanding read data remaining`.
+
+A backend that closes *cleanly*, on a response with no announced length, produces **no error key at all**. Closing is a legitimate way to delimit the body in that case.
+
+{% hint style="warning" %}
+**Check your timeout settings before you blame the backend.**
+
+This key is also what you get when the Gateway closes the connection itself, on its own `idleTimeout`. The two are indistinguishable in the reporting: same key, same message, same status.
+
+The duration tells them apart. An `idleTimeout` produces the same duration every time, within a few milliseconds of the configured value. A genuine backend problem produces scattered durations.
+
+For the configuration that causes this, see [Timeout management](../prepare-a-production-environment/timeout-management.md#distinguish-a-backend-closure-from-an-idle-timeout).
+{% endhint %}
+
+## The API consumer aborted the request
+
+The Gateway raises these keys when the **caller** goes away. It sets status `499`, but only when no status has been sent yet. On a streamed response the status is already committed, usually `200`, so only the error key is recorded and the status stays as it was.
+
+<table><thead><tr><th width="80">Status</th><th width="330">Error key</th><th>Message</th></tr></thead><tbody><tr><td>499</td><td><code>CLIENT_ABORTED_CHANNEL_CLOSED</code></td><td>The client closed the connection</td></tr><tr><td>499</td><td><code>CLIENT_ABORTED_TCP_RESET</code></td><td>The client reset the connection</td></tr><tr><td>499</td><td><code>CLIENT_ABORTED_BROKEN_PIPE</code></td><td>The client closed the connection while the response was being written</td></tr><tr><td>499</td><td><code>CLIENT_ABORTED_DURING_REQUEST_ERROR</code></td><td>The request was aborted by the client before it was fully received</td></tr><tr><td>499</td><td><code>CLIENT_ABORTED_DURING_RESPONSE_ERROR</code></td><td>The response cannot be sent to the client because the client has aborted</td></tr></tbody></table>
+
+The first three come from the HTTP layer of the Gateway, which classifies them from the underlying exception. The last two are a coarser fallback, used when nothing more precise was recorded.
+
+These keys never overlap with the backend keys above. An abort by the API consumer is always reported under a `CLIENT_ABORTED_` key, never as `GATEWAY_CLIENT_CONNECTION_CLOSED`.
+
+## Request handling and routing
+
+<table><thead><tr><th width="80">Status</th><th width="330">Error key</th><th>What it means</th></tr></thead><tbody><tr><td>400</td><td><code>REQUEST_NULL_BYTE_REJECTED</code></td><td>The request contained a null byte, and was rejected before processing.</td></tr><tr><td>400</td><td><code>INVALID_HTTP_METHOD</code></td><td>The HTTP method isn't usable for this endpoint.</td></tr><tr><td>400</td><td><code>CORS_PREFLIGHT_FAILED</code></td><td>The CORS preflight request didn't satisfy the configured policy.</td></tr><tr><td>401</td><td><code>GATEWAY_PLAN_UNRESOLVABLE</code></td><td>No plan could be resolved for the request: missing or invalid credentials, or no matching subscription.</td></tr><tr><td>404</td><td><code>FLOW_EXECUTION_FLOW_MATCHED_FAILURE</code></td><td>No flow matched the request while flow matching was mandatory.</td></tr><tr><td>500</td><td><code>GATEWAY_POLICY_INTERNAL_ERROR</code></td><td>A policy failed unexpectedly while streaming.</td></tr><tr><td>503</td><td><code>NO_ENDPOINT_FOUND</code></td><td>The endpoint targeted by the request doesn't exist or isn't available. Often a dynamic routing target that matches no declared endpoint.</td></tr></tbody></table>
+
+## Responses with no error key
+
+Two cases produce a completed request that carries no key at all. Both are worth knowing when you build dashboards:
+
+* A normal success.
+* A backend that closed cleanly, on a response with no announced length. The response may be shorter than the API consumer expected, but nothing in HTTP terms was violated.
+
+## Keys reported by policies
+
+Policies and plugins report their own keys, in the same field. Their status and their message are defined by the policy, not by the Gateway. Custom keys set through an `interrupt` policy behave the same way.
+
+Common examples in a typical setup: `JWT_INVALID_TOKEN`, `JWT_JWKS_RESOLUTION_ERROR`, `OAS_VALIDATION_ERROR`, `TRANSFORM_HEADERS_FAILURE`, `REQUEST_VALIDATION_INVALID`, `RATE_LIMIT_TOO_MANY_REQUESTS`, and `QUOTA_TOO_MANY_REQUESTS`.
+
+## Use error keys in response templates
+
+Response templates match on the error key, which lets an API return its own payload for a given failure. Target the fine-grained key to handle one case, or the umbrella key to cover a family.
+
+{% hint style="info" %}
+On connection failures, the failure carries a key and a cause, but no message. In a response template, use `{#error.cause}` rather than `{#error.message}`, which is empty for these errors.
+{% endhint %}
+
+## Related pages
+
+* [Timeout management](../prepare-a-production-environment/timeout-management.md) — which timer produces which timeout key, and how to configure them.
+* [Execution transparency analytics](execution-transparency-analytics.md) — where these keys surface in the logs and the analytics.
+* [Response templates](../create-and-configure-apis/configure-v4-apis/response-templates.md) — how to map a key to a custom response.

--- a/docs/apim/4.13/prepare-a-production-environment/timeout-management.md
+++ b/docs/apim/4.13/prepare-a-production-environment/timeout-management.md
@@ -1,0 +1,273 @@
+---
+description: >-
+  How Gateway and endpoint timeouts interact, how each protocol behaves, and how
+  to configure them so that failures are reported accurately.
+---
+
+# Timeout management
+
+## Overview
+
+Timeouts apply at two independent scopes, and both run at the same time on every request:
+
+* **Gateway scope.** `http.requestTimeout` bounds the whole request, from the moment the Gateway receives it to the moment the response completes. It applies to every API deployed on that Gateway.
+* **Endpoint scope.** The HTTP client of each endpoint or endpoint group carries its own timeouts towards the backend: `connectTimeout`, `readTimeout`, `idleTimeout`, and `keepAliveTimeout`.
+
+The two scopes don't override each other. Whichever expires first interrupts the request. An endpoint `readTimeout` longer than `http.requestTimeout` never takes effect, and the reverse is also true.
+
+Timeouts can't be configured per plan. To apply different timeout behavior to different consumers, expose the backend through separate APIs with different endpoint configurations.
+
+<table><thead><tr><th width="190">Setting</th><th width="120">Scope</th><th width="110">Default (ms)</th><th>What it bounds</th></tr></thead><tbody><tr><td><code>http.requestTimeout</code></td><td>Gateway</td><td>30000</td><td>The complete request, until the response ends.</td></tr><tr><td><code>http.requestTimeoutGraceDelay</code></td><td>Gateway</td><td>30</td><td>The minimum execution window granted to the response phase.</td></tr><tr><td><code>connectTimeout</code></td><td>Endpoint</td><td>5000</td><td>Establishing the TCP connection to the backend.</td></tr><tr><td><code>readTimeout</code></td><td>Endpoint</td><td>10000</td><td>Inactivity during a request, and connection acquisition from the pool.</td></tr><tr><td><code>idleTimeout</code></td><td>Endpoint</td><td>60000</td><td>Inactivity on the connection itself, whether or not a request is in flight.</td></tr><tr><td><code>keepAliveTimeout</code></td><td>Endpoint</td><td>30000</td><td>How long an unused connection stays in the pool. HTTP/1.x only.</td></tr></tbody></table>
+
+You configure every one of these settings in milliseconds, at both scopes.
+
+The following diagram places each timer on the life of a single request, using the default values. The request arrives at second 0, the connection is obtained at second 5, and the response completes at second 12.
+
+```mermaid
+gantt
+    title Timer windows over one request, with the default values
+    dateFormat HH:mm:ss
+    axisFormat %M:%S
+    section Gateway
+    http.requestTimeout 30s              :done, req, 00:00:00, 30s
+    section Connection
+    connectTimeout 5s                    :crit, conn, 00:00:00, 5s
+    idleTimeout 60s                      :active, idle, 00:00:05, 60s
+    keepAliveTimeout 30s, back in pool   :active, ka, 00:00:12, 30s
+    section Request in flight
+    readTimeout 10s, reset by data       :crit, read, 00:00:05, 10s
+    Response complete                    :milestone, resp, 00:00:12, 0s
+```
+
+Two properties of this layout carry the rules that follow. Only `readTimeout` and `idleTimeout` overlap while the request is in flight, so they're the only pair that competes. `keepAliveTimeout` starts when the connection returns to the pool, which is why it never interacts with `readTimeout`.
+
+## How each setting behaves
+
+### Gateway request timeout
+
+`requestTimeout` caps the total time the Gateway spends on a request. The budget covers the backend response and the execution of response policies. When the setting is absent, the Gateway applies `30000` ms and logs a warning at startup. A value of `0` or less disables it.
+
+When it fires, the consumer receives a `504` with the error key `REQUEST_TIMEOUT`. Responses that consistently fail at exactly 30 seconds usually indicate that the default is in effect.
+
+`requestTimeoutGraceDelay` guarantees a minimum window for the response phase. When a request has already consumed most of its budget, the Gateway still grants at least this delay to the platform and response flows. The effective value is `Max(requestTimeoutGraceDelay, requestTimeout - apiElapsedTime)`.
+
+{% hint style="info" %}
+`requestTimeout` stops protecting the request once the response status and headers are committed. A streamed response is therefore bounded by the endpoint timeouts alone. See [Protocol behavior](timeout-management.md#protocol-behavior).
+{% endhint %}
+
+For the configuration syntax, see [Configure your HTTP server](configure-your-http-server.md#request-timeout-behavior).
+
+### Connect timeout
+
+`connectTimeout` bounds the establishment of the TCP connection to the backend, including the TLS handshake. When it fires, the consumer receives a `504` with the error key `GATEWAY_CLIENT_CONNECT_TIMEOUT`, and the message names the target host.
+
+{% hint style="warning" %}
+`connectTimeout` doesn't bound the acquisition of a connection **from the pool**. That wait is governed by `readTimeout`. A request queued behind a saturated pool therefore waits up to `readTimeout`, not up to `connectTimeout`. Both cases report `GATEWAY_CLIENT_CONNECT_TIMEOUT`, and the duration in the message tells them apart.
+{% endhint %}
+
+### Read timeout
+
+`readTimeout` is an **inactivity timer**, not a total budget for the request. It expires only when the backend sends nothing for the configured duration. Every chunk received resets it, so a response that keeps producing data isn't interrupted, however long it runs.
+
+The same value also governs the acquisition of a connection from the pool, as described above.
+
+When it fires, the consumer receives a `504` with the error key `GATEWAY_CLIENT_READ_TIMEOUT`, and the message names the timeout, the method, and the target.
+
+### Idle timeout
+
+`idleTimeout` is a **connection-level** timer. It closes the connection when no data is received or sent for the configured duration. It has no notion of a request in flight, so it applies whether the connection is idle in the pool or actively carrying a request.
+
+When it closes a connection that carries a request, the failure surfaces as a `502` with the error key `GATEWAY_CLIENT_CONNECTION_CLOSED`. A genuine backend disconnection produces the same key and the same message. See [Diagnose a timeout](timeout-management.md#diagnose-a-timeout).
+
+{% hint style="warning" %}
+`idleTimeout` is configured in milliseconds but applied in whole seconds. The remainder is discarded: `12200` ms becomes 12 seconds. Any value below `1000` ms becomes `0`, which **disables the timeout** instead of tightening it.
+{% endhint %}
+
+### Keep-alive timeout
+
+`keepAliveTimeout` determines how long a connection stays **unused in the pool** before it's evicted and closed. It never applies to a request in flight, so it doesn't interact with `readTimeout`.
+
+Two properties are worth knowing:
+
+* It applies to **HTTP/1.x only**. HTTP/2 connections are governed by `idleTimeout` alone.
+* When the backend returns a `Keep-Alive: timeout=N` header, the Gateway adopts that value for the connection, replacing the configured one. Backends that advertise their keep-alive timeout therefore align the Gateway automatically.
+
+Backends that close idle connections without advertising the header are the case to configure for. Set `keepAliveTimeout` below the backend's own keep-alive window, so that the pool retires connections before the backend drops them. A connection retired by the backend while the Gateway still considers it usable produces a `GATEWAY_CLIENT_CONNECTION_CLOSED` on the next request that borrows it.
+
+Like `idleTimeout`, this value is applied in whole seconds.
+
+## Configuration rules
+
+### Keep `readTimeout` shorter than `idleTimeout`
+
+This is the one inequality that governs correctness. Both timers run during a request in flight, and the shorter one always wins.
+
+* When `readTimeout` is the shorter, an unresponsive backend produces a `504` with `GATEWAY_CLIENT_READ_TIMEOUT` and a message naming the timeout, the method, and the target.
+* When `idleTimeout` is the shorter, it closes the connection first. `readTimeout` can never fire, and the failure is reported as `502 GATEWAY_CLIENT_CONNECTION_CLOSED` — a backend disconnection that didn't happen.
+
+The default values satisfy this rule. Inverting them changes the diagnosis rather than the behavior. The request fails at the same point either way, but the reported cause then points at the backend.
+
+### Keep `http.requestTimeout` above `readTimeout`
+
+The endpoint timeout produces the more precise diagnosis, so let it fire first. Set `http.requestTimeout` above `readTimeout` and below whatever the API consumers themselves tolerate.
+
+### Size `readTimeout` from the backend, not from the stream
+
+Because `readTimeout` measures inactivity, it doesn't need to accommodate the total duration of a long response. Set it from the p99 response time of the backend, plus margin. For streaming APIs, the constraint is on the heartbeat interval rather than the stream duration — see [Protocol behavior](timeout-management.md#protocol-behavior).
+
+### Bound the pool wait
+
+`maxConcurrentConnections` caps the pool. Requests that find it full wait for a slot, and that wait is bounded by `readTimeout`. A long `readTimeout` therefore has a second effect: each failing request holds a connection for that duration, which reduces the throughput the pool can sustain.
+
+## Protocol behavior
+
+The timer that actually governs a request depends on the protocol, and on whether the exchange is a single request-response or a long-lived stream.
+
+<table><thead><tr><th width="170">Protocol</th><th width="185">Governing timer</th><th>Notes</th></tr></thead><tbody><tr><td>HTTP/1.1</td><td><code>readTimeout</code></td><td>Reset by each chunk received. <code>idleTimeout</code> acts as the outer bound on the connection.</td></tr><tr><td>HTTP/2</td><td><code>readTimeout</code> per stream</td><td><code>idleTimeout</code> applies to the shared connection. <code>keepAliveTimeout</code> doesn't apply.</td></tr><tr><td>SSE and chunked streaming</td><td><code>readTimeout</code></td><td>Reset by each event or chunk. The heartbeat interval must stay below it.</td></tr><tr><td>WebSocket</td><td><code>idleTimeout</code></td><td><code>readTimeout</code> covers the handshake only. Reset by any traffic in either direction.</td></tr><tr><td>gRPC</td><td><code>readTimeout</code></td><td>Runs over HTTP/2. A timeout reaches the client as <code>UNAVAILABLE</code>.</td></tr></tbody></table>
+
+### HTTP/1.1
+
+One connection carries one request at a time. `readTimeout` bounds inactivity within the request, and `idleTimeout` bounds the connection itself. Once the response ends and the connection returns to the pool, `keepAliveTimeout` governs how long it's retained.
+
+### HTTP/2
+
+An HTTP/2 connection is multiplexed: several streams share it. This changes two things.
+
+* `readTimeout` still applies per request, so each stream carries its own inactivity timer.
+* `idleTimeout` applies to the **connection**, which means it's reset by traffic on any of its streams. A connection carrying one active stream stays alive for all the others. Conversely, when it does expire, every stream on that connection is affected.
+
+`keepAliveTimeout` has no effect on HTTP/2 connections.
+
+Two further settings size the connection pool. `http2MultiplexingLimit` caps the concurrent streams per connection, and defaults to `25` streams. `maxConcurrentConnections` caps the connections themselves, and the Gateway applies `100` connections when the setting is absent. The product of the two gives the maximum number of concurrent requests towards the backend, subject to the limit the server advertises in its own settings.
+
+{% hint style="info" %}
+The console can propose a different `maxConcurrentConnections` depending on the endpoint plugin, and the value it proposes is then stored in the API. Check the value your API carries rather than assuming the Gateway default.
+{% endhint %}
+
+### Server-sent events and chunked streaming
+
+A stream isn't bounded by `readTimeout` — only the gaps between its events are. A stream that keeps emitting data runs for as long as the backend keeps producing it, regardless of how short `readTimeout` is.
+
+The requirement is therefore:
+
+> heartbeat interval < `readTimeout`
+
+A short `readTimeout` doesn't break long-lived streams. It breaks streams that go quiet for longer than the timeout.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant C as API consumer
+    participant G as Gateway
+    participant B as Backend
+
+    C->>G: GET /events
+    G->>B: GET /events
+    B-->>G: 200, headers sent, stream opens
+    Note over G: readTimeout armed for 30s
+
+    alt Heartbeat shorter than readTimeout
+        loop Every 20s
+            B-->>G: event
+            Note over G: timer reset to 30s
+        end
+        B-->>G: stream ends at 100s
+        Note over C,G: complete response, never cut
+    else Backend silent for more than 30s
+        Note over G: readTimeout fires
+        G--xC: body ends early, under the 200 already committed
+    end
+```
+
+Before you lower `readTimeout`, confirm the heartbeat interval of each streaming backend. If one exceeds the value you plan to set, either shorten the heartbeat or give that API its own shared configuration with a longer `readTimeout` — still below its `idleTimeout`.
+
+{% hint style="warning" %}
+When a stream is cut after the response headers were committed, the status has already been sent. The consumer receives a truncated body under the status that was announced, usually `200`, and the failure appears in the metrics rather than in the status. Consider streamed responses as successful only when the payload is complete.
+{% endhint %}
+
+### WebSocket
+
+`readTimeout` covers the handshake only. Once the session is established, `readTimeout` no longer applies, and the connection is governed by `idleTimeout` alone.
+
+`idleTimeout` is reset by traffic in either direction, so an application-level ping keeps the session open. Set `idleTimeout` above the ping interval of the client or the backend, whichever is longer. A session that goes quiet for longer than `idleTimeout` is closed with a normal close frame.
+
+This is the one protocol where `idleTimeout` is the setting to tune rather than a safety net.
+
+### gRPC
+
+gRPC runs over HTTP/2, which the Gateway selects for these endpoints regardless of the configured version. The multiplexing behavior described in [HTTP/2](timeout-management.md#http-2) applies.
+
+`readTimeout` applies as it does to any HTTP request. When it fires, the `504` is translated by the gRPC layer, and the client observes the `UNAVAILABLE` status code rather than an HTTP status.
+
+## Start from the defaults
+
+The default values already satisfy the rules above. `readTimeout` at `10000` ms sits well below `idleTimeout` at `60000` ms, and the Gateway `requestTimeout` of `30000` ms sits above `readTimeout`. A backend that answers within ten seconds needs no timeout configuration at all.
+
+Change them when the backend is slower than the default `readTimeout`, in this order:
+
+1. Raise `readTimeout` to the p99 response time of the backend, plus margin.
+2. Raise `idleTimeout` if the new `readTimeout` comes close to it. Keep a clear gap between the two.
+3. Raise `http.requestTimeout` above the new `readTimeout`. The default of `30000` ms no longer clears a `readTimeout` set to `30000` ms.
+
+The following example configures an endpoint whose backend answers in about 25 seconds at the p99.
+
+{% code title="Endpoint shared configuration, for a backend slower than the default" %}
+```json
+{
+  "http": {
+    "connectTimeout": 5000,
+    "readTimeout": 30000,
+    "keepAliveTimeout": 30000,
+    "idleTimeout": 90000,
+    "maxConcurrentConnections": 100,
+    "keepAlive": true,
+    "pipelining": false,
+    "followRedirects": false,
+    "useCompression": true,
+    "version": "HTTP_1_1"
+  }
+}
+```
+{% endcode %}
+
+{% code title="gravitee.yml" %}
+```yaml
+http:
+  requestTimeout: 60000
+  requestTimeoutGraceDelay: 30
+```
+{% endcode %}
+
+`keepAliveTimeout` keeps its default here. It governs connections that sit unused in the pool, so a slow backend gives no reason to change it. Adjust it against the keep-alive window of the backend, as described in [Keep-alive timeout](timeout-management.md#keep-alive-timeout).
+
+The ordering carries the behavior, not the values. `readTimeout` stays the shortest, so it governs and produces the precise diagnosis. `idleTimeout` stays a safety net rather than the effective limit. `requestTimeout` stays above `readTimeout`, so the endpoint timeout fires first.
+
+## Diagnose a timeout
+
+The error key recorded in the API logs and analytics identifies which timer fired.
+
+<table><thead><tr><th width="330">Error key</th><th width="80">Status</th><th>What fired</th></tr></thead><tbody><tr><td><code>REQUEST_TIMEOUT</code></td><td>504</td><td>The Gateway-level <code>requestTimeout</code>.</td></tr><tr><td><code>GATEWAY_CLIENT_CONNECT_TIMEOUT</code></td><td>504</td><td>No connection was obtained in time: TCP establishment, or a wait on a saturated pool.</td></tr><tr><td><code>GATEWAY_CLIENT_READ_TIMEOUT</code></td><td>504</td><td>The connection was established, and the backend then went silent for longer than <code>readTimeout</code>.</td></tr><tr><td><code>GATEWAY_CLIENT_CONNECTION_CLOSED</code></td><td>502</td><td>The connection closed while a response was still expected. See the note below.</td></tr></tbody></table>
+
+For the complete list of connectivity error keys, see [Execution transparency analytics](../analyze-and-monitor-apis/execution-transparency-analytics.md#connectivity-and-timeout-error-keys).
+
+### Distinguish a backend closure from an idle timeout
+
+`GATEWAY_CLIENT_CONNECTION_CLOSED` covers two situations that report identically — the same key, the same `Connection was closed` message, and the same `502`:
+
+* The backend closed the connection while the response was incomplete.
+* The Gateway closed it on its own `idleTimeout`.
+
+The duration tells them apart. An `idleTimeout` produces the **same duration every time**, within a few milliseconds of the configured value. A genuine backend problem produces scattered durations. If your failures cluster tightly around your `idleTimeout`, and `readTimeout` is longer than it, the Gateway is the one closing the connection.
+
+Setting `readTimeout` below `idleTimeout` resolves the ambiguity: the same situation then surfaces as `GATEWAY_CLIENT_READ_TIMEOUT` with a `504` and a message naming the timeout, the method, and the target.
+
+{% hint style="info" %}
+On connection failures, the `ExecutionFailure` carries a key and a cause, but no message. In a response template, use `{#error.cause}` rather than `{#error.message}`, which is empty for these errors.
+{% endhint %}
+
+## Related pages
+
+* [Configure your HTTP server](configure-your-http-server.md) — the Gateway-side settings and their syntax.
+* [Endpoints](../create-and-configure-apis/configure-v4-apis/endpoints/README.md) — where the endpoint timeouts are configured in the console.
+* [Execution engine](../create-and-configure-apis/gravitee-api-definitions/execution-engine.md#timeout-management) — how the reactive engine applies the Gateway timeout across the request and response phases.
+* [Execution transparency analytics](../analyze-and-monitor-apis/execution-transparency-analytics.md#connectivity-and-timeout-error-keys) — the complete error key reference.


### PR DESCRIPTION
## What

Two new reference pages, and one correction to an existing page. Written on 4.12 and copied to 4.13.

**`prepare-a-production-environment/timeout-management.md`** (new)
How the Gateway request timeout and the endpoint HTTP client timeouts interact: what each setting actually governs, the rules to keep between them, and how the behaviour differs across HTTP/1.1, HTTP/2, server-sent events and chunked streaming, WebSocket, and gRPC. Includes two mermaid diagrams and a starting point for configuration.

**`analyze-and-monitor-apis/gateway-error-key-reference.md`** (new)
Every error key the Gateway itself reports, with the status it produces by default, the message it attaches, and what it means. Grouped into backend connection failures, aborts by the API consumer, and request handling and routing.

**`analyze-and-monitor-apis/execution-transparency-analytics.md`** (updated)
Adds the missing `GATEWAY_CLIENT_CONNECTION_POOL_EXHAUSTED` key, and states how a response template changes the status it produces.

## Why

APIM has had no dedicated timeout page since 4.2. The subject was spread over five pages with no entry point, and nothing in the navigation named it. More importantly, the settings do not behave the way their names suggest, and the gap produces misleading diagnostics in production:

- `readTimeout` is an inactivity timer, not a request budget. It is reset by every chunk, so a short value does not break long-lived streams. It also governs connection acquisition from the pool, which supersedes the configured `connectTimeout` for that wait.
- `idleTimeout` is a connection-level timer that applies whether or not a request is in flight. When it is shorter than `readTimeout`, it closes the connection first and the failure is reported as `GATEWAY_CLIENT_CONNECTION_CLOSED` — a backend disconnection that never happened. The two cases are indistinguishable in the reporting, which sends investigations towards the backend.
- `idleTimeout` is applied in whole seconds, so any value below 1000 ms becomes 0 and disables the timeout instead of tightening it.
- `keepAliveTimeout` only governs connections sitting unused in the pool, and only on HTTP/1.x, so it never competes with `readTimeout`.

On the error keys, the existing coverage stopped at connectivity: the keys raised on routing, plan resolution and request handling were documented nowhere. `GATEWAY_CLIENT_CONNECTION_POOL_EXHAUSTED` was missing altogether, and it is the one key whose status differs from its parent's.

## How to verify

Facts were checked against the `4.12.x` sources rather than taken from field notes:

| Claim | Source |
| --- | --- |
| Statuses, error keys and parent keys | `ConnectionFailureClassifier` |
| Messages of the `CLIENT_ABORTED_*` keys | `ClientCloseClassifier` |
| Default timeout values | `VertxHttpClientOptions`, and the console form defaults |
| A response template dictates the status | `ResponseTemplateBasedFailureProcessor.handleTemplate` |
| `keepAliveTimeout` covers pooled connections, HTTP/1.x only | Vert.x 5.0.12 `HttpClientOptions.setKeepAliveTimeout` |

Vale reports no error, warning or suggestion on the new pages. Internal links and anchors were checked.

Two points worth a reviewer's attention:

- The **HTTP/2** section is derived from the code and the plugin schema, not from measurements. The other protocols were measured.
- The gantt diagram is the **first of its kind in this repo**; sequence diagrams already render in the GKO pages. Worth a look on the GitBook preview.

## Notes

- 4.12 and 4.13 are byte-identical, so the version sync will not replay one over the other.
- Both `SUMMARY.md` files carry the new entries, since they are never propagated between versions.
- Add the `vale integration` label to run the linter on this PR.
