### PR TITLE
docs(apim): document the stream-ended-early and unexpected-error keys

### DIFF
--- a/docs/apim/4.12/analyze-and-monitor-apis/gateway-error-key-reference.md
+++ b/docs/apim/4.12/analyze-and-monitor-apis/gateway-error-key-reference.md
@@ -20,7 +20,7 @@ Two properties of these keys matter when you read them.
 
 The Gateway raises these keys while it acts as an HTTP client towards the backend.
 
-<table><thead><tr><th width="80">Status</th><th width="330">Error key</th><th>What it means</th></tr></thead><tbody><tr><td>502</td><td><code>GATEWAY_CLIENT_CONNECTION_ERROR</code></td><td>Umbrella key. A backend connection failed for a reason that no more specific key covers.</td></tr><tr><td>502</td><td><code>GATEWAY_CLIENT_CONNECTION_REFUSED</code></td><td>The backend refused the TCP connection. Nothing listens on that port.</td></tr><tr><td>502</td><td><code>GATEWAY_CLIENT_DNS_RESOLUTION_ERROR</code></td><td>The backend hostname didn't resolve.</td></tr><tr><td>502</td><td><code>GATEWAY_CLIENT_UNREACHABLE</code></td><td>No network route to the backend host exists.</td></tr><tr><td>502</td><td><code>GATEWAY_CLIENT_TLS_HANDSHAKE_ERROR</code></td><td>The TLS handshake with the backend failed: certificate, protocol, or cipher mismatch.</td></tr><tr><td>502</td><td><code>GATEWAY_CLIENT_CONNECTION_RESET</code></td><td>The backend reset the connection with a TCP RST, or sent an HTTP/2 RST_STREAM.</td></tr><tr><td>502</td><td><code>GATEWAY_CLIENT_CONNECTION_CLOSED</code></td><td>The connection closed while a response was still expected. See the note that follows this table.</td></tr><tr><td>503</td><td><code>GATEWAY_CLIENT_CONNECTION_POOL_EXHAUSTED</code></td><td>The connection pool and its wait queue are both full, so the Gateway sheds the load deliberately. The request never reached the backend, and it can be retried.</td></tr><tr><td>504</td><td><code>GATEWAY_CLIENT_CONNECT_TIMEOUT</code></td><td>No connection was obtained in time: pool saturation, slow DNS, or slow TCP connect. The request never reached the backend.</td></tr><tr><td>504</td><td><code>GATEWAY_CLIENT_READ_TIMEOUT</code></td><td>A connection was obtained and the request was sent, but the backend stayed silent for longer than <code>readTimeout</code>.</td></tr><tr><td>504</td><td><code>REQUEST_TIMEOUT</code></td><td>Umbrella key for the two timeout keys. Also the key that the Gateway-wide request timeout produces.</td></tr></tbody></table>
+<table><thead><tr><th width="80">Status</th><th width="330">Error key</th><th>What it means</th></tr></thead><tbody><tr><td>502</td><td><code>GATEWAY_CLIENT_CONNECTION_ERROR</code></td><td>Umbrella key. A backend connection failed for a reason that no more specific key covers.</td></tr><tr><td>502</td><td><code>GATEWAY_CLIENT_CONNECTION_REFUSED</code></td><td>The backend refused the TCP connection. Nothing listens on that port.</td></tr><tr><td>502</td><td><code>GATEWAY_CLIENT_DNS_RESOLUTION_ERROR</code></td><td>The backend hostname didn't resolve.</td></tr><tr><td>502</td><td><code>GATEWAY_CLIENT_UNREACHABLE</code></td><td>No network route to the backend host exists.</td></tr><tr><td>502</td><td><code>GATEWAY_CLIENT_TLS_HANDSHAKE_ERROR</code></td><td>The TLS handshake with the backend failed: certificate, protocol, or cipher mismatch.</td></tr><tr><td>502</td><td><code>GATEWAY_CLIENT_CONNECTION_RESET</code></td><td>The backend reset the connection with a TCP RST, or sent an HTTP/2 RST_STREAM.</td></tr><tr><td>502</td><td><code>GATEWAY_CLIENT_CONNECTION_CLOSED</code></td><td>The connection closed before any response reached the API consumer. See the note that follows this table.</td></tr><tr><td>—</td><td><code>GATEWAY_CLIENT_STREAM_ENDED_EARLY</code></td><td>The backend ended the response body before it was complete, after the status and the headers had already been sent. The API consumer received a valid response with a truncated body, so the status stays as it was, usually <code>200</code>. Available from 4.12.16.</td></tr><tr><td>503</td><td><code>GATEWAY_CLIENT_CONNECTION_POOL_EXHAUSTED</code></td><td>The connection pool and its wait queue are both full, so the Gateway sheds the load deliberately. The request never reached the backend, and it can be retried.</td></tr><tr><td>504</td><td><code>GATEWAY_CLIENT_CONNECT_TIMEOUT</code></td><td>No connection was obtained in time: pool saturation, slow DNS, or slow TCP connect. The request never reached the backend.</td></tr><tr><td>504</td><td><code>GATEWAY_CLIENT_READ_TIMEOUT</code></td><td>A connection was obtained and the request was sent, but the backend stayed silent for longer than <code>readTimeout</code>.</td></tr><tr><td>504</td><td><code>REQUEST_TIMEOUT</code></td><td>Umbrella key for the two timeout keys. Also the key that the Gateway-wide request timeout produces.</td></tr></tbody></table>
 
 The two timeout keys carry `REQUEST_TIMEOUT` as their parent. Every other key in this table carries `GATEWAY_CLIENT_CONNECTION_ERROR`.
 
@@ -28,20 +28,31 @@ The two timeout keys carry `REQUEST_TIMEOUT` as their parent. Every other key in
 `GATEWAY_CLIENT_CONNECTION_POOL_EXHAUSTED` is the one key whose status differs from its parent's: `503` against `502`. With no response template in play, it returns `503` as expected. But a template configured on `GATEWAY_CLIENT_CONNECTION_ERROR` — or a `DEFAULT` one — applies to it as well, and a template always dictates the status: pool exhaustion then reaches the consumer as `502`. Give this key a template of its own when the distinction matters.
 {% endhint %}
 
-### On `GATEWAY_CLIENT_CONNECTION_CLOSED`
+### On `GATEWAY_CLIENT_CONNECTION_CLOSED` and `GATEWAY_CLIENT_STREAM_ENDED_EARLY`
 
-This key is misread more often than any other. It doesn't mean that the API consumer went away, and it doesn't mean that the Gateway timed out. It means the connection closed while the response was still incomplete in HTTP terms.
+These keys are misread more often than any other. Neither means that the API consumer went away, and neither means that the Gateway timed out. Both mean the connection closed while the response was still incomplete in HTTP terms.
 
-The common case on streaming APIs: the backend announces `Transfer-Encoding: chunked`, sends data, then closes without the terminating zero-length chunk. Any HTTP client sees the same thing. `curl` reports `transfer closed with outstanding read data remaining`.
+What separates them is **how far the response had got**:
+
+* `GATEWAY_CLIENT_STREAM_ENDED_EARLY` — the status and the headers had already been sent. The API consumer received a valid response, only with a truncated body. The request did not fail, so the status stays as it was and no response template applies.
+* `GATEWAY_CLIENT_CONNECTION_CLOSED` — nothing had reached the API consumer yet, so the Gateway answers `502`.
+
+The common case on streaming APIs is the first: the backend announces `Transfer-Encoding: chunked`, sends data, then closes without the terminating zero-length chunk. Any HTTP client sees the same thing. `curl` reports `transfer closed with outstanding read data remaining`.
 
 A backend that closes *cleanly*, on a response with no announced length, produces **no error key at all**. Closing is a legitimate way to delimit the body in that case.
+
+{% hint style="info" %}
+`GATEWAY_CLIENT_STREAM_ENDED_EARLY` is available from **4.12.16**. Before that version, a truncated body was reported as `GATEWAY_CLIENT_CONNECTION_CLOSED`, like a connection that never delivered anything. If your dashboards filter on `GATEWAY_CLIENT_CONNECTION_CLOSED` to track truncated responses, add the new key to the condition when you upgrade.
+{% endhint %}
 
 {% hint style="warning" %}
 **Check your timeout settings before you blame the backend.**
 
-This key is also what you get when the Gateway closes the connection itself, on its own `idleTimeout`. The two are indistinguishable in the reporting: same key, same message, same status.
+Both keys are also what you get when the Gateway closes the connection itself, on the endpoint's own `idleTimeout`.
 
