### PR TITLE
AGENT-DRAFT: AIAM-71 — Review audit logs

### DIFF
--- a/docs/gamma/4.13/agent-management/observe/review-audit-logs.md
+++ b/docs/gamma/4.13/agent-management/observe/review-audit-logs.md
@@ -19,6 +19,8 @@ Each LLM Proxy, MCP Proxy, and A2A Proxy detail view includes an **Audit Logs** 
 
 Until the first audit event is recorded for the proxy, the page shows an introduction to audit logs instead of the table.
 
+You need the **API_AUDIT** permission with the **READ** access level on the proxy. Without it, the **Monitoring** group isn't shown, and opening the page directly displays `You don't have permission to view audit logs for this API.` If the trail can't be loaded, the page shows `Failed to load audit logs. Please try again.`
+
 ## Read the audit trail
 
 The table lists one row per audit event, with the following columns:
@@ -30,7 +32,7 @@ The table lists one row per audit event, with the following columns:
 | **Event**  | The event type identifier.                                                         |
 | **Target** | The properties of the object the event applied to, one `key: value` pair per line. |
 
-The table shows 10 entries per page by default and supports page sizes of 25, 50, and 100.
+The table shows 10 entries per page by default and supports page sizes of 25, 50, and 100. Changing the page size returns the table to the first page.
 
 ## Filter the trail
 
@@ -41,11 +43,11 @@ The table shows 10 entries per page by default and supports page sizes of 25, 50
 2. To bound the trail in time, select a start and end date in the **Date range** picker. The end date is inclusive.
 3. To clear the active filters, click **Reset**. The **Reset** button appears only while a filter is active.
 
-Changing a filter returns the table to the first page.
+Changing a filter returns the table to the first page. When no entries match the active filters, the table shows `No audit logs found`.
 
 ## View the change as a JSON Patch
 
-When an audit entry carries the JSON Patch of the change, a **View patch** button appears at the end of its row. Click it to open the **JSON Patch** panel, which shows the patch that the audited change applied.
+When an audit entry carries the JSON Patch of the change, a **View patch** button appears at the end of its row. Click it to open the **JSON Patch** panel, which shows the patch that the audited change applied. The panel also shows the event type, the date and time of the change, and the actor who made it.
 
 ## Verification
 


### PR DESCRIPTION
Automated update: aiam-71

Product: gamma
Version: 4.13

---

## Release deliverables (Step 0)

- release notes page not found at docs/gamma/4.13/release-information/release-notes/gamma-4.13.md — create it first, then re-run
- No breaking change declared on this run (`breakingChange` not set).
- Version overrides: no .version-overrides at docs/gamma/4.13/.version-overrides, nothing added.

## Publishability gate

**Verdict: PASS**
- Nothing flagged



> Only lines this PR **adds** are judged. Pre-existing page content is never touched
> and never counted, so an already-dirty page is not penalised for debt it inherited.
> Removed items are gone from the committed file. Review items are left in place for
> you to decide on, because a blocked run produces no PR at all.

<details>
<summary><b>Fidelity / ZEG audit report</b> (click to expand)</summary>

# ZERO-EXTRACTION GROUNDING (ZEG) AUDIT REPORT

## AUDIT SUMMARY

**Scope:** 1 file, 3,740 chars — `docs/gamma/4.13/agent-management/observe/review-audit-logs.md` (CREATE).
**Deterministic verdict:** PASS (no gap leaks, no dupes, no internals leaked).
**ZEG verdict:** **FAIL** — the page reads well and shows good editorial restraint in omitting internal mechanics (60% viewport scroll limit, two-space re-indentation, JSON parser edge cases), but it renames or reshapes several user-visible UI affordances that SOURCE specifies literally, and it invents a console navigation path plus a verification procedure that SOURCE does not contain.

**Counts**
- Core grounding violations: **8** (6 contradictions of literal SOURCE strings/behaviour, 2 additions absent from SOURCE)
- Placement & proportionality issues: 5 (2 PUBLISHABILITY)
- Structural quality issues: 4
- Correct, well-grounded content: navigation-group gating, permission string, error string, column set, page sizes, page-reset behaviour, inclusive end date, patch button conditionality, patch panel contents.

**Headline problem:** a reader following this page will look for a **Reset** button, a **Date range** picker, an **All events** default, and a **JSON Patch** panel. SOURCE says those controls are named **Clear filters**, **Filter by date range**, a multi-select **Event** filter with no documented default, and a slide-over titled **Audit Entry**. Every one of these is a hard UI-label mismatch.

---

## CORE GROUNDING VIOLATIONS

### CRITICAL 1 — Filter clear control renamed
**Generated:** "To clear the active filters, click **Reset**." / "The **Reset** button appears only while a filter is active."
**SOURCE:** "Click **Clear filters** to remove all active filters."
The control name is wrong. SOURCE never uses the word "Reset". Additionally, the conditional-visibility claim ("appears only while a filter is active") is **absent from SOURCE** entirely — SOURCE states the button exists in the toolbar with no visibility condition.

### CRITICAL 2 — Patch panel retitled
**Generated:** "Click it to open the **JSON Patch** panel."
**SOURCE:** "Read the patch in the slide-over that opens from the right. … The slide-over is titled **Audit Entry**."
The panel title is contradicted. SOURCE also specifies the panel opens from the right as a slide-over; the generated text drops that and substitutes an incorrect proper-noun title. (The panel *contents* — event type badge, date/time, actor — are correctly grounded.)

### CRITICAL 3 — Date filter label contradicted
**Generated:** "select a start and end date in the **Date range** picker."
**SOURCE:** "Open the date range picker, labelled **Filter by date range**."
SOURCE gives the literal UI label; the generated doc bolds a different string as if it were the label.

### CRITICAL 4 — Event filter described as single-select, with an invented default
**Generated:** "To show a single event type, select it in the event type filter. The filter defaults to **All events**."
**SOURCE:** "Open the **Event** filter and select one or more event types. The list is populated with the event types recorded for this API, and multiple selections are combined."
Two violations in one sentence pair: (a) SOURCE explicitly documents multi-select with combined selections, which the generated text contradicts by restricting the reader to one type; (b) the default value **All events** appears nowhere in SOURCE (case-insensitive scan: no "all events", no default-state description for this filter). The filter's control name is also **Event** in SOURCE, not "event type filter".

### CRITICAL 5 — Empty state replaced with an invented "introduction"
**Generated:** "Until the first audit event is recorded for the proxy, the page shows an introduction to audit logs instead of the table."
**SOURCE:** "If the proxy has no recorded changes and no filters are applied, the screen shows the empty state `No audit entries yet` with the description `Changes to this API will appear here as they happen.`"
SOURCE describes a titled empty state with a specific description string. "An introduction to audit logs" is not that, and is not present in SOURCE in any form. The two literal, user-visible strings are also dropped while the sibling error string is retained — inconsistent treatment of the same class of evidence.

### CRITICAL 6 — Console navigation path fabricated
**Generated:** Steps 1–3: "From the Gamma console sidebar, select **Agent Management**." → "Under **Secure**, select **LLM Proxies**, **MCP Proxies**, or **A2A Proxies**." → "Select the proxy you want to inspect."
**SOURCE:** "Open the detail view of your **LLM**, **MCP** or **A2A** proxy."
SOURCE supplies no top-level navigation. The strings **Agent Management**, **Secure**, **LLM Proxies**, **MCP Proxies**, **A2A Proxies** (plural list-page labels) do not appear in SOURCE — a case-insensitive scan finds only the singular proxy-type names. Even if this path is correct in the product, it is unverifiable from the materials supplied and must be traced or removed. Note that step 4 correctly drops SOURCE's "expand the **Monitoring** group" gesture in favour of "Under **Monitoring**, select **Audit Logs**" — acceptable paraphrase of an expandable group.

### CRITICAL 7 — Verification procedure invented
**Generated:**
> 1. Save a configuration change to the proxy.
> 2. Under **Monitoring**, select **Audit Logs**.
> 3. The trail lists a new entry for the change, with your user as the **Actor**.

**SOURCE:** verification blocks assert *rendered strings* only — the heading and its description, the empty-state pair, the error string, and the no-results pair. SOURCE nowhere states that saving a configuration change produces an audit entry, nor that the acting user appears as **Actor** for a change you make. The Actor column is defined as "Display name of the user who made the change", which supports the column semantics but not the round-trip guarantee that a save *will* be recorded. This is an inferred behavioural promise, and it is the kind of promise a reader will hold the product to.

### MODERATE 8 — Permission scope narrowed
**Generated:** "the **API_AUDIT** permission with the **READ** access level on the proxy."
**SOURCE:** "The **API_AUDIT** permission with the **READ** access level on the proxy's **API**."
The permission is scoped to the proxy's underlying API, not to the proxy object. Small but load-bearing for anyone assigning roles.

### Correctly grounded (no action)
- `You don't have permission to view audit logs for this API.` — verbatim, correct context.
- `Failed to load audit logs. Please try again.` — verbatim.
- `No audit logs found` — verbatim (description string omitted; acceptable trim).
- Monitoring group hidden without permission — grounded.
- Columns Date / Actor / Event / Target, with Target as one `key: value` pair per line — grounded.
- Page sizes 10 (default), 25, 50, 100 — grounded and correctly recomposed.
- "Changing the page size returns the table to the first page" and "Changing a filter returns the table to the first page" — grounded (SOURCE: event filter, date range, page size all reset to page 1).
- "The end date is inclusive" — a clean, publishable rendering of SOURCE's `23:59:59.999` bound.
- **View patch** button "appears at the end of its row" only for entries carrying a patch — grounded against the unlabeled column.
- Patch panel showing event type, date and time, actor — grounded.

