### PR TITLE
docs(apim): fix the timer windows diagram rendering

### DIFF
--- a/docs/apim/4.12/.gitbook/assets/apim-timeout-timer-windows.svg
+++ b/docs/apim/4.12/.gitbook/assets/apim-timeout-timer-windows.svg
@@ -1,0 +1,44 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 252" width="760" height="252" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" role="img">
+<title>Timer windows over one request, with the default values</title>
+<rect width="760" height="252" fill="#ffffff"/>
+<text x="380.0" y="22" text-anchor="middle" font-size="13" font-weight="600" fill="#1b1f24">Timer windows over one request, with the default values</text>
+<rect x="0" y="52" width="760" height="32" fill="#f7f8fa"/>
+<text x="112" y="72.0" text-anchor="end" font-size="11" fill="#656d76">Gateway</text>
+<text x="112" y="132.0" text-anchor="end" font-size="11" fill="#656d76">Connection</text>
+<rect x="0" y="172" width="760" height="40" fill="#f7f8fa"/>
+<text x="112" y="196.0" text-anchor="end" font-size="11" fill="#656d76">Request in flight</text>
+<line x1="124.0" y1="52" x2="124.0" y2="212" stroke="#d8dbdf" stroke-width="1"/>
+<line x1="220.6" y1="52" x2="220.6" y2="212" stroke="#d8dbdf" stroke-width="1"/>
+<line x1="317.3" y1="52" x2="317.3" y2="212" stroke="#d8dbdf" stroke-width="1"/>
+<line x1="413.9" y1="52" x2="413.9" y2="212" stroke="#d8dbdf" stroke-width="1"/>
+<line x1="510.5" y1="52" x2="510.5" y2="212" stroke="#d8dbdf" stroke-width="1"/>
+<line x1="607.2" y1="52" x2="607.2" y2="212" stroke="#d8dbdf" stroke-width="1"/>
+<line x1="703.8" y1="52" x2="703.8" y2="212" stroke="#d8dbdf" stroke-width="1"/>
+<line x1="201.3" y1="46" x2="201.3" y2="212" stroke="#656d76" stroke-width="1" stroke-dasharray="3 3"/>
+<rect x="124.0" y="58" width="193.3" height="18" rx="3" fill="#b9bcc4"/>
+<text x="220.6" y="71" text-anchor="middle" font-size="11" fill="#1b1f24">http.requestTimeout 30s</text>
+<rect x="124.0" y="90" width="32.2" height="18" rx="3" fill="#dc4c4c"/>
+<text x="163.2" y="103" font-size="11" fill="#1b1f24" stroke="#ffffff" stroke-width="3" paint-order="stroke">connectTimeout 5s</text>
+<rect x="156.2" y="118" width="386.5" height="18" rx="3" fill="#6f97dd"/>
+<text x="349.5" y="131" text-anchor="middle" font-size="11" fill="#ffffff">idleTimeout 60s</text>
+<rect x="201.3" y="146" width="193.3" height="18" rx="3" fill="#a9c2ea"/>
+<text x="297.9" y="159" text-anchor="middle" font-size="11" fill="#1b1f24">keepAliveTimeout 30s</text>
+<rect x="156.2" y="180" width="64.4" height="18" rx="3" fill="#dc4c4c"/>
+<text x="227.6" y="193" font-size="11" fill="#1b1f24" stroke="#ffffff" stroke-width="3" paint-order="stroke">readTimeout 10s, reset by data</text>
+<text x="207.3" y="43" font-size="11" fill="#656d76">Response complete</text>
+<line x1="124" y1="222" x2="736" y2="222" stroke="#656d76" stroke-width="1"/>
+<line x1="124.0" y1="222" x2="124.0" y2="227" stroke="#656d76" stroke-width="1"/>
+<text x="124.0" y="240" text-anchor="middle" font-size="10" fill="#656d76">0s</text>
+<line x1="220.6" y1="222" x2="220.6" y2="227" stroke="#656d76" stroke-width="1"/>
+<text x="220.6" y="240" text-anchor="middle" font-size="10" fill="#656d76">15s</text>
+<line x1="317.3" y1="222" x2="317.3" y2="227" stroke="#656d76" stroke-width="1"/>
+<text x="317.3" y="240" text-anchor="middle" font-size="10" fill="#656d76">30s</text>
+<line x1="413.9" y1="222" x2="413.9" y2="227" stroke="#656d76" stroke-width="1"/>
+<text x="413.9" y="240" text-anchor="middle" font-size="10" fill="#656d76">45s</text>
+<line x1="510.5" y1="222" x2="510.5" y2="227" stroke="#656d76" stroke-width="1"/>
+<text x="510.5" y="240" text-anchor="middle" font-size="10" fill="#656d76">60s</text>
+<line x1="607.2" y1="222" x2="607.2" y2="227" stroke="#656d76" stroke-width="1"/>
+<text x="607.2" y="240" text-anchor="middle" font-size="10" fill="#656d76">75s</text>
+<line x1="703.8" y1="222" x2="703.8" y2="227" stroke="#656d76" stroke-width="1"/>
+<text x="703.8" y="240" text-anchor="middle" font-size="10" fill="#656d76">90s</text>
+</svg>