-The duration tells them apart. An `idleTimeout` produces the same duration every time, within a few milliseconds of the configured value. A genuine backend problem produces scattered durations.
+From 4.12.16 the error message tells you: it states how long the backend had been silent, and, when that silence matches the configured `idleTimeout`, that the Gateway is the likely closer, naming the values involved.
+
+On earlier versions the duration is the only clue. An `idleTimeout` produces the same duration every time, within a few milliseconds of the configured value. A genuine backend problem produces scattered durations. Note that the silence, not the total duration of the exchange, is what to compare: `idleTimeout` restarts on every byte received.
 
 For the configuration that causes this, see [Timeout management](../prepare-a-production-environment/timeout-management.md#distinguish-a-backend-closure-from-an-idle-timeout).
 {% endhint %}
@@ -58,7 +69,22 @@ These keys never overlap with the backend connection keys. An abort by the API c
 
 ## Request handling and routing
 
-<table><thead><tr><th width="80">Status</th><th width="330">Error key</th><th>What it means</th></tr></thead><tbody><tr><td>400</td><td><code>REQUEST_NULL_BYTE_REJECTED</code></td><td>The request contained a null byte, and was rejected before processing.</td></tr><tr><td>400</td><td><code>INVALID_HTTP_METHOD</code></td><td>The HTTP method isn't usable for this endpoint.</td></tr><tr><td>400</td><td><code>CORS_PREFLIGHT_FAILED</code></td><td>The CORS preflight request didn't satisfy the configured policy.</td></tr><tr><td>401</td><td><code>GATEWAY_PLAN_UNRESOLVABLE</code></td><td>No plan could be resolved for the request: missing or invalid credentials, or no matching subscription.</td></tr><tr><td>404</td><td><code>FLOW_EXECUTION_FLOW_MATCHED_FAILURE</code></td><td>No flow matched the request while flow matching was mandatory.</td></tr><tr><td>500</td><td><code>GATEWAY_POLICY_INTERNAL_ERROR</code></td><td>A policy failed unexpectedly while streaming.</td></tr><tr><td>503</td><td><code>NO_ENDPOINT_FOUND</code></td><td>The endpoint targeted by the request doesn't exist or isn't available. Often a dynamic routing target that matches no declared endpoint.</td></tr></tbody></table>
+<table><thead><tr><th width="80">Status</th><th width="330">Error key</th><th>What it means</th></tr></thead><tbody><tr><td>400</td><td><code>REQUEST_NULL_BYTE_REJECTED</code></td><td>The request contained a null byte, and was rejected before processing.</td></tr><tr><td>400</td><td><code>INVALID_HTTP_METHOD</code></td><td>The HTTP method isn't usable for this endpoint.</td></tr><tr><td>400</td><td><code>CORS_PREFLIGHT_FAILED</code></td><td>The CORS preflight request didn't satisfy the configured policy.</td></tr><tr><td>401</td><td><code>GATEWAY_PLAN_UNRESOLVABLE</code></td><td>No plan could be resolved for the request: missing or invalid credentials, or no matching subscription.</td></tr><tr><td>404</td><td><code>FLOW_EXECUTION_FLOW_MATCHED_FAILURE</code></td><td>No flow matched the request while flow matching was mandatory.</td></tr><tr><td>500</td><td><code>GATEWAY_POLICY_INTERNAL_ERROR</code></td><td>A policy failed unexpectedly while streaming.</td></tr><tr><td>500</td><td><code>GATEWAY_UNEXPECTED_ERROR</code></td><td>An error reached the end of the Gateway's processing chain without being turned into a proper failure. See the note that follows this table. Available from 4.12.16.</td></tr><tr><td>503</td><td><code>NO_ENDPOINT_FOUND</code></td><td>The endpoint targeted by the request doesn't exist or isn't available. Often a dynamic routing target that matches no declared endpoint.</td></tr></tbody></table>
+
+### On `GATEWAY_UNEXPECTED_ERROR`
+
+The Gateway answers a bare `500` when an error reaches the end of its processing chain without having been turned into a proper failure — no response template applies on that path, so the body is empty.
+
+Two things make this outcome easy to misread, and both are addressed from 4.12.16:
+
+* **The status you see is not always the one the failure called for.** The `500` overwrites whatever status the request had reached. A request can therefore be reported as a `500` while carrying an error key that belongs to another status, such as a `GATEWAY_CLIENT_` key normally answered with a `502`. The Gateway log now states the status it replaced.
+* **The request used to carry no key at all**, which reads as a success in any dashboard that counts failures by key. It now carries `GATEWAY_UNEXPECTED_ERROR`, with the cause in the message.
+
+When an error key had already been attributed to the request, that key is kept — it names what actually went wrong — and the unexpected failure is recorded alongside it as a **warning**, carrying the exception. Warnings appear in the Issues panel of the request details in the Console.
+
+{% hint style="info" %}
+The Gateway log line for this path is `Unexpected error while handling request`. From 4.12.16 it carries the request and transaction ids, the status being replaced, the error already attributed, the endpoint, the elapsed time, and the cause — enough to conclude without correlating anything.
+{% endhint %}
 
 ## Responses with no error key
 

--- a/docs/apim/4.12/analyze-and-monitor-apis/gateway-error-key-reference.md
+++ b/docs/apim/4.12/analyze-and-monitor-apis/gateway-error-key-reference.md
@@ -30,12 +30,12 @@ The two timeout keys carry `REQUEST_TIMEOUT` as their parent. Every other key in
 
 ### On `GATEWAY_CLIENT_CONNECTION_CLOSED` and `GATEWAY_CLIENT_STREAM_ENDED_EARLY`
 
-These keys are misread more often than any other. Neither means that the API consumer went away, and neither means that the Gateway timed out. Both mean the connection closed while the response was still incomplete in HTTP terms.
+These keys are misread more often than any other key. Neither means that the API consumer went away, and neither means that the Gateway timed out. Both mean the connection closed while the response was still incomplete in HTTP terms.
 
-What separates them is **how far the response had got**:
+The following two keys differ in **how far the response had progressed**:
 
-* `GATEWAY_CLIENT_STREAM_ENDED_EARLY` — the status and the headers had already been sent. The API consumer received a valid response, only with a truncated body. The request did not fail, so the status stays as it was and no response template applies.
-* `GATEWAY_CLIENT_CONNECTION_CLOSED` — nothing had reached the API consumer yet, so the Gateway answers `502`.
+* `GATEWAY_CLIENT_STREAM_ENDED_EARLY`. The status and the headers had already been sent. The API consumer received a valid response, only with a truncated body. The request didn't fail, so the status stays as it was and no response template applies.
+* `GATEWAY_CLIENT_CONNECTION_CLOSED`. Nothing had reached the API consumer yet, so the Gateway answers `502`.
 
 The common case on streaming APIs is the first: the backend announces `Transfer-Encoding: chunked`, sends data, then closes without the terminating zero-length chunk. Any HTTP client sees the same thing. `curl` reports `transfer closed with outstanding read data remaining`.
 
@@ -50,9 +50,9 @@ A backend that closes *cleanly*, on a response with no announced length, produce
 
 Both keys are also what you get when the Gateway closes the connection itself, on the endpoint's own `idleTimeout`.
 
-From 4.12.16 the error message tells you: it states how long the backend had been silent, and, when that silence matches the configured `idleTimeout`, that the Gateway is the likely closer, naming the values involved.
+From 4.12.16, the error message states how long the backend had been silent. When that silence matches the configured `idleTimeout`, the message also says that the Gateway is the likely closer, and names the values involved.
 
-On earlier versions the duration is the only clue. An `idleTimeout` produces the same duration every time, within a few milliseconds of the configured value. A genuine backend problem produces scattered durations. Note that the silence, not the total duration of the exchange, is what to compare: `idleTimeout` restarts on every byte received.
+On earlier versions, the duration is the only clue. An `idleTimeout` produces the same duration every time, within a few milliseconds of the configured value. A genuine backend problem produces scattered durations. Compare the silence, not the total duration of the exchange: `idleTimeout` restarts on every byte received.
 
 For the configuration that causes this, see [Timeout management](../prepare-a-production-environment/timeout-management.md#distinguish-a-backend-closure-from-an-idle-timeout).
 {% endhint %}
@@ -73,17 +73,17 @@ These keys never overlap with the backend connection keys. An abort by the API c
 
 ### On `GATEWAY_UNEXPECTED_ERROR`
 
-The Gateway answers a bare `500` when an error reaches the end of its processing chain without having been turned into a proper failure — no response template applies on that path, so the body is empty.
+The Gateway answers a bare `500` when an error reaches the end of its processing chain without having been turned into a proper failure. No response template applies on that path, so the body is empty.
 
-Two things make this outcome easy to misread, and both are addressed from 4.12.16:
+The following two things make this outcome easy to misread, and both are addressed from 4.12.16:
 
 * **The status you see is not always the one the failure called for.** The `500` overwrites whatever status the request had reached. A request can therefore be reported as a `500` while carrying an error key that belongs to another status, such as a `GATEWAY_CLIENT_` key normally answered with a `502`. The Gateway log now states the status it replaced.
-* **The request used to carry no key at all**, which reads as a success in any dashboard that counts failures by key. It now carries `GATEWAY_UNEXPECTED_ERROR`, with the cause in the message.
+* **The request used to carry no key at all.** A missing key reads as a success in any dashboard that counts failures by key. It now carries `GATEWAY_UNEXPECTED_ERROR`, with the cause in the message.
 
-When an error key had already been attributed to the request, that key is kept — it names what actually went wrong — and the unexpected failure is recorded alongside it as a **warning**, carrying the exception. Warnings appear in the Issues panel of the request details in the Console.
+When an error key had already been attributed to the request, that key is kept. It names what actually went wrong. The unexpected failure is recorded alongside it as a **warning**, carrying the exception. Warnings appear in the Issues panel of the request details in the Console.
 
 {% hint style="info" %}
-The Gateway log line for this path is `Unexpected error while handling request`. From 4.12.16 it carries the request and transaction ids, the status being replaced, the error already attributed, the endpoint, the elapsed time, and the cause — enough to conclude without correlating anything.
+The Gateway log line for this path is `Unexpected error while handling request`. From 4.12.16, it carries the request and transaction IDs, the status being replaced, the error already attributed, the endpoint, the elapsed time, and the cause. That is enough to conclude without correlating anything.
 {% endhint %}
 
 ## Responses with no error key

--- a/docs/apim/4.12/prepare-a-production-environment/timeout-management.md
+++ b/docs/apim/4.12/prepare-a-production-environment/timeout-management.md
@@ -10,7 +10,7 @@ description: >-
 
 Timeouts apply at two independent scopes, and both run at the same time on every request:
 
-* **Gateway scope.** `http.requestTimeout` bounds the processing of the request, from the moment the Gateway receives it until the response is handed over. It applies to every API deployed on that Gateway. It does **not** bound the transfer of the response body — see below.
+* **Gateway scope.** `http.requestTimeout` bounds the processing of the request, from the moment the Gateway receives it until the response is handed over. It applies to every API deployed on that Gateway. It does **not** bound the transfer of the response body. See [Gateway request timeout](timeout-management.md#gateway-request-timeout).
 * **Endpoint scope.** The HTTP client of each endpoint or endpoint group carries its own timeouts towards the backend: `connectTimeout`, `readTimeout`, `idleTimeout`, and `keepAliveTimeout`.
 
 The two scopes don't override each other. Whichever expires first interrupts the request. An endpoint `readTimeout` longer than `http.requestTimeout` never takes effect, and the reverse is also true.
@@ -55,7 +55,7 @@ For the configuration syntax, see [Configure your HTTP server](configure-your-ht
 
 `readTimeout` bounds the wait for the backend **response**, not the whole request and not the transfer of the body. It expires when the backend has sent nothing for the configured duration, and it is **disarmed as soon as the response headers arrive**.
 
-Past that point the response is governed by `idleTimeout` alone, which is reset by each chunk. This is why a streaming API is bounded by `idleTimeout` and not by `readTimeout`, however short the latter is.
+Past that point, the response is governed by `idleTimeout` alone, which is reset by each chunk. This is why a streaming API is bounded by `idleTimeout` and not by `readTimeout`, however short the latter is.
 
 The same value also governs the acquisition of a connection from the pool, as described above.
 
@@ -65,7 +65,7 @@ When it fires, the consumer receives a `504` with the error key `GATEWAY_CLIENT_
 
 `idleTimeout` is a **connection-level** timer. It closes the connection when no data is received or sent for the configured duration. It has no notion of a request in flight, so it applies whether the connection is idle in the pool or actively carrying a request.
 
-When it closes a connection that carries a request, the failure surfaces as a `502` with the error key `GATEWAY_CLIENT_CONNECTION_CLOSED` — or, when the response had already started, as `GATEWAY_CLIENT_STREAM_ENDED_EARLY` on the status already sent. A genuine backend disconnection produces the same keys. See [Diagnose a timeout](timeout-management.md#diagnose-a-timeout).
+When it closes a connection that carries a request, the failure surfaces as a `502` with the error key `GATEWAY_CLIENT_CONNECTION_CLOSED`. When the response had already started, the key is `GATEWAY_CLIENT_STREAM_ENDED_EARLY`, recorded on the status already sent. A genuine backend disconnection produces the same keys. See [Diagnose a timeout](timeout-management.md#diagnose-a-timeout).
 
 {% hint style="warning" %}
 `idleTimeout` is configured in milliseconds but applied in whole seconds. The remainder is discarded: `12200` ms becomes 12 seconds. Any value below `1000` ms becomes `0`, which **disables the timeout** instead of tightening it.
@@ -88,7 +88,7 @@ Like `idleTimeout`, this value is applied in whole seconds.
 
 ### Keep `readTimeout` shorter than `idleTimeout`
 
-This is the one inequality that governs correctness. Both timers run while the Gateway waits for the response, and the shorter one wins. Past the response headers only `idleTimeout` remains, so it also has to suit your streaming APIs on its own.
+This is the one inequality that governs correctness. Both timers run while the Gateway waits for the response, and the shorter one wins. Past the response headers, only `idleTimeout` remains, so it also has to suit your streaming APIs on its own.
 
 * When `readTimeout` is the shorter, an unresponsive backend produces a `504` with `GATEWAY_CLIENT_READ_TIMEOUT` and a message naming the timeout, the method, and the target.
 * When `idleTimeout` is the shorter, it closes the connection first. `readTimeout` can never fire, and the failure is reported as a connection closed by the backend — a disconnection that didn't happen.
@@ -240,15 +240,15 @@ For the complete list of connectivity error keys, see [Execution transparency an
 
 ### Distinguish a backend closure from an idle timeout
 
-A connection closed mid-exchange covers two situations that used to report identically:
+A connection closed mid-exchange covers the following two situations, which used to report identically:
 
 * The backend closed the connection while the response was incomplete.
 * The Gateway closed it on its own `idleTimeout`.
 
 {% hint style="success" %}
-**From 4.12.16, the Gateway tells you which one it was.** The error message states how long the backend had been silent before the connection closed and, when that silence matches the endpoint's `idleTimeout`, says that the Gateway is the likely closer — naming the configured values:
+**From 4.12.16, the Gateway tells you which one it was.** The error message states how long the backend had been silent before the connection closed. When that silence matches the endpoint's `idleTimeout`, the message says that the Gateway is the likely closer, and names the configured values:
 
-```
+```text
 The backend ended the response body before it was complete (Connection was closed), after
 123062 ms, having received nothing from it for the last 122002 ms. This matches the endpoint
 idleTimeout (122000 ms, applied as 122000 ms), so the gateway itself likely closed this
@@ -261,9 +261,9 @@ The last two sentences only appear when the evidence supports them. On a genuine
 
 On earlier versions, the duration is the only clue. An `idleTimeout` produces the **same duration every time**, within a few milliseconds of the configured value. A genuine backend problem produces scattered durations. If your failures cluster tightly around your `idleTimeout`, and `readTimeout` is longer than it, the Gateway is the one closing the connection.
 
-Compare the **silence**, not the total duration of the exchange: `idleTimeout` restarts on every byte received, so a stream that ran for ten minutes before going quiet is still cut one `idleTimeout` after its last byte.
+Compare the **silence**, not the total duration of the exchange. `idleTimeout` restarts on every byte received, so a stream that ran for ten minutes before going quiet is still cut one `idleTimeout` after its last byte.
 
-Setting `readTimeout` below `idleTimeout` resolves the ambiguity whatever the version: the same situation then surfaces as `GATEWAY_CLIENT_READ_TIMEOUT` with a `504` and a message naming the timeout, the method, and the target.
+To resolve the ambiguity whatever the version, set `readTimeout` below `idleTimeout`. The same situation then surfaces as `GATEWAY_CLIENT_READ_TIMEOUT` with a `504` and a message naming the timeout, the method, and the target.
 
 {% hint style="info" %}
 On connection failures, the `ExecutionFailure` carries a key and a cause, but no message. In a response template, use `{#error.cause}` rather than `{#error.message}`, which is empty for these errors.

--- a/docs/apim/4.12/prepare-a-production-environment/timeout-management.md
+++ b/docs/apim/4.12/prepare-a-production-environment/timeout-management.md
@@ -10,14 +10,14 @@ description: >-
 
 Timeouts apply at two independent scopes, and both run at the same time on every request:
 
-* **Gateway scope.** `http.requestTimeout` bounds the whole request, from the moment the Gateway receives it to the moment the response completes. It applies to every API deployed on that Gateway.
+* **Gateway scope.** `http.requestTimeout` bounds the processing of the request, from the moment the Gateway receives it until the response is handed over. It applies to every API deployed on that Gateway. It does **not** bound the transfer of the response body — see below.
 * **Endpoint scope.** The HTTP client of each endpoint or endpoint group carries its own timeouts towards the backend: `connectTimeout`, `readTimeout`, `idleTimeout`, and `keepAliveTimeout`.
 
 The two scopes don't override each other. Whichever expires first interrupts the request. An endpoint `readTimeout` longer than `http.requestTimeout` never takes effect, and the reverse is also true.
 
 Timeouts can't be configured per plan. To apply different timeout behavior to different consumers, expose the backend through separate APIs with different endpoint configurations.
 
-<table><thead><tr><th width="190">Setting</th><th width="120">Scope</th><th width="110">Default (ms)</th><th>What it bounds</th></tr></thead><tbody><tr><td><code>http.requestTimeout</code></td><td>Gateway</td><td>30000</td><td>The complete request, until the response ends.</td></tr><tr><td><code>http.requestTimeoutGraceDelay</code></td><td>Gateway</td><td>30</td><td>The minimum execution window granted to the response phase.</td></tr><tr><td><code>connectTimeout</code></td><td>Endpoint</td><td>5000</td><td>Establishing the TCP connection to the backend.</td></tr><tr><td><code>readTimeout</code></td><td>Endpoint</td><td>10000</td><td>Inactivity during a request, and connection acquisition from the pool.</td></tr><tr><td><code>idleTimeout</code></td><td>Endpoint</td><td>60000</td><td>Inactivity on the connection itself, whether or not a request is in flight.</td></tr><tr><td><code>keepAliveTimeout</code></td><td>Endpoint</td><td>30000</td><td>How long an unused connection stays in the pool. HTTP/1.x only.</td></tr></tbody></table>
+<table><thead><tr><th width="190">Setting</th><th width="120">Scope</th><th width="110">Default (ms)</th><th>What it bounds</th></tr></thead><tbody><tr><td><code>http.requestTimeout</code></td><td>Gateway</td><td>30000</td><td>The processing of the request, up to the response. Not the transfer of the body.</td></tr><tr><td><code>http.requestTimeoutGraceDelay</code></td><td>Gateway</td><td>30</td><td>The minimum execution window granted to the response phase.</td></tr><tr><td><code>connectTimeout</code></td><td>Endpoint</td><td>5000</td><td>Establishing the TCP connection to the backend.</td></tr><tr><td><code>readTimeout</code></td><td>Endpoint</td><td>10000</td><td>Waiting for the backend response, and connection acquisition from the pool. Disarmed once the response headers arrive.</td></tr><tr><td><code>idleTimeout</code></td><td>Endpoint</td><td>60000</td><td>Inactivity on the connection itself, whether or not a request is in flight.</td></tr><tr><td><code>keepAliveTimeout</code></td><td>Endpoint</td><td>30000</td><td>How long an unused connection stays in the pool. HTTP/1.x only.</td></tr></tbody></table>
 
 You configure every one of these settings in milliseconds, at both scopes.
 
@@ -53,7 +53,9 @@ For the configuration syntax, see [Configure your HTTP server](configure-your-ht
 
 ### Read timeout
 
-`readTimeout` is an **inactivity timer**, not a total budget for the request. It expires only when the backend sends nothing for the configured duration. Every chunk received resets it, so a response that keeps producing data isn't interrupted, however long it runs.
+`readTimeout` bounds the wait for the backend **response**, not the whole request and not the transfer of the body. It expires when the backend has sent nothing for the configured duration, and it is **disarmed as soon as the response headers arrive**.
+
+Past that point the response is governed by `idleTimeout` alone, which is reset by each chunk. This is why a streaming API is bounded by `idleTimeout` and not by `readTimeout`, however short the latter is.
 
 The same value also governs the acquisition of a connection from the pool, as described above.
 
@@ -86,7 +88,7 @@ Like `idleTimeout`, this value is applied in whole seconds.
 
 ### Keep `readTimeout` shorter than `idleTimeout`
 
-This is the one inequality that governs correctness. Both timers run during a request in flight, and the shorter one always wins.
+This is the one inequality that governs correctness. Both timers run while the Gateway waits for the response, and the shorter one wins. Past the response headers only `idleTimeout` remains, so it also has to suit your streaming APIs on its own.
 
 * When `readTimeout` is the shorter, an unresponsive backend produces a `504` with `GATEWAY_CLIENT_READ_TIMEOUT` and a message naming the timeout, the method, and the target.
 * When `idleTimeout` is the shorter, it closes the connection first. `readTimeout` can never fire, and the failure is reported as a connection closed by the backend — a disconnection that didn't happen.
@@ -109,11 +111,11 @@ Because `readTimeout` measures inactivity, it doesn't need to accommodate the to
 
 The timer that actually governs a request depends on the protocol, and on whether the exchange is a single request-response or a long-lived stream.
 
-<table><thead><tr><th width="170">Protocol</th><th width="185">Governing timer</th><th>Notes</th></tr></thead><tbody><tr><td>HTTP/1.1</td><td><code>readTimeout</code></td><td>Reset by each chunk received. <code>idleTimeout</code> acts as the outer bound on the connection.</td></tr><tr><td>HTTP/2</td><td><code>readTimeout</code> per stream</td><td><code>idleTimeout</code> applies to the shared connection. <code>keepAliveTimeout</code> doesn't apply.</td></tr><tr><td>SSE and chunked streaming</td><td><code>readTimeout</code></td><td>Reset by each event or chunk. The heartbeat interval must stay below it.</td></tr><tr><td>WebSocket</td><td><code>idleTimeout</code></td><td><code>readTimeout</code> covers the handshake only. Reset by any traffic in either direction.</td></tr><tr><td>gRPC</td><td><code>readTimeout</code></td><td>Runs over HTTP/2. A timeout reaches the client as <code>UNAVAILABLE</code>.</td></tr></tbody></table>
+<table><thead><tr><th width="170">Protocol</th><th width="185">Governing timer</th><th>Notes</th></tr></thead><tbody><tr><td>HTTP/1.1</td><td><code>readTimeout</code> until the response headers, then <code>idleTimeout</code></td><td><code>readTimeout</code> bounds the wait for the response. Once it arrives, <code>idleTimeout</code> governs, reset by each chunk.</td></tr><tr><td>HTTP/2</td><td><code>readTimeout</code> per stream, until its response headers</td><td><code>idleTimeout</code> applies to the shared connection. <code>keepAliveTimeout</code> doesn't apply.</td></tr><tr><td>SSE and chunked streaming</td><td><code>idleTimeout</code></td><td>The stream starts with the response headers, which disarm <code>readTimeout</code>. The heartbeat interval must stay below <code>idleTimeout</code>.</td></tr><tr><td>WebSocket</td><td><code>idleTimeout</code></td><td><code>readTimeout</code> covers the handshake only. Reset by any traffic in either direction.</td></tr><tr><td>gRPC</td><td><code>readTimeout</code></td><td>Runs over HTTP/2. A timeout reaches the client as <code>UNAVAILABLE</code>.</td></tr></tbody></table>
 
 ### HTTP/1.1
 
-One connection carries one request at a time. `readTimeout` bounds inactivity within the request, and `idleTimeout` bounds the connection itself. Once the response ends and the connection returns to the pool, `keepAliveTimeout` governs how long it's retained.
+One connection carries one request at a time. `readTimeout` bounds the wait for the backend response and is disarmed once its headers arrive; `idleTimeout` bounds the connection itself, before and after that point. Once the response ends and the connection returns to the pool, `keepAliveTimeout` governs how long it's retained.
 
 ### HTTP/2
 

--- a/docs/apim/4.12/prepare-a-production-environment/timeout-management.md
+++ b/docs/apim/4.12/prepare-a-production-environment/timeout-management.md
@@ -63,7 +63,7 @@ When it fires, the consumer receives a `504` with the error key `GATEWAY_CLIENT_
 
 `idleTimeout` is a **connection-level** timer. It closes the connection when no data is received or sent for the configured duration. It has no notion of a request in flight, so it applies whether the connection is idle in the pool or actively carrying a request.
 
-When it closes a connection that carries a request, the failure surfaces as a `502` with the error key `GATEWAY_CLIENT_CONNECTION_CLOSED`. A genuine backend disconnection produces the same key and the same message. See [Diagnose a timeout](timeout-management.md#diagnose-a-timeout).
+When it closes a connection that carries a request, the failure surfaces as a `502` with the error key `GATEWAY_CLIENT_CONNECTION_CLOSED` — or, when the response had already started, as `GATEWAY_CLIENT_STREAM_ENDED_EARLY` on the status already sent. A genuine backend disconnection produces the same keys. See [Diagnose a timeout](timeout-management.md#diagnose-a-timeout).
 
 {% hint style="warning" %}
 `idleTimeout` is configured in milliseconds but applied in whole seconds. The remainder is discarded: `12200` ms becomes 12 seconds. Any value below `1000` ms becomes `0`, which **disables the timeout** instead of tightening it.
@@ -89,7 +89,7 @@ Like `idleTimeout`, this value is applied in whole seconds.
 This is the one inequality that governs correctness. Both timers run during a request in flight, and the shorter one always wins.
 
 * When `readTimeout` is the shorter, an unresponsive backend produces a `504` with `GATEWAY_CLIENT_READ_TIMEOUT` and a message naming the timeout, the method, and the target.
-* When `idleTimeout` is the shorter, it closes the connection first. `readTimeout` can never fire, and the failure is reported as `502 GATEWAY_CLIENT_CONNECTION_CLOSED` — a backend disconnection that didn't happen.
+* When `idleTimeout` is the shorter, it closes the connection first. `readTimeout` can never fire, and the failure is reported as a connection closed by the backend — a disconnection that didn't happen.
 
 The default values satisfy this rule. Inverting them changes the diagnosis rather than the behavior. The request fails at the same point either way, but the reported cause then points at the backend.
 
@@ -238,14 +238,30 @@ For the complete list of connectivity error keys, see [Execution transparency an
 
 ### Distinguish a backend closure from an idle timeout
 
-`GATEWAY_CLIENT_CONNECTION_CLOSED` covers two situations that report identically — the same key, the same `Connection was closed` message, and the same `502`:
+A connection closed mid-exchange covers two situations that used to report identically:
 
 * The backend closed the connection while the response was incomplete.
 * The Gateway closed it on its own `idleTimeout`.
 
-The duration tells them apart. An `idleTimeout` produces the **same duration every time**, within a few milliseconds of the configured value. A genuine backend problem produces scattered durations. If your failures cluster tightly around your `idleTimeout`, and `readTimeout` is longer than it, the Gateway is the one closing the connection.
+{% hint style="success" %}
+**From 4.12.16, the Gateway tells you which one it was.** The error message states how long the backend had been silent before the connection closed and, when that silence matches the endpoint's `idleTimeout`, says that the Gateway is the likely closer — naming the configured values:
 
-Setting `readTimeout` below `idleTimeout` resolves the ambiguity: the same situation then surfaces as `GATEWAY_CLIENT_READ_TIMEOUT` with a `504` and a message naming the timeout, the method, and the target.
+```
+The backend ended the response body before it was complete (Connection was closed), after
+123062 ms, having received nothing from it for the last 122002 ms. This matches the endpoint
+idleTimeout (122000 ms, applied as 122000 ms), so the gateway itself likely closed this
+connection. Note that readTimeout (240000 ms) is not shorter than idleTimeout, so it can never
+fire: lowering readTimeout below idleTimeout would surface this as a read timeout instead.
+```
+
+The last two sentences only appear when the evidence supports them. On a genuine backend failure, the message stops after the durations and makes no claim about your configuration.
+{% endhint %}
+
+On earlier versions, the duration is the only clue. An `idleTimeout` produces the **same duration every time**, within a few milliseconds of the configured value. A genuine backend problem produces scattered durations. If your failures cluster tightly around your `idleTimeout`, and `readTimeout` is longer than it, the Gateway is the one closing the connection.
+
+Compare the **silence**, not the total duration of the exchange: `idleTimeout` restarts on every byte received, so a stream that ran for ten minutes before going quiet is still cut one `idleTimeout` after its last byte.
+
+Setting `readTimeout` below `idleTimeout` resolves the ambiguity whatever the version: the same situation then surfaces as `GATEWAY_CLIENT_READ_TIMEOUT` with a `504` and a message naming the timeout, the method, and the target.
 
 {% hint style="info" %}
 On connection failures, the `ExecutionFailure` carries a key and a cause, but no message. In a response template, use `{#error.cause}` rather than `{#error.message}`, which is empty for these errors.

--- a/docs/apim/4.13/analyze-and-monitor-apis/gateway-error-key-reference.md
+++ b/docs/apim/4.13/analyze-and-monitor-apis/gateway-error-key-reference.md
@@ -20,7 +20,7 @@ Two properties of these keys matter when you read them.
 
 The Gateway raises these keys while it acts as an HTTP client towards the backend.
 
-<table><thead><tr><th width="80">Status</th><th width="330">Error key</th><th>What it means</th></tr></thead><tbody><tr><td>502</td><td><code>GATEWAY_CLIENT_CONNECTION_ERROR</code></td><td>Umbrella key. A backend connection failed for a reason that no more specific key covers.</td></tr><tr><td>502</td><td><code>GATEWAY_CLIENT_CONNECTION_REFUSED</code></td><td>The backend refused the TCP connection. Nothing listens on that port.</td></tr><tr><td>502</td><td><code>GATEWAY_CLIENT_DNS_RESOLUTION_ERROR</code></td><td>The backend hostname didn't resolve.</td></tr><tr><td>502</td><td><code>GATEWAY_CLIENT_UNREACHABLE</code></td><td>No network route to the backend host exists.</td></tr><tr><td>502</td><td><code>GATEWAY_CLIENT_TLS_HANDSHAKE_ERROR</code></td><td>The TLS handshake with the backend failed: certificate, protocol, or cipher mismatch.</td></tr><tr><td>502</td><td><code>GATEWAY_CLIENT_CONNECTION_RESET</code></td><td>The backend reset the connection with a TCP RST, or sent an HTTP/2 RST_STREAM.</td></tr><tr><td>502</td><td><code>GATEWAY_CLIENT_CONNECTION_CLOSED</code></td><td>The connection closed while a response was still expected. See the note that follows this table.</td></tr><tr><td>503</td><td><code>GATEWAY_CLIENT_CONNECTION_POOL_EXHAUSTED</code></td><td>The connection pool and its wait queue are both full, so the Gateway sheds the load deliberately. The request never reached the backend, and it can be retried.</td></tr><tr><td>504</td><td><code>GATEWAY_CLIENT_CONNECT_TIMEOUT</code></td><td>No connection was obtained in time: pool saturation, slow DNS, or slow TCP connect. The request never reached the backend.</td></tr><tr><td>504</td><td><code>GATEWAY_CLIENT_READ_TIMEOUT</code></td><td>A connection was obtained and the request was sent, but the backend stayed silent for longer than <code>readTimeout</code>.</td></tr><tr><td>504</td><td><code>REQUEST_TIMEOUT</code></td><td>Umbrella key for the two timeout keys. Also the key that the Gateway-wide request timeout produces.</td></tr></tbody></table>
+<table><thead><tr><th width="80">Status</th><th width="330">Error key</th><th>What it means</th></tr></thead><tbody><tr><td>502</td><td><code>GATEWAY_CLIENT_CONNECTION_ERROR</code></td><td>Umbrella key. A backend connection failed for a reason that no more specific key covers.</td></tr><tr><td>502</td><td><code>GATEWAY_CLIENT_CONNECTION_REFUSED</code></td><td>The backend refused the TCP connection. Nothing listens on that port.</td></tr><tr><td>502</td><td><code>GATEWAY_CLIENT_DNS_RESOLUTION_ERROR</code></td><td>The backend hostname didn't resolve.</td></tr><tr><td>502</td><td><code>GATEWAY_CLIENT_UNREACHABLE</code></td><td>No network route to the backend host exists.</td></tr><tr><td>502</td><td><code>GATEWAY_CLIENT_TLS_HANDSHAKE_ERROR</code></td><td>The TLS handshake with the backend failed: certificate, protocol, or cipher mismatch.</td></tr><tr><td>502</td><td><code>GATEWAY_CLIENT_CONNECTION_RESET</code></td><td>The backend reset the connection with a TCP RST, or sent an HTTP/2 RST_STREAM.</td></tr><tr><td>502</td><td><code>GATEWAY_CLIENT_CONNECTION_CLOSED</code></td><td>The connection closed before any response reached the API consumer. See the note that follows this table.</td></tr><tr><td>—</td><td><code>GATEWAY_CLIENT_STREAM_ENDED_EARLY</code></td><td>The backend ended the response body before it was complete, after the status and the headers had already been sent. The API consumer received a valid response with a truncated body, so the status stays as it was, usually <code>200</code>. Available from 4.12.16.</td></tr><tr><td>503</td><td><code>GATEWAY_CLIENT_CONNECTION_POOL_EXHAUSTED</code></td><td>The connection pool and its wait queue are both full, so the Gateway sheds the load deliberately. The request never reached the backend, and it can be retried.</td></tr><tr><td>504</td><td><code>GATEWAY_CLIENT_CONNECT_TIMEOUT</code></td><td>No connection was obtained in time: pool saturation, slow DNS, or slow TCP connect. The request never reached the backend.</td></tr><tr><td>504</td><td><code>GATEWAY_CLIENT_READ_TIMEOUT</code></td><td>A connection was obtained and the request was sent, but the backend stayed silent for longer than <code>readTimeout</code>.</td></tr><tr><td>504</td><td><code>REQUEST_TIMEOUT</code></td><td>Umbrella key for the two timeout keys. Also the key that the Gateway-wide request timeout produces.</td></tr></tbody></table>
 
 The two timeout keys carry `REQUEST_TIMEOUT` as their parent. Every other key in this table carries `GATEWAY_CLIENT_CONNECTION_ERROR`.
 
@@ -28,20 +28,31 @@ The two timeout keys carry `REQUEST_TIMEOUT` as their parent. Every other key in
 `GATEWAY_CLIENT_CONNECTION_POOL_EXHAUSTED` is the one key whose status differs from its parent's: `503` against `502`. With no response template in play, it returns `503` as expected. But a template configured on `GATEWAY_CLIENT_CONNECTION_ERROR` — or a `DEFAULT` one — applies to it as well, and a template always dictates the status: pool exhaustion then reaches the consumer as `502`. Give this key a template of its own when the distinction matters.
 {% endhint %}
 
-### On `GATEWAY_CLIENT_CONNECTION_CLOSED`
+### On `GATEWAY_CLIENT_CONNECTION_CLOSED` and `GATEWAY_CLIENT_STREAM_ENDED_EARLY`
 
-This key is misread more often than any other. It doesn't mean that the API consumer went away, and it doesn't mean that the Gateway timed out. It means the connection closed while the response was still incomplete in HTTP terms.
+These keys are misread more often than any other. Neither means that the API consumer went away, and neither means that the Gateway timed out. Both mean the connection closed while the response was still incomplete in HTTP terms.
 
-The common case on streaming APIs: the backend announces `Transfer-Encoding: chunked`, sends data, then closes without the terminating zero-length chunk. Any HTTP client sees the same thing. `curl` reports `transfer closed with outstanding read data remaining`.
+What separates them is **how far the response had got**:
+
+* `GATEWAY_CLIENT_STREAM_ENDED_EARLY` — the status and the headers had already been sent. The API consumer received a valid response, only with a truncated body. The request did not fail, so the status stays as it was and no response template applies.
+* `GATEWAY_CLIENT_CONNECTION_CLOSED` — nothing had reached the API consumer yet, so the Gateway answers `502`.
+
+The common case on streaming APIs is the first: the backend announces `Transfer-Encoding: chunked`, sends data, then closes without the terminating zero-length chunk. Any HTTP client sees the same thing. `curl` reports `transfer closed with outstanding read data remaining`.
 
 A backend that closes *cleanly*, on a response with no announced length, produces **no error key at all**. Closing is a legitimate way to delimit the body in that case.
+
+{% hint style="info" %}
+`GATEWAY_CLIENT_STREAM_ENDED_EARLY` is available from **4.12.16**. Before that version, a truncated body was reported as `GATEWAY_CLIENT_CONNECTION_CLOSED`, like a connection that never delivered anything. If your dashboards filter on `GATEWAY_CLIENT_CONNECTION_CLOSED` to track truncated responses, add the new key to the condition when you upgrade.
+{% endhint %}
 
 {% hint style="warning" %}
 **Check your timeout settings before you blame the backend.**
 
-This key is also what you get when the Gateway closes the connection itself, on its own `idleTimeout`. The two are indistinguishable in the reporting: same key, same message, same status.
+Both keys are also what you get when the Gateway closes the connection itself, on the endpoint's own `idleTimeout`.
 
-The duration tells them apart. An `idleTimeout` produces the same duration every time, within a few milliseconds of the configured value. A genuine backend problem produces scattered durations.
+From 4.12.16 the error message tells you: it states how long the backend had been silent, and, when that silence matches the configured `idleTimeout`, that the Gateway is the likely closer, naming the values involved.
+
+On earlier versions the duration is the only clue. An `idleTimeout` produces the same duration every time, within a few milliseconds of the configured value. A genuine backend problem produces scattered durations. Note that the silence, not the total duration of the exchange, is what to compare: `idleTimeout` restarts on every byte received.
 
 For the configuration that causes this, see [Timeout management](../prepare-a-production-environment/timeout-management.md#distinguish-a-backend-closure-from-an-idle-timeout).
 {% endhint %}
@@ -58,7 +69,22 @@ These keys never overlap with the backend connection keys. An abort by the API c
 
 ## Request handling and routing
 
-<table><thead><tr><th width="80">Status</th><th width="330">Error key</th><th>What it means</th></tr></thead><tbody><tr><td>400</td><td><code>REQUEST_NULL_BYTE_REJECTED</code></td><td>The request contained a null byte, and was rejected before processing.</td></tr><tr><td>400</td><td><code>INVALID_HTTP_METHOD</code></td><td>The HTTP method isn't usable for this endpoint.</td></tr><tr><td>400</td><td><code>CORS_PREFLIGHT_FAILED</code></td><td>The CORS preflight request didn't satisfy the configured policy.</td></tr><tr><td>401</td><td><code>GATEWAY_PLAN_UNRESOLVABLE</code></td><td>No plan could be resolved for the request: missing or invalid credentials, or no matching subscription.</td></tr><tr><td>404</td><td><code>FLOW_EXECUTION_FLOW_MATCHED_FAILURE</code></td><td>No flow matched the request while flow matching was mandatory.</td></tr><tr><td>500</td><td><code>GATEWAY_POLICY_INTERNAL_ERROR</code></td><td>A policy failed unexpectedly while streaming.</td></tr><tr><td>503</td><td><code>NO_ENDPOINT_FOUND</code></td><td>The endpoint targeted by the request doesn't exist or isn't available. Often a dynamic routing target that matches no declared endpoint.</td></tr></tbody></table>
+<table><thead><tr><th width="80">Status</th><th width="330">Error key</th><th>What it means</th></tr></thead><tbody><tr><td>400</td><td><code>REQUEST_NULL_BYTE_REJECTED</code></td><td>The request contained a null byte, and was rejected before processing.</td></tr><tr><td>400</td><td><code>INVALID_HTTP_METHOD</code></td><td>The HTTP method isn't usable for this endpoint.</td></tr><tr><td>400</td><td><code>CORS_PREFLIGHT_FAILED</code></td><td>The CORS preflight request didn't satisfy the configured policy.</td></tr><tr><td>401</td><td><code>GATEWAY_PLAN_UNRESOLVABLE</code></td><td>No plan could be resolved for the request: missing or invalid credentials, or no matching subscription.</td></tr><tr><td>404</td><td><code>FLOW_EXECUTION_FLOW_MATCHED_FAILURE</code></td><td>No flow matched the request while flow matching was mandatory.</td></tr><tr><td>500</td><td><code>GATEWAY_POLICY_INTERNAL_ERROR</code></td><td>A policy failed unexpectedly while streaming.</td></tr><tr><td>500</td><td><code>GATEWAY_UNEXPECTED_ERROR</code></td><td>An error reached the end of the Gateway's processing chain without being turned into a proper failure. See the note that follows this table. Available from 4.12.16.</td></tr><tr><td>503</td><td><code>NO_ENDPOINT_FOUND</code></td><td>The endpoint targeted by the request doesn't exist or isn't available. Often a dynamic routing target that matches no declared endpoint.</td></tr></tbody></table>
+
+### On `GATEWAY_UNEXPECTED_ERROR`
+
+The Gateway answers a bare `500` when an error reaches the end of its processing chain without having been turned into a proper failure — no response template applies on that path, so the body is empty.
+
+Two things make this outcome easy to misread, and both are addressed from 4.12.16:
+
+* **The status you see is not always the one the failure called for.** The `500` overwrites whatever status the request had reached. A request can therefore be reported as a `500` while carrying an error key that belongs to another status, such as a `GATEWAY_CLIENT_` key normally answered with a `502`. The Gateway log now states the status it replaced.
+* **The request used to carry no key at all**, which reads as a success in any dashboard that counts failures by key. It now carries `GATEWAY_UNEXPECTED_ERROR`, with the cause in the message.
+
+When an error key had already been attributed to the request, that key is kept — it names what actually went wrong — and the unexpected failure is recorded alongside it as a **warning**, carrying the exception. Warnings appear in the Issues panel of the request details in the Console.
+
+{% hint style="info" %}
+The Gateway log line for this path is `Unexpected error while handling request`. From 4.12.16 it carries the request and transaction ids, the status being replaced, the error already attributed, the endpoint, the elapsed time, and the cause — enough to conclude without correlating anything.
+{% endhint %}
 
 ## Responses with no error key
 

--- a/docs/apim/4.13/analyze-and-monitor-apis/gateway-error-key-reference.md
+++ b/docs/apim/4.13/analyze-and-monitor-apis/gateway-error-key-reference.md
@@ -30,12 +30,12 @@ The two timeout keys carry `REQUEST_TIMEOUT` as their parent. Every other key in
 
 ### On `GATEWAY_CLIENT_CONNECTION_CLOSED` and `GATEWAY_CLIENT_STREAM_ENDED_EARLY`
 
-These keys are misread more often than any other. Neither means that the API consumer went away, and neither means that the Gateway timed out. Both mean the connection closed while the response was still incomplete in HTTP terms.
+These keys are misread more often than any other key. Neither means that the API consumer went away, and neither means that the Gateway timed out. Both mean the connection closed while the response was still incomplete in HTTP terms.
 
-What separates them is **how far the response had got**:
+The following two keys differ in **how far the response had progressed**:
 
-* `GATEWAY_CLIENT_STREAM_ENDED_EARLY` — the status and the headers had already been sent. The API consumer received a valid response, only with a truncated body. The request did not fail, so the status stays as it was and no response template applies.
-* `GATEWAY_CLIENT_CONNECTION_CLOSED` — nothing had reached the API consumer yet, so the Gateway answers `502`.
+* `GATEWAY_CLIENT_STREAM_ENDED_EARLY`. The status and the headers had already been sent. The API consumer received a valid response, only with a truncated body. The request didn't fail, so the status stays as it was and no response template applies.
+* `GATEWAY_CLIENT_CONNECTION_CLOSED`. Nothing had reached the API consumer yet, so the Gateway answers `502`.
 
 The common case on streaming APIs is the first: the backend announces `Transfer-Encoding: chunked`, sends data, then closes without the terminating zero-length chunk. Any HTTP client sees the same thing. `curl` reports `transfer closed with outstanding read data remaining`.
 
@@ -50,9 +50,9 @@ A backend that closes *cleanly*, on a response with no announced length, produce
 
 Both keys are also what you get when the Gateway closes the connection itself, on the endpoint's own `idleTimeout`.
 
-From 4.12.16 the error message tells you: it states how long the backend had been silent, and, when that silence matches the configured `idleTimeout`, that the Gateway is the likely closer, naming the values involved.
+From 4.12.16, the error message states how long the backend had been silent. When that silence matches the configured `idleTimeout`, the message also says that the Gateway is the likely closer, and names the values involved.
 
-On earlier versions the duration is the only clue. An `idleTimeout` produces the same duration every time, within a few milliseconds of the configured value. A genuine backend problem produces scattered durations. Note that the silence, not the total duration of the exchange, is what to compare: `idleTimeout` restarts on every byte received.
+On earlier versions, the duration is the only clue. An `idleTimeout` produces the same duration every time, within a few milliseconds of the configured value. A genuine backend problem produces scattered durations. Compare the silence, not the total duration of the exchange: `idleTimeout` restarts on every byte received.
 
 For the configuration that causes this, see [Timeout management](../prepare-a-production-environment/timeout-management.md#distinguish-a-backend-closure-from-an-idle-timeout).
 {% endhint %}
@@ -73,17 +73,17 @@ These keys never overlap with the backend connection keys. An abort by the API c
 
 ### On `GATEWAY_UNEXPECTED_ERROR`
 
-The Gateway answers a bare `500` when an error reaches the end of its processing chain without having been turned into a proper failure — no response template applies on that path, so the body is empty.
+The Gateway answers a bare `500` when an error reaches the end of its processing chain without having been turned into a proper failure. No response template applies on that path, so the body is empty.
 
-Two things make this outcome easy to misread, and both are addressed from 4.12.16:
+The following two things make this outcome easy to misread, and both are addressed from 4.12.16:
 
 * **The status you see is not always the one the failure called for.** The `500` overwrites whatever status the request had reached. A request can therefore be reported as a `500` while carrying an error key that belongs to another status, such as a `GATEWAY_CLIENT_` key normally answered with a `502`. The Gateway log now states the status it replaced.
-* **The request used to carry no key at all**, which reads as a success in any dashboard that counts failures by key. It now carries `GATEWAY_UNEXPECTED_ERROR`, with the cause in the message.
+* **The request used to carry no key at all.** A missing key reads as a success in any dashboard that counts failures by key. It now carries `GATEWAY_UNEXPECTED_ERROR`, with the cause in the message.
 
-When an error key had already been attributed to the request, that key is kept — it names what actually went wrong — and the unexpected failure is recorded alongside it as a **warning**, carrying the exception. Warnings appear in the Issues panel of the request details in the Console.
+When an error key had already been attributed to the request, that key is kept. It names what actually went wrong. The unexpected failure is recorded alongside it as a **warning**, carrying the exception. Warnings appear in the Issues panel of the request details in the Console.
 
 {% hint style="info" %}
-The Gateway log line for this path is `Unexpected error while handling request`. From 4.12.16 it carries the request and transaction ids, the status being replaced, the error already attributed, the endpoint, the elapsed time, and the cause — enough to conclude without correlating anything.
+The Gateway log line for this path is `Unexpected error while handling request`. From 4.12.16, it carries the request and transaction IDs, the status being replaced, the error already attributed, the endpoint, the elapsed time, and the cause. That is enough to conclude without correlating anything.
 {% endhint %}
 
 ## Responses with no error key

--- a/docs/apim/4.13/prepare-a-production-environment/timeout-management.md
+++ b/docs/apim/4.13/prepare-a-production-environment/timeout-management.md
@@ -10,7 +10,7 @@ description: >-
 
 Timeouts apply at two independent scopes, and both run at the same time on every request:
 
-* **Gateway scope.** `http.requestTimeout` bounds the processing of the request, from the moment the Gateway receives it until the response is handed over. It applies to every API deployed on that Gateway. It does **not** bound the transfer of the response body — see below.
+* **Gateway scope.** `http.requestTimeout` bounds the processing of the request, from the moment the Gateway receives it until the response is handed over. It applies to every API deployed on that Gateway. It does **not** bound the transfer of the response body. See [Gateway request timeout](timeout-management.md#gateway-request-timeout).
 * **Endpoint scope.** The HTTP client of each endpoint or endpoint group carries its own timeouts towards the backend: `connectTimeout`, `readTimeout`, `idleTimeout`, and `keepAliveTimeout`.
 
 The two scopes don't override each other. Whichever expires first interrupts the request. An endpoint `readTimeout` longer than `http.requestTimeout` never takes effect, and the reverse is also true.
@@ -55,7 +55,7 @@ For the configuration syntax, see [Configure your HTTP server](configure-your-ht
 
 `readTimeout` bounds the wait for the backend **response**, not the whole request and not the transfer of the body. It expires when the backend has sent nothing for the configured duration, and it is **disarmed as soon as the response headers arrive**.
 
-Past that point the response is governed by `idleTimeout` alone, which is reset by each chunk. This is why a streaming API is bounded by `idleTimeout` and not by `readTimeout`, however short the latter is.
+Past that point, the response is governed by `idleTimeout` alone, which is reset by each chunk. This is why a streaming API is bounded by `idleTimeout` and not by `readTimeout`, however short the latter is.
 
 The same value also governs the acquisition of a connection from the pool, as described above.
 
@@ -65,7 +65,7 @@ When it fires, the consumer receives a `504` with the error key `GATEWAY_CLIENT_
 
 `idleTimeout` is a **connection-level** timer. It closes the connection when no data is received or sent for the configured duration. It has no notion of a request in flight, so it applies whether the connection is idle in the pool or actively carrying a request.
 
-When it closes a connection that carries a request, the failure surfaces as a `502` with the error key `GATEWAY_CLIENT_CONNECTION_CLOSED` — or, when the response had already started, as `GATEWAY_CLIENT_STREAM_ENDED_EARLY` on the status already sent. A genuine backend disconnection produces the same keys. See [Diagnose a timeout](timeout-management.md#diagnose-a-timeout).
+When it closes a connection that carries a request, the failure surfaces as a `502` with the error key `GATEWAY_CLIENT_CONNECTION_CLOSED`. When the response had already started, the key is `GATEWAY_CLIENT_STREAM_ENDED_EARLY`, recorded on the status already sent. A genuine backend disconnection produces the same keys. See [Diagnose a timeout](timeout-management.md#diagnose-a-timeout).
 
 {% hint style="warning" %}
 `idleTimeout` is configured in milliseconds but applied in whole seconds. The remainder is discarded: `12200` ms becomes 12 seconds. Any value below `1000` ms becomes `0`, which **disables the timeout** instead of tightening it.
@@ -88,7 +88,7 @@ Like `idleTimeout`, this value is applied in whole seconds.
 
 ### Keep `readTimeout` shorter than `idleTimeout`
 
-This is the one inequality that governs correctness. Both timers run while the Gateway waits for the response, and the shorter one wins. Past the response headers only `idleTimeout` remains, so it also has to suit your streaming APIs on its own.
+This is the one inequality that governs correctness. Both timers run while the Gateway waits for the response, and the shorter one wins. Past the response headers, only `idleTimeout` remains, so it also has to suit your streaming APIs on its own.
 
 * When `readTimeout` is the shorter, an unresponsive backend produces a `504` with `GATEWAY_CLIENT_READ_TIMEOUT` and a message naming the timeout, the method, and the target.
 * When `idleTimeout` is the shorter, it closes the connection first. `readTimeout` can never fire, and the failure is reported as a connection closed by the backend — a disconnection that didn't happen.
@@ -240,15 +240,15 @@ For the complete list of connectivity error keys, see [Execution transparency an
 
 ### Distinguish a backend closure from an idle timeout
 
-A connection closed mid-exchange covers two situations that used to report identically:
+A connection closed mid-exchange covers the following two situations, which used to report identically:
 
 * The backend closed the connection while the response was incomplete.
 * The Gateway closed it on its own `idleTimeout`.
 
 {% hint style="success" %}
-**From 4.12.16, the Gateway tells you which one it was.** The error message states how long the backend had been silent before the connection closed and, when that silence matches the endpoint's `idleTimeout`, says that the Gateway is the likely closer — naming the configured values:
+**From 4.12.16, the Gateway tells you which one it was.** The error message states how long the backend had been silent before the connection closed. When that silence matches the endpoint's `idleTimeout`, the message says that the Gateway is the likely closer, and names the configured values:
 
-```
+```text
 The backend ended the response body before it was complete (Connection was closed), after
 123062 ms, having received nothing from it for the last 122002 ms. This matches the endpoint
 idleTimeout (122000 ms, applied as 122000 ms), so the gateway itself likely closed this
@@ -261,9 +261,9 @@ The last two sentences only appear when the evidence supports them. On a genuine
 
 On earlier versions, the duration is the only clue. An `idleTimeout` produces the **same duration every time**, within a few milliseconds of the configured value. A genuine backend problem produces scattered durations. If your failures cluster tightly around your `idleTimeout`, and `readTimeout` is longer than it, the Gateway is the one closing the connection.
 
-Compare the **silence**, not the total duration of the exchange: `idleTimeout` restarts on every byte received, so a stream that ran for ten minutes before going quiet is still cut one `idleTimeout` after its last byte.
+Compare the **silence**, not the total duration of the exchange. `idleTimeout` restarts on every byte received, so a stream that ran for ten minutes before going quiet is still cut one `idleTimeout` after its last byte.
 
-Setting `readTimeout` below `idleTimeout` resolves the ambiguity whatever the version: the same situation then surfaces as `GATEWAY_CLIENT_READ_TIMEOUT` with a `504` and a message naming the timeout, the method, and the target.
+To resolve the ambiguity whatever the version, set `readTimeout` below `idleTimeout`. The same situation then surfaces as `GATEWAY_CLIENT_READ_TIMEOUT` with a `504` and a message naming the timeout, the method, and the target.
 
 {% hint style="info" %}
 On connection failures, the `ExecutionFailure` carries a key and a cause, but no message. In a response template, use `{#error.cause}` rather than `{#error.message}`, which is empty for these errors.

--- a/docs/apim/4.13/prepare-a-production-environment/timeout-management.md
+++ b/docs/apim/4.13/prepare-a-production-environment/timeout-management.md
@@ -10,14 +10,14 @@ description: >-
 
 Timeouts apply at two independent scopes, and both run at the same time on every request:
 
-* **Gateway scope.** `http.requestTimeout` bounds the whole request, from the moment the Gateway receives it to the moment the response completes. It applies to every API deployed on that Gateway.
+* **Gateway scope.** `http.requestTimeout` bounds the processing of the request, from the moment the Gateway receives it until the response is handed over. It applies to every API deployed on that Gateway. It does **not** bound the transfer of the response body — see below.
 * **Endpoint scope.** The HTTP client of each endpoint or endpoint group carries its own timeouts towards the backend: `connectTimeout`, `readTimeout`, `idleTimeout`, and `keepAliveTimeout`.
 
 The two scopes don't override each other. Whichever expires first interrupts the request. An endpoint `readTimeout` longer than `http.requestTimeout` never takes effect, and the reverse is also true.
 
 Timeouts can't be configured per plan. To apply different timeout behavior to different consumers, expose the backend through separate APIs with different endpoint configurations.
 
-<table><thead><tr><th width="190">Setting</th><th width="120">Scope</th><th width="110">Default (ms)</th><th>What it bounds</th></tr></thead><tbody><tr><td><code>http.requestTimeout</code></td><td>Gateway</td><td>30000</td><td>The complete request, until the response ends.</td></tr><tr><td><code>http.requestTimeoutGraceDelay</code></td><td>Gateway</td><td>30</td><td>The minimum execution window granted to the response phase.</td></tr><tr><td><code>connectTimeout</code></td><td>Endpoint</td><td>5000</td><td>Establishing the TCP connection to the backend.</td></tr><tr><td><code>readTimeout</code></td><td>Endpoint</td><td>10000</td><td>Inactivity during a request, and connection acquisition from the pool.</td></tr><tr><td><code>idleTimeout</code></td><td>Endpoint</td><td>60000</td><td>Inactivity on the connection itself, whether or not a request is in flight.</td></tr><tr><td><code>keepAliveTimeout</code></td><td>Endpoint</td><td>30000</td><td>How long an unused connection stays in the pool. HTTP/1.x only.</td></tr></tbody></table>
+<table><thead><tr><th width="190">Setting</th><th width="120">Scope</th><th width="110">Default (ms)</th><th>What it bounds</th></tr></thead><tbody><tr><td><code>http.requestTimeout</code></td><td>Gateway</td><td>30000</td><td>The processing of the request, up to the response. Not the transfer of the body.</td></tr><tr><td><code>http.requestTimeoutGraceDelay</code></td><td>Gateway</td><td>30</td><td>The minimum execution window granted to the response phase.</td></tr><tr><td><code>connectTimeout</code></td><td>Endpoint</td><td>5000</td><td>Establishing the TCP connection to the backend.</td></tr><tr><td><code>readTimeout</code></td><td>Endpoint</td><td>10000</td><td>Waiting for the backend response, and connection acquisition from the pool. Disarmed once the response headers arrive.</td></tr><tr><td><code>idleTimeout</code></td><td>Endpoint</td><td>60000</td><td>Inactivity on the connection itself, whether or not a request is in flight.</td></tr><tr><td><code>keepAliveTimeout</code></td><td>Endpoint</td><td>30000</td><td>How long an unused connection stays in the pool. HTTP/1.x only.</td></tr></tbody></table>
 
 You configure every one of these settings in milliseconds, at both scopes.
 
@@ -53,7 +53,9 @@ For the configuration syntax, see [Configure your HTTP server](configure-your-ht
 
 ### Read timeout
 
-`readTimeout` is an **inactivity timer**, not a total budget for the request. It expires only when the backend sends nothing for the configured duration. Every chunk received resets it, so a response that keeps producing data isn't interrupted, however long it runs.
+`readTimeout` bounds the wait for the backend **response**, not the whole request and not the transfer of the body. It expires when the backend has sent nothing for the configured duration, and it is **disarmed as soon as the response headers arrive**.
+
+Past that point the response is governed by `idleTimeout` alone, which is reset by each chunk. This is why a streaming API is bounded by `idleTimeout` and not by `readTimeout`, however short the latter is.
 
 The same value also governs the acquisition of a connection from the pool, as described above.
 
@@ -86,7 +88,7 @@ Like `idleTimeout`, this value is applied in whole seconds.
 
 ### Keep `readTimeout` shorter than `idleTimeout`
 
-This is the one inequality that governs correctness. Both timers run during a request in flight, and the shorter one always wins.
+This is the one inequality that governs correctness. Both timers run while the Gateway waits for the response, and the shorter one wins. Past the response headers only `idleTimeout` remains, so it also has to suit your streaming APIs on its own.
 
 * When `readTimeout` is the shorter, an unresponsive backend produces a `504` with `GATEWAY_CLIENT_READ_TIMEOUT` and a message naming the timeout, the method, and the target.
 * When `idleTimeout` is the shorter, it closes the connection first. `readTimeout` can never fire, and the failure is reported as a connection closed by the backend — a disconnection that didn't happen.
@@ -109,11 +111,11 @@ Because `readTimeout` measures inactivity, it doesn't need to accommodate the to
 
 The timer that actually governs a request depends on the protocol, and on whether the exchange is a single request-response or a long-lived stream.
 
-<table><thead><tr><th width="170">Protocol</th><th width="185">Governing timer</th><th>Notes</th></tr></thead><tbody><tr><td>HTTP/1.1</td><td><code>readTimeout</code></td><td>Reset by each chunk received. <code>idleTimeout</code> acts as the outer bound on the connection.</td></tr><tr><td>HTTP/2</td><td><code>readTimeout</code> per stream</td><td><code>idleTimeout</code> applies to the shared connection. <code>keepAliveTimeout</code> doesn't apply.</td></tr><tr><td>SSE and chunked streaming</td><td><code>readTimeout</code></td><td>Reset by each event or chunk. The heartbeat interval must stay below it.</td></tr><tr><td>WebSocket</td><td><code>idleTimeout</code></td><td><code>readTimeout</code> covers the handshake only. Reset by any traffic in either direction.</td></tr><tr><td>gRPC</td><td><code>readTimeout</code></td><td>Runs over HTTP/2. A timeout reaches the client as <code>UNAVAILABLE</code>.</td></tr></tbody></table>
+<table><thead><tr><th width="170">Protocol</th><th width="185">Governing timer</th><th>Notes</th></tr></thead><tbody><tr><td>HTTP/1.1</td><td><code>readTimeout</code> until the response headers, then <code>idleTimeout</code></td><td><code>readTimeout</code> bounds the wait for the response. Once it arrives, <code>idleTimeout</code> governs, reset by each chunk.</td></tr><tr><td>HTTP/2</td><td><code>readTimeout</code> per stream, until its response headers</td><td><code>idleTimeout</code> applies to the shared connection. <code>keepAliveTimeout</code> doesn't apply.</td></tr><tr><td>SSE and chunked streaming</td><td><code>idleTimeout</code></td><td>The stream starts with the response headers, which disarm <code>readTimeout</code>. The heartbeat interval must stay below <code>idleTimeout</code>.</td></tr><tr><td>WebSocket</td><td><code>idleTimeout</code></td><td><code>readTimeout</code> covers the handshake only. Reset by any traffic in either direction.</td></tr><tr><td>gRPC</td><td><code>readTimeout</code></td><td>Runs over HTTP/2. A timeout reaches the client as <code>UNAVAILABLE</code>.</td></tr></tbody></table>
 
 ### HTTP/1.1
 
-One connection carries one request at a time. `readTimeout` bounds inactivity within the request, and `idleTimeout` bounds the connection itself. Once the response ends and the connection returns to the pool, `keepAliveTimeout` governs how long it's retained.
+One connection carries one request at a time. `readTimeout` bounds the wait for the backend response and is disarmed once its headers arrive; `idleTimeout` bounds the connection itself, before and after that point. Once the response ends and the connection returns to the pool, `keepAliveTimeout` governs how long it's retained.
 
 ### HTTP/2
 

--- a/docs/apim/4.13/prepare-a-production-environment/timeout-management.md
+++ b/docs/apim/4.13/prepare-a-production-environment/timeout-management.md
@@ -63,7 +63,7 @@ When it fires, the consumer receives a `504` with the error key `GATEWAY_CLIENT_
 
 `idleTimeout` is a **connection-level** timer. It closes the connection when no data is received or sent for the configured duration. It has no notion of a request in flight, so it applies whether the connection is idle in the pool or actively carrying a request.
 
-When it closes a connection that carries a request, the failure surfaces as a `502` with the error key `GATEWAY_CLIENT_CONNECTION_CLOSED`. A genuine backend disconnection produces the same key and the same message. See [Diagnose a timeout](timeout-management.md#diagnose-a-timeout).
+When it closes a connection that carries a request, the failure surfaces as a `502` with the error key `GATEWAY_CLIENT_CONNECTION_CLOSED` — or, when the response had already started, as `GATEWAY_CLIENT_STREAM_ENDED_EARLY` on the status already sent. A genuine backend disconnection produces the same keys. See [Diagnose a timeout](timeout-management.md#diagnose-a-timeout).
 
 {% hint style="warning" %}
 `idleTimeout` is configured in milliseconds but applied in whole seconds. The remainder is discarded: `12200` ms becomes 12 seconds. Any value below `1000` ms becomes `0`, which **disables the timeout** instead of tightening it.
@@ -89,7 +89,7 @@ Like `idleTimeout`, this value is applied in whole seconds.
 This is the one inequality that governs correctness. Both timers run during a request in flight, and the shorter one always wins.
 
 * When `readTimeout` is the shorter, an unresponsive backend produces a `504` with `GATEWAY_CLIENT_READ_TIMEOUT` and a message naming the timeout, the method, and the target.
-* When `idleTimeout` is the shorter, it closes the connection first. `readTimeout` can never fire, and the failure is reported as `502 GATEWAY_CLIENT_CONNECTION_CLOSED` — a backend disconnection that didn't happen.
+* When `idleTimeout` is the shorter, it closes the connection first. `readTimeout` can never fire, and the failure is reported as a connection closed by the backend — a disconnection that didn't happen.
 
 The default values satisfy this rule. Inverting them changes the diagnosis rather than the behavior. The request fails at the same point either way, but the reported cause then points at the backend.
 
@@ -238,14 +238,30 @@ For the complete list of connectivity error keys, see [Execution transparency an
 
 ### Distinguish a backend closure from an idle timeout
 
-`GATEWAY_CLIENT_CONNECTION_CLOSED` covers two situations that report identically — the same key, the same `Connection was closed` message, and the same `502`:
+A connection closed mid-exchange covers two situations that used to report identically:
 
 * The backend closed the connection while the response was incomplete.
 * The Gateway closed it on its own `idleTimeout`.
 
-The duration tells them apart. An `idleTimeout` produces the **same duration every time**, within a few milliseconds of the configured value. A genuine backend problem produces scattered durations. If your failures cluster tightly around your `idleTimeout`, and `readTimeout` is longer than it, the Gateway is the one closing the connection.
+{% hint style="success" %}
+**From 4.12.16, the Gateway tells you which one it was.** The error message states how long the backend had been silent before the connection closed and, when that silence matches the endpoint's `idleTimeout`, says that the Gateway is the likely closer — naming the configured values:
 
-Setting `readTimeout` below `idleTimeout` resolves the ambiguity: the same situation then surfaces as `GATEWAY_CLIENT_READ_TIMEOUT` with a `504` and a message naming the timeout, the method, and the target.
+```
+The backend ended the response body before it was complete (Connection was closed), after
+123062 ms, having received nothing from it for the last 122002 ms. This matches the endpoint
+idleTimeout (122000 ms, applied as 122000 ms), so the gateway itself likely closed this
+connection. Note that readTimeout (240000 ms) is not shorter than idleTimeout, so it can never
+fire: lowering readTimeout below idleTimeout would surface this as a read timeout instead.
+```
+
+The last two sentences only appear when the evidence supports them. On a genuine backend failure, the message stops after the durations and makes no claim about your configuration.
+{% endhint %}
+
+On earlier versions, the duration is the only clue. An `idleTimeout` produces the **same duration every time**, within a few milliseconds of the configured value. A genuine backend problem produces scattered durations. If your failures cluster tightly around your `idleTimeout`, and `readTimeout` is longer than it, the Gateway is the one closing the connection.
+
+Compare the **silence**, not the total duration of the exchange: `idleTimeout` restarts on every byte received, so a stream that ran for ten minutes before going quiet is still cut one `idleTimeout` after its last byte.
+
+Setting `readTimeout` below `idleTimeout` resolves the ambiguity whatever the version: the same situation then surfaces as `GATEWAY_CLIENT_READ_TIMEOUT` with a `504` and a message naming the timeout, the method, and the target.
 
 {% hint style="info" %}
 On connection failures, the `ExecutionFailure` carries a key and a cause, but no message. In a response template, use `{#error.cause}` rather than `{#error.message}`, which is empty for these errors.


### PR DESCRIPTION
Documents the two error keys shipped in **4.12.16** by
[gravitee-api-management#19132](https://github.com/gravitee-io/gravitee-api-management/pull/19132)
(backported to `master` in
[#19184](https://github.com/gravitee-io/gravitee-api-management/pull/19184)). Neither appeared in
the reference, which is the page readers are sent to when interpreting their analytics.

Written in 4.12 and copied to 4.13. `SUMMARY.md` needs no change — both pages already exist.

## Gateway error key reference

**`GATEWAY_CLIENT_STREAM_ENDED_EARLY`** — added to the backend connection table, and the section
that used to cover only `GATEWAY_CLIENT_CONNECTION_CLOSED` now covers both, explaining what
separates them: how far the response had got. A body cut short after the status was sent is a
truncated response, not a failed request, so the status stays as it was and no response template
applies.

Its status column reads `—` rather than a number, because the status is whatever had already been
committed, usually `200`.

**`GATEWAY_UNEXPECTED_ERROR`** — added to the request handling table, with a section explaining the
two things that make the bare `500` easy to misread: the status it overwrites, and the fact that
such a request previously carried no key at all, reading as a success in any dashboard counting
failures by key.

## Timeout management

The page stated that a backend closure and an idle timeout are indistinguishable, which stopped
being true in 4.12.16. The message now names the `idleTimeout` as the likely closer, so the actual
message is quoted, with the duration heuristic kept for earlier versions.

Also corrected a subtlety the previous text glossed over: what compares to `idleTimeout` is the
**silence** before the close, not the total duration of the exchange — the timer restarts on every
byte received, so a stream running for ten minutes before going quiet is still cut one
`idleTimeout` after its last byte.

## Version notes

Every addition is marked *Available from 4.12.16*, and the reference carries a hint telling readers
to add the new key to any dashboard that filters `GATEWAY_CLIENT_CONNECTION_CLOSED` to track
truncated responses. That filter will otherwise report zero after upgrading.

Related: [FOUND-212](https://gravitee.atlassian.net/browse/FOUND-212).

---

## Second commit: correcting which timer governs a response once it has started

Bench testing the configuration for the customer surfaced two inaccuracies on the timeout page,
both measured rather than reasoned.

**The page contradicted itself on `http.requestTimeout`.** The overview and the settings table
said it bounds the request *until the response ends*; a hint further down said it stops protecting
the request once the status and headers are committed. The hint was right — a stream sending one
chunk every 10 s ran **250 s uninterrupted** with `requestTimeout` at 180 s. The reactor applies
its `timeout()` to the processing phases; `ctx.response().end(ctx)` is outside that scope.

**The protocol table was wrong in a way that could mislead SSE users.** It described `readTimeout`
as reset by each chunk, and told them to keep their heartbeat below it. `readTimeout` is in fact
disarmed as soon as the response headers arrive; past that point `idleTimeout` alone governs.

Measured twice, at two scales:

- `readTimeout` 120 s / `idleTimeout` 150 s, endpoint going silent after its headers → cut at
  **150 s**, not 120 s;
- `readTimeout` 10 s / `idleTimeout` 20 s → cut at **20 s**, and an SSE stream with a **15-second
  heartbeat**, well above `readTimeout`, ran without interruption.

A heartbeat sized against `readTimeout` is therefore sized against a timer that no longer runs.
The rule is now stated against `idleTimeout`, and the protocol table lists the governing timer per
phase rather than per protocol alone.

This is beyond the original scope of the PR, but it touches the same pages, and leaving a
measured inaccuracy in place once found seemed worse than a slightly wider diff.


[FOUND-212]: https://gravitee.atlassian.net/browse/FOUND-212?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