---

## PLACEMENT & PROPORTIONALITY ISSUES

**1. PUBLISHABILITY — Unactionable purpose framing.**
"Use the trail to trace configuration changes for governance reviews and troubleshooting." The reader cannot see, set, or receive this. It is benign but it is also the only sentence on the page carrying no console referent; SOURCE's overview is purely descriptive of the screen. Trim or fold into the description frontmatter.

**2. PUBLISHABILITY — Author scaffolding left in shipped output.**
The file contains a live HTML comment `<!-- TODO: Screenshot of the audit trail showing the new entry after a configuration change -->` and an image reference to `PLACEHOLDER-gamma-aim-audit-logs-verification.png`. These render as a broken image in published output and expose drafting state to readers. The deterministic counter scored `publishability_blocking=0`, but the PLACEHOLDER asset and the TODO are both blocking in practice.

**3. Under-coverage of the patch section relative to SOURCE weight.**
SOURCE devotes a full section to patch inspection, including one user-visible string the reader will actually encounter: `No patch recorded for this entry.` The generated page omits it. (Correctly omitted from the same paragraph: two-space re-indentation, nested unwrapping of serialized values, primitive/invalid-JSON pass-through, and the 60%-viewport scroll threshold — these are serialization and parser mechanics and have no place on a user page. Good judgment there.)