--- a/docs/apim/4.12/prepare-a-production-environment/timeout-management.md
+++ b/docs/apim/4.12/prepare-a-production-environment/timeout-management.md
@@ -23,21 +23,7 @@ You configure every one of these settings in milliseconds, at both scopes.
 
 The following diagram places each timer on the life of a single request, using the default values. The request arrives at second 0, the connection is obtained at second 5, and the response completes at second 12.
 
-```mermaid
-gantt
-    title Timer windows over one request, with the default values
-    dateFormat HH:mm:ss
-    axisFormat %M:%S
-    section Gateway
-    http.requestTimeout 30s              :done, req, 00:00:00, 30s
-    section Connection
-    connectTimeout 5s                    :crit, conn, 00:00:00, 5s
-    idleTimeout 60s                      :active, idle, 00:00:05, 60s
-    keepAliveTimeout 30s, back in pool   :active, ka, 00:00:12, 30s
-    section Request in flight
-    readTimeout 10s, reset by data       :crit, read, 00:00:05, 10s
-    Response complete                    :milestone, resp, 00:00:12, 0s
-```
+<figure><img src="../.gitbook/assets/apim-timeout-timer-windows.svg" alt="Timer windows over one request, with the default values"><figcaption><p>Each timer over the life of one request, with the default values</p></figcaption></figure>
 
 Two properties of this layout carry the rules that follow. Only `readTimeout` and `idleTimeout` overlap while the request is in flight, so they're the only pair that competes. `keepAliveTimeout` starts when the connection returns to the pool, which is why it never interacts with `readTimeout`.
 

--- a/docs/apim/4.13/.gitbook/assets/apim-timeout-timer-windows.svg
+++ b/docs/apim/4.13/.gitbook/assets/apim-timeout-timer-windows.svg
@@ -1,0 +1,44 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 252" width="760" height="252" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" role="img">
+<title>Timer windows over one request, with the default values</title>
+<rect width="760" height="252" fill="#ffffff"/>
+<text x="380.0" y="22" text-anchor="middle" font-size="13" font-weight="600" fill="#1b1f24">Timer windows over one request, with the default values</text>
+<rect x="0" y="52" width="760" height="32" fill="#f7f8fa"/>
+<text x="112" y="72.0" text-anchor="end" font-size="11" fill="#656d76">Gateway</text>
+<text x="112" y="132.0" text-anchor="end" font-size="11" fill="#656d76">Connection</text>
+<rect x="0" y="172" width="760" height="40" fill="#f7f8fa"/>
+<text x="112" y="196.0" text-anchor="end" font-size="11" fill="#656d76">Request in flight</text>
+<line x1="124.0" y1="52" x2="124.0" y2="212" stroke="#d8dbdf" stroke-width="1"/>
+<line x1="220.6" y1="52" x2="220.6" y2="212" stroke="#d8dbdf" stroke-width="1"/>
+<line x1="317.3" y1="52" x2="317.3" y2="212" stroke="#d8dbdf" stroke-width="1"/>
+<line x1="413.9" y1="52" x2="413.9" y2="212" stroke="#d8dbdf" stroke-width="1"/>
+<line x1="510.5" y1="52" x2="510.5" y2="212" stroke="#d8dbdf" stroke-width="1"/>
+<line x1="607.2" y1="52" x2="607.2" y2="212" stroke="#d8dbdf" stroke-width="1"/>
+<line x1="703.8" y1="52" x2="703.8" y2="212" stroke="#d8dbdf" stroke-width="1"/>
+<line x1="201.3" y1="46" x2="201.3" y2="212" stroke="#656d76" stroke-width="1" stroke-dasharray="3 3"/>
+<rect x="124.0" y="58" width="193.3" height="18" rx="3" fill="#b9bcc4"/>
+<text x="220.6" y="71" text-anchor="middle" font-size="11" fill="#1b1f24">http.requestTimeout 30s</text>
+<rect x="124.0" y="90" width="32.2" height="18" rx="3" fill="#dc4c4c"/>
+<text x="163.2" y="103" font-size="11" fill="#1b1f24" stroke="#ffffff" stroke-width="3" paint-order="stroke">connectTimeout 5s</text>
+<rect x="156.2" y="118" width="386.5" height="18" rx="3" fill="#6f97dd"/>
+<text x="349.5" y="131" text-anchor="middle" font-size="11" fill="#ffffff">idleTimeout 60s</text>
+<rect x="201.3" y="146" width="193.3" height="18" rx="3" fill="#a9c2ea"/>
+<text x="297.9" y="159" text-anchor="middle" font-size="11" fill="#1b1f24">keepAliveTimeout 30s</text>
+<rect x="156.2" y="180" width="64.4" height="18" rx="3" fill="#dc4c4c"/>
+<text x="227.6" y="193" font-size="11" fill="#1b1f24" stroke="#ffffff" stroke-width="3" paint-order="stroke">readTimeout 10s, reset by data</text>
+<text x="207.3" y="43" font-size="11" fill="#656d76">Response complete</text>
+<line x1="124" y1="222" x2="736" y2="222" stroke="#656d76" stroke-width="1"/>
+<line x1="124.0" y1="222" x2="124.0" y2="227" stroke="#656d76" stroke-width="1"/>
+<text x="124.0" y="240" text-anchor="middle" font-size="10" fill="#656d76">0s</text>
+<line x1="220.6" y1="222" x2="220.6" y2="227" stroke="#656d76" stroke-width="1"/>
+<text x="220.6" y="240" text-anchor="middle" font-size="10" fill="#656d76">15s</text>
+<line x1="317.3" y1="222" x2="317.3" y2="227" stroke="#656d76" stroke-width="1"/>
+<text x="317.3" y="240" text-anchor="middle" font-size="10" fill="#656d76">30s</text>
+<line x1="413.9" y1="222" x2="413.9" y2="227" stroke="#656d76" stroke-width="1"/>
+<text x="413.9" y="240" text-anchor="middle" font-size="10" fill="#656d76">45s</text>
+<line x1="510.5" y1="222" x2="510.5" y2="227" stroke="#656d76" stroke-width="1"/>
+<text x="510.5" y="240" text-anchor="middle" font-size="10" fill="#656d76">60s</text>
+<line x1="607.2" y1="222" x2="607.2" y2="227" stroke="#656d76" stroke-width="1"/>
+<text x="607.2" y="240" text-anchor="middle" font-size="10" fill="#656d76">75s</text>
+<line x1="703.8" y1="222" x2="703.8" y2="227" stroke="#656d76" stroke-width="1"/>
+<text x="703.8" y="240" text-anchor="middle" font-size="10" fill="#656d76">90s</text>
+</svg>

