### PR TITLE
AGENT-DRAFT: AIAM-71 — Review audit logs

### DIFF
--- a/docs/gamma/4.13/agent-management/observe/review-audit-logs.md
+++ b/docs/gamma/4.13/agent-management/observe/review-audit-logs.md
@@ -10,6 +10,8 @@ Each LLM Proxy, MCP Proxy, and A2A Proxy detail view includes an **Audit Logs** 
 
 ## Open the Audit Logs page
 
+Before you start, make sure your role grants the API_AUDIT permission with Read access for the proxy. Without it, the **Monitoring** group isn't shown in the proxy sidebar, and opening the page directly shows `You don't have permission to view audit logs for this API.` instead of the table.
+
 1. From the Gamma console sidebar, select **Agent Management**.
 2. Under **Secure**, select **LLM Proxies**, **MCP Proxies**, or **A2A Proxies**.
 3. Select the proxy you want to inspect.
@@ -30,7 +32,11 @@ The table lists one row per audit event, with the following columns:
 | **Event**  | The event type identifier.                                                         |
 | **Target** | The properties of the object the event applied to, one `key: value` pair per line. |
 
+When an entry has no properties, the **Target** column shows a dash.
+
 The table shows 10 entries per page by default and supports page sizes of 25, 50, and 100.
+
+If the trail can't be retrieved, the page shows `Failed to load audit logs. Please try again.`
 
 ## Filter the trail
 
@@ -41,11 +47,13 @@ The table shows 10 entries per page by default and supports page sizes of 25, 50
 2. To bound the trail in time, select a start and end date in the **Date range** picker. The end date is inclusive.
 3. To clear the active filters, click **Reset**. The **Reset** button appears only while a filter is active.
 
-Changing a filter returns the table to the first page.
+Changing a filter returns the table to the first page. Changing the page size also returns the table to the first page.
+
+When no entry matches the active filters, the table shows `No audit logs found` and `Try adjusting or clearing your filters.`
 
 ## View the change as a JSON Patch
 
-When an audit entry carries the JSON Patch of the change, a **View patch** button appears at the end of its row. Click it to open the **JSON Patch** panel, which shows the patch that the audited change applied.
+When an audit entry carries the JSON Patch of the change, a **View patch** button appears at the end of its row. Click it to open the **JSON Patch** panel, which shows the patch that the audited change applied. The panel header shows the event type, with the timestamp and the actor below it. The patch is shown as read-only, pretty-printed JSON. Close the panel to return to the table.
 
 ## Verification
 


### PR DESCRIPTION
Automated update: aiam-71

Product: gamma
Version: 4.13

---

## Release deliverables (Step 0)

- release notes page not found at docs/gamma/4.13/release-information/release-notes/gamma-4.13.md — create it first, then re-run
- No breaking change declared on this run (`breakingChange` not set).
- Version overrides: no .version-overrides at docs/gamma/4.13/.version-overrides, nothing added.

## Publishability gate

**Verdict: PASS**
- Nothing flagged



> Only lines this PR **adds** are judged. Pre-existing page content is never touched
> and never counted, so an already-dirty page is not penalised for debt it inherited.
> Removed items are gone from the committed file. Review items are left in place for
> you to decide on, because a blocked run produces no PR at all.