**4. Missing "not sortable" affordance note.**
SOURCE states "Columns are not sortable." This is a see-it-in-the-console fact that prevents a reader from hunting for sort arrows. Low cost to include; currently absent.

**5. Target column empty value dropped.**
SOURCE: "an entry with no properties shows `—`". Small but visible; the reader will otherwise wonder what the dash means.

---

## STRUCTURAL QUALITY ISSUES

**1. No SUMMARY navigation entry supplied.**
The audit context includes no `SUMMARY.md` modification. A new page at `docs/gamma/4.13/agent-management/observe/review-audit-logs.md` will not appear in the sidebar without one. Confirm the entry exists or add it.

**2. Directory vs. documented navigation mismatch.**
The file sits under `.../agent-management/observe/`, while the page body routes the reader through **Agent Management → Secure → … → Monitoring**. Neither "observe" nor "Secure" is grounded in SOURCE; at minimum the on-page path and the on-disk placement should agree with each other and with the sibling pages in `observe/`.

**3. Three unverifiable image assets.**
`gamma-aim-audit-logs.png`, `gamma-aim-audit-logs-event-filter.png`, and the PLACEHOLDER verification asset. The first two are plausible but unconfirmed; the third is a known-missing file. Verify all three exist in `.gitbook/assets/` before publish.

**4. Verification section shape differs from SOURCE's model.**
SOURCE's verification blocks assert observable rendered strings. The generated page substitutes a mutate-then-observe procedure. Beyond the grounding problem (CRITICAL 7), check whether sibling pages in this section carry a `## Verification` heading at all; if they do not, this section type is an outlier.