--- a/docs/apim/4.13/prepare-a-production-environment/timeout-management.md
+++ b/docs/apim/4.13/prepare-a-production-environment/timeout-management.md
@@ -23,21 +23,7 @@ You configure every one of these settings in milliseconds, at both scopes.
 
 The following diagram places each timer on the life of a single request, using the default values. The request arrives at second 0, the connection is obtained at second 5, and the response completes at second 12.
 
-```mermaid
-gantt
-    title Timer windows over one request, with the default values
-    dateFormat HH:mm:ss
-    axisFormat %M:%S
-    section Gateway
-    http.requestTimeout 30s              :done, req, 00:00:00, 30s
-    section Connection
-    connectTimeout 5s                    :crit, conn, 00:00:00, 5s
-    idleTimeout 60s                      :active, idle, 00:00:05, 60s
-    keepAliveTimeout 30s, back in pool   :active, ka, 00:00:12, 30s
-    section Request in flight
-    readTimeout 10s, reset by data       :crit, read, 00:00:05, 10s
-    Response complete                    :milestone, resp, 00:00:12, 0s
-```
+<figure><img src="../.gitbook/assets/apim-timeout-timer-windows.svg" alt="Timer windows over one request, with the default values"><figcaption><p>Each timer over the life of one request, with the default values</p></figcaption></figure>
 
 Two properties of this layout carry the rules that follow. Only `readTimeout` and `idleTimeout` overlap while the request is in flight, so they're the only pair that competes. `keepAliveTimeout` starts when the connection returns to the pool, which is why it never interacts with `readTimeout`.
 


### PR DESCRIPTION
Follow-up to #2215, on the published page.

## The problem

The mermaid `gantt` renders badly on the site. It sizes its **width on the browser viewport** while keeping a fixed height, and GitBook then scales the result down to fit its 768 px content column. The wider the reader's window, the flatter the diagram.

Measured on the published page:

| Viewport | viewBox produced | Rendered | Result |
| --- | --- | --- | --- |
| 1682 px | 1682 × 244 | 752 × 109 | labels unreadable |
| 1000 px | 1000 × 244 | 752 × 183 | still cramped |

So the readers on the widest screens get the worst version, which is the opposite of what you would expect.

## The fix

Replace the gantt with an SVG of fixed dimensions, 760 × 252, sized for the content column so it renders at its natural scale and stays identical on every screen. Same content: the window of each timer over the life of one request, with the default values.

The file is committed as an asset in both versions. SVG is already used elsewhere in the repo, including under `docs/apim/4.6/.gitbook/assets/`.

**The sequence diagram in the streaming section is kept as mermaid.** It derives its size from its own content rather than from the viewport, and renders at 752 × 675 on the published page, which is comfortable. The problem is specific to `gantt`.

## Note for future diagrams

`sequenceDiagram` and the content-sized types are safe in this repo. `gantt` is not, unless its width is pinned.

## How to verify

Open the GitBook preview of this branch on the Timeout Management page, at a wide window, and compare with [the published page](https://documentation.gravitee.io/apim/prepare-a-production-environment/timeout-management). The diagram should keep its proportions instead of flattening.
