### PR TITLE
AGENT-DRAFT: APIM-14598 — Import and Update v4 APIs from OpenAPI and Gravitee Definitions

### DIFF
--- a/docs/apim/4.13/.version-overrides
+++ b/docs/apim/4.13/.version-overrides
@@ -22,3 +22,4 @@ management-api-reference.md
 plugins/customization/schema-registry-provider.md
 # Confluent Schema Registry resource note (ESM-28) and emulation-mode copy edit
 create-and-configure-apis/apply-policies/resources.md
+create-and-configure-apis/create-apis/import-and-update-v4-apis-from-openapi-and-gravitee-definitions.md

--- a/docs/apim/4.13/create-and-configure-apis/create-apis/import-and-update-v4-apis-from-openapi-and-gravitee-definitions.md
+++ b/docs/apim/4.13/create-and-configure-apis/create-apis/import-and-update-v4-apis-from-openapi-and-gravitee-definitions.md
@@ -25,7 +25,7 @@ The wizard interface supports the following three import formats:
 APIs can be imported from the following two sources:
 
 * **Local file**. This source uploads a definition file from your machine by using drag-and-drop or a file picker.
-* **Remote URL**. This source fetches the definition from an HTTP or HTTPS endpoint. You can optionally provide an Authorization header for authenticated sources. Remote sources require the target URL to allow CORS requests from the Management Console origin.
+* **Remote URL**. This source fetches the definition from an HTTP or HTTPS endpoint. Addresses that don't use HTTP or HTTPS are rejected with a validation message. You can optionally provide an Authorization header for authenticated sources. Remote sources require the target URL to allow CORS requests from the Management Console origin.
 
 ### Update Behavior
 
@@ -48,7 +48,7 @@ To update an existing v4 API, complete the following steps:
 2. In the **Update API** modal, select the API format. You can select **Gravitee v4 Definition** for a complete Gravitee export or **OpenAPI Specification** for an OpenAPI descriptor.
 
     <figure><img src="../../.gitbook/assets/apim-api-import-update-from-openapi-and-gravitee-definition-step-07.png" alt="Select API format"><figcaption></figcaption></figure>
-3. Choose the file source. You can select **Local file** to upload a `.json`, `.yml`, or `.yaml` file, or you can select **Remote URL** to fetch from an HTTP or HTTPS endpoint. You can optionally provide an Authorization header for the remote URL.
+3. Choose the file source. You can select **Local file** to upload a `.json`, `.yml`, or `.yaml` file, or you can select **Remote URL** to fetch from an HTTP or HTTPS endpoint. You can optionally provide an Authorization header for the remote URL. For the Gravitee v4 Definition format, the address field is labeled **Definition URL**. For the OpenAPI Specification format, it is labeled **Specification URL**.
 
     <figure><img src="../../.gitbook/assets/apim-api-import-update-from-openapi-and-gravitee-definition-step-04.png" alt="Update API dialog from Configuration page showing file source selection with drag and drop area for JSON files"><figcaption></figcaption></figure>
 
@@ -58,8 +58,10 @@ To update an existing v4 API, complete the following steps:
 
     <figure><img src="../../.gitbook/assets/apim-api-import-update-from-openapi-and-gravitee-definition-step-05.png" alt="Update API dialog showing local file option selected with kafka-1.json file uploaded"><figcaption></figcaption></figure>
 4. For OpenAPI imports, configure the following options:
-    * Enable **Create documentation page from spec** to generate a Documentation page from the imported specification.
-    * Enable **Add OpenAPI Specification Validation policy** to attach the OAS Validation policy to generated flows. This option is enabled by default if the policy is installed.
+    * Enable **Create documentation page from spec** to generate a Documentation page from the imported specification. The page is published automatically, and you can change its publication status later.
+    * Enable **Add OpenAPI Specification Validation policy** to attach the OAS Validation policy to generated flows. This option is enabled by default if the policy is installed. The policy is added with all of its options enabled, and you can change them later.
+
+    If the list of installed policies can't be retrieved, the options step reports that some options may be unavailable.
 5. Review the selected format, source, and options.
 
     <figure><img src="../../.gitbook/assets/apim-api-import-update-from-openapi-and-gravitee-definition-step-03.png" alt="Import API review screen showing configuration summary with Gravitee definition format and local file source"><figcaption></figcaption></figure>
@@ -114,4 +116,4 @@ The import and update feature has the following restrictions:
 
 ## Related Changes
 