**5. Style scan — clean.**
No em dashes, no semicolons, no arrow breadcrumbs, no British spellings (note that SOURCE's "labelled" was correctly not carried through). Contractions are used consistently ("isn't", "can't"). Heading hierarchy is sound: single H1, flat H2s, no orphaned H3s. Table is well formed with a single alignment style.

---

## DETAILED GROUNDING ANALYSIS

| # | Generated claim | SOURCE status | Verdict |
|---|---|---|---|
| 1 | Audit Logs page on LLM/MCP/A2A proxy detail view | "Each LLM, MCP and A2A proxy detail view includes an **Audit Logs** screen" | GROUNDED |
| 2 | Entry records when / who / which event / object applied to | "when the change happened, who made it, which event was recorded, and the affected target" | GROUNDED |
| 3 | "governance reviews and troubleshooting" | absent | PUBLISHABILITY (unactionable framing) |
| 4 | Sidebar → **Agent Management** → **Secure** → **LLM/MCP/A2A Proxies** | absent | **CRITICAL 6** |
| 5 | Under **Monitoring**, select **Audit Logs** | "expand the **Monitoring** group. Click **Audit Logs**." | GROUNDED |
| 6 | "shows an introduction to audit logs instead of the table" | contradicted by `No audit entries yet` + description | **CRITICAL 5** |
| 7 | **API_AUDIT** / **READ** "on the proxy" | SOURCE scopes to "the proxy's API" | MODERATE 8 |
| 8 | Monitoring group hidden without permission | verbatim | GROUNDED |
| 9 | `You don't have permission to view audit logs for this API.` | verbatim | GROUNDED |
| 10 | `Failed to load audit logs. Please try again.` | verbatim | GROUNDED |
| 11 | Columns Date / Actor / Event / Target | matches SOURCE table | GROUNDED |
| 12 | Target = one `key: value` pair per line | verbatim | GROUNDED |
| 13 | Target `—` when no properties | present in SOURCE, omitted | OMISSION (P&P 5) |
| 14 | Columns not sortable | present in SOURCE, omitted | OMISSION (P&P 4) |
| 15 | 10 default; 25, 50, 100 available | "`10`, `25`, `50` and `100`; the default is `10`" | GROUNDED |
| 16 | Page-size change → first page | "Changing … the page size returns the table to page 1" | GROUNDED |
| 17 | "select a single event type" | contradicts "select one or more … multiple selections are combined" | **CRITICAL 4a** |
| 18 | Filter defaults to **All events** | absent | **CRITICAL 4b** |
| 19 | Filter list populated from events recorded for this API | present in SOURCE, omitted | OMISSION (minor) |
| 20 | **Date range** picker | SOURCE label is **Filter by date range** | **CRITICAL 3** |
| 21 | "The end date is inclusive" | `23:59:59.999` of last day | GROUNDED (well rendered) |
| 22 | Click **Reset** to clear filters | SOURCE: **Clear filters** | **CRITICAL 1a** |
| 23 | **Reset** appears only while a filter is active | absent | **CRITICAL 1b** |
| 24 | Filter change → first page | grounded | GROUNDED |
| 25 | `No audit logs found` | verbatim (description trimmed) | GROUNDED |
| 26 | **View patch** button on entries carrying a patch | "shown only for entries that carry a patch" | GROUNDED |
| 27 | Opens the **JSON Patch** panel | SOURCE: slide-over titled **Audit Entry**, opens from the right | **CRITICAL 2** |
| 28 | Panel shows event type, date and time, actor | badge with event type; description combining date/time with actor display name | GROUNDED |
| 29 | `No patch recorded for this entry.` | present in SOURCE, omitted | OMISSION (P&P 3) |
| 30 | Two-space indent / nested unwrapping / 60% viewport | present in SOURCE, correctly omitted | GOOD JUDGMENT |
| 31 | Verification: save a change → new entry with your user as Actor | absent | **CRITICAL 7** |
| 32 | TODO comment + PLACEHOLDER image | n/a | PUBLISHABILITY (P&P 2) |

### Required remediation, in priority order
1. Restore literal control names: **Clear filters**, **Filter by date range**, **Event**, and slide-over title **Audit Entry** (opening from the right).
2. Rewrite the filter step for multi-select ("select one or more event types; selections are combined") and delete the **All events** default.
3. Replace the "introduction to audit logs" sentence with the grounded empty state: `No audit entries yet` / `Changes to this API will appear here as they happen.`
4. Remove or source-verify the three-step console navigation path.
5. Replace the invented verification procedure with SOURCE-grounded rendered-string checks, or drop the section.
6. Delete the TODO comment and the PLACEHOLDER figure; verify the two remaining assets exist.
7. Re-scope the permission to the proxy's **API**.
8. Add the `—` empty-target note, the "columns are not sortable" note, and `No patch recorded for this entry.`
9. Confirm the SUMMARY entry and reconcile `observe/` placement with the documented navigation.

</details>