-The **Import** button on the v4 API details page is now enabled, and it opens a new **Update API** modal that reuses the v4 import wizard stepper. For v2 APIs, the button continues to open the legacy import dialog. The wizard includes four steps. These steps are select API format, configure file source, options, and review and import. The options step is shown only for OpenAPI and WSDL formats. The file picker clears the selected file when the API format changes, but it preserves the file when you navigate back within the same format or toggle options. After a successful update, the API configuration reflects the imported definition. For OpenAPI imports with documentation enabled, a new page appears under Documentation and Pages. With OAS Validation enabled, the OpenAPI Specification Validation policy appears on generated flows in Policy Studio. The API Gateway sync indicator shows the API as out-of-sync until it is redeployed, and an audit log entry is recorded for the update action.
+The **Import** button on the v4 API details page is now enabled, and it opens a new **Update API** modal that reuses the v4 import wizard stepper. For v2 APIs, the button continues to open the legacy import dialog. The wizard includes four steps. These steps are select API format, configure file source, options, and review and import. The options step is shown only for OpenAPI and WSDL formats. The file picker clears the selected file when the API format changes, but it preserves the file when you navigate back within the same format or toggle options. Each time you open the modal, the format resets to **Gravitee v4 Definition**, the source resets to **Local file**, and the options reset to their defaults for the selected format. After a successful update, the API configuration reflects the imported definition. For OpenAPI imports with documentation enabled, a new page appears under Documentation and Pages. With OAS Validation enabled, the OpenAPI Specification Validation policy appears on generated flows in Policy Studio. The API Gateway sync indicator shows the API as out-of-sync until it is redeployed, and an audit log entry is recorded for the update action.

--- a/docs/apim/4.13/release-information/release-notes/apim-4.13.md
+++ b/docs/apim/4.13/release-information/release-notes/apim-4.13.md
@@ -32,6 +32,7 @@ documentation.gravitee.io links for other versions.
 * The Generate JWT policy adds optional `x5t` and `x5t#S256` certificate thumbprint headers to generated JWTs, for downstream systems that select the validation certificate by thumbprint.
 * The schema registry provider contract now exposes the serialization format of each schema and answers subject membership and version-list lookups, and the bundled Confluent Schema Registry resource implements all three.
 * The plan endpoints of the legacy Management API v1 now reject V4, Federated, and Federated Agent APIs with an HTTP `400` error that points to Management API v2.
+* The v4 API import wizard can now fetch a Gravitee v4 Definition or OpenAPI Specification from a remote HTTP or HTTPS endpoint, and the **Import** button on a v4 API updates an existing API with the imported definition.
 
 ## Breaking Changes and deprecations
 
@@ -71,6 +72,14 @@ The plan endpoints of the legacy Management API v1 no longer accept V4, Federate
 * `getVersions(subject)` lists the version identifiers registered under a subject.
 * Every addition carries a default implementation (`UNKNOWN` type, empty results), so an existing provider compiled against contract version `1.0.1` compiles and runs unchanged, and a registry that doesn't support these lookups returns the defaults.
 * The Confluent Schema Registry resource implements the new surface from plugin version `5.1.0`, bundled with APIM 4.13. For more information, see [Implement a schema registry provider](../../plugins/customization/schema-registry-provider.md).
+
+#### **Remote URL Import and Update for v4 APIs**
+
+* On the file source step, select **Local file** to upload a `.json`, `.yml`, or `.yaml` file, or select **Remote URL** to fetch the definition from an HTTP or HTTPS endpoint, with an optional Authorization header for authenticated sources.
+* The address field is labeled **Definition URL** for the Gravitee v4 Definition format and **Specification URL** for the OpenAPI Specification format.
+* For OpenAPI and WSDL formats, the options step lets you enable **Create documentation page from spec** to generate a published Documentation page, and **Add OpenAPI Specification Validation policy** to attach the OpenAPI Specification Validation policy with all of its options enabled to the generated flows, which is on by default when the policy is installed.
+* The **Import** button on the v4 API details page opens a new **Update API** modal that reuses the four-step v4 import wizard, and v2 APIs continue to open the legacy import dialog: after a successful update the API shows as out of sync until you redeploy it, and an audit log entry is recorded.
+* Addresses that don't use HTTP or HTTPS are rejected with a validation message, and a remote source requires the target URL to allow CORS requests from the Management Console origin.
 
 ## Improvements
 


### PR DESCRIPTION
Automated update: apim-14598

Product: apim
Version: 4.13

---

## Release deliverables (Step 0)

- ✅ Release notes entry added to `docs/apim/4.13/release-information/release-notes/apim-4.13.md` under **New Features**: Remote URL Import and Update for v4 APIs
- No breaking change declared on this run (`breakingChange` not set).
- \u2705 Added 1 entry to `docs/apim/4.13/.version-overrides`: `create-and-configure-apis/create-apis/import-and-update-v4-apis-from-openapi-and-gravitee-definitions.md`

## Publishability gate

**Verdict: FAIL**
- Multiple CRITICAL flags in audit



> Only lines this PR **adds** are judged. Pre-existing page content is never touched
> and never counted, so an already-dirty page is not penalised for debt it inherited.
> Removed items are gone from the committed file. Review items are left in place for
> you to decide on, because a blocked run produces no PR at all.