### PR TITLE
docs(apim): document Virtual Cluster broker addressing and DNS

### DIFF
--- a/docs/apim/4.12/SUMMARY.md
+++ b/docs/apim/4.12/SUMMARY.md
@@ -508,6 +508,7 @@
       * [Documentation](kafka-gateway/create-and-configure-kafka-apis/configure-kafka-apis/documentation.md)
       * [Deployment](kafka-gateway/create-and-configure-kafka-apis/configure-kafka-apis/deployment.md)
   * [Create and Configure Kafka Clusters](kafka-gateway/create-and-configure-kafka-clusters.md)
+  * [Virtual Cluster Broker Addressing](kafka-gateway/virtual-cluster-broker-addressing.md)
   * [Configure and Deploy Kafka Console](kafka-gateway/configure-and-deploy-kafka-console.md)
   * [Plans](kafka-gateway/plans.md)
   * [Applications](kafka-gateway/applications.md)

--- a/docs/apim/4.12/kafka-gateway/virtual-cluster-broker-addressing.md
+++ b/docs/apim/4.12/kafka-gateway/virtual-cluster-broker-addressing.md
@@ -1,0 +1,124 @@
+---
+description: >-
+  How the Kafka Gateway rewrites broker IDs when a Kafka API is backed by a Virtual Cluster, and
+  which DNS entries and certificate SANs that requires.
+---
+
+# Virtual Cluster Broker Addressing
+
+## Overview
+
+A Virtual Cluster presents several backend Kafka clusters to clients as one. Kafka requires every broker in a cluster to have a unique ID, but two backends will happily both have a `broker.id=0`. The Gateway therefore rewrites broker IDs before advertising them, which means **the IDs clients see are not the IDs configured on your brokers**.
+
+This changes which DNS entries you need. It is the one part of the [Kafka Gateway host routing setup](configure-the-kafka-client-and-gateway.md) that a Virtual Cluster does not inherit unchanged, so read this page before exposing a Kafka API backed by a Virtual Cluster.
+
+## How broker IDs are rewritten
+
+Each backend cluster is assigned a block of 10,000 IDs, in the order the backends are listed in the Virtual Cluster configuration:
+
+```
+advertised broker ID = (backend position + 1) × 10000 + real broker ID
+```
+
+`backend position` is zero-based, so:
+
+| Backend position | Real broker IDs | Advertised IDs         |
+| ---------------- | --------------- | ---------------------- |
+| 0 (first listed) | 0, 1, 2, …      | 10000, 10001, 10002, … |
+| 1                | 0, 1, 2, …      | 20000, 20001, 20002, … |
+| 2                | 0, 1, 2, …      | 30000, 30001, 30002, … |
+
+The same rewriting applies everywhere a broker ID is visible to a client: `Metadata` responses, `DescribeCluster`, partition leaders and replicas, `FindCoordinator`, and the `resourceName` of a `BROKER` config resource.
+
+## DNS entries
+
+The broker hostname pattern is unchanged — by default `{brokerPrefix}{brokerId}{domainSeparator}{apiHost}.{defaultDomain}` — but `{brokerId}` carries the **advertised** ID, not the real one.
+
+For example, with two backends of 75 brokers each (real IDs 0–74), a Kafka API whose host prefix is `myapi`, and a default domain of `mycompany.org`:
+
+| Entry                                                                     | Resolves to             |
+| ------------------------------------------------------------------------- | ----------------------- |
+| `myapi.mycompany.org`                                                     | the Gateway (bootstrap) |
+| `broker-10000-myapi.mycompany.org` … `broker-10074-myapi.mycompany.org`   | the Gateway (backend 0) |
+| `broker-20000-myapi.mycompany.org` … `broker-20074-myapi.mycompany.org`   | the Gateway (backend 1) |
+
+All of them resolve to the same Gateway address — the Gateway tells the backends apart from the SNI, not from the IP. The same hostnames must also appear in the SAN of the certificate the Gateway presents.
+
+{% hint style="info" %}
+A wildcard DNS entry and a wildcard certificate covering `*.mycompany.org` cover every broker at once and keep working when you add a backend or scale one out. With per-broker entries, you must create new ones each time the topology changes. Use wildcards wherever your DNS and certificate policy allow it.
+{% endhint %}
+
+If you are moving an existing single-backend Kafka API to a Virtual Cluster, the broker entries you already have (`broker-0-…` through `broker-74-…`) no longer match anything the Virtual Cluster advertises. You must **add** the rewritten ones.
+
+## Keeping your own broker numbering
+
+{% hint style="warning" %}
+`virtualClusterBrokerDomainPattern` and the `{realBrokerId}` and `{clusterIndex}` placeholders require **4.12.18 or later** (Kafka reactor 7.1.0).
+
+Everything above applies to every 4.12 release: broker IDs have been rewritten since 4.12.0 (Kafka reactor 7.0.0). On earlier 4.12 patches, Virtual Clusters follow `brokerDomainPattern` and the advertised IDs are the only ones you can build a hostname from.
+{% endhint %}
+
+If the rewritten IDs do not fit a DNS convention you already run, you can give Virtual Clusters their own broker hostname scheme with `virtualClusterBrokerDomainPattern`. It applies **only** to APIs backed by a Virtual Cluster, so the Kafka APIs already running on that Gateway keep their hostnames — and their DNS entries and certificate SANs — untouched.
+
+Three placeholders are available, in either pattern:
+
+| Placeholder      | Value                                                            |
+| ---------------- | ---------------------------------------------------------------- |
+| `{brokerId}`     | the advertised ID — rewritten on a Virtual Cluster (the default) |
+| `{realBrokerId}` | the ID as configured on the backend broker                       |
+| `{clusterIndex}` | the backend's zero-based position in the Virtual Cluster         |
+
+```yaml
+kafka:
+  enabled: true
+
+  routingMode: host
+  routingHostMode:
+    defaultDomain: "mycompany.org"
+
+    # Plain Kafka APIs: unchanged. broker 3 stays broker3-myapi.mycompany.org
+    brokerDomainPattern: "broker{brokerId}-{apiHost}.{defaultDomain}"
+
+    # Virtual Cluster APIs only: broker 3 of the second backend becomes
+    # broker3-c1-mymesh.mycompany.org
+    virtualClusterBrokerDomainPattern: "broker{realBrokerId}-c{clusterIndex}-{apiHost}.{defaultDomain}"
+```
+
+Brokers then keep the numbers your operators know, and the backend gets its own label. The placeholders can appear in any order in the pattern.
+
+`virtualClusterBrokerDomainPattern` is optional. Left unset, Virtual Clusters follow `brokerDomainPattern` like every other API, and their hostnames carry the rewritten IDs described above.
+
+{% hint style="info" %}
+A Virtual Cluster hostname **must** distinguish the backends, either through `{brokerId}` (which encodes the backend) or through `{clusterIndex}`. A pattern built only from `{realBrokerId}` would send broker 3 of the first backend and broker 3 of the second to the same hostname, and the Gateway could no longer tell them apart.
+{% endhint %}
+
+{% hint style="warning" %}
+Both settings are Gateway-wide, so `virtualClusterBrokerDomainPattern` applies to **every** Virtual Cluster API on that Gateway. Changing it after Virtual Clusters are in production moves their DNS entries and certificate SANs.
+{% endhint %}
+
+This override does not apply to Gateways using access points, where the broker domain comes from the access point rather than from configuration.
+
+## Clients reaching an unadvertised broker hostname
+
+A client connecting on a broker hostname whose ID falls outside every advertised block — an entry left over from a single-backend deployment, most often — is served as a bootstrap connection: it receives the merged metadata and re-targets itself at the correct broker. The Gateway logs a warning naming the ID it received and the range it advertises:
+
+```
+Client connected on a broker host carrying id 0, which this virtual cluster never advertised
+(it advertises 10000..29999 across 2 backends). Serving the connection as bootstrap so the client
+can re-target itself; check the broker DNS records point at the ids the mesh advertises.
+```
+
+Treat that warning as a DNS mismatch to fix rather than a supported mode: the extra round trip is paid on every connection.
+
+## Backend broker ID limit
+
+Every backend broker ID must be **below 10000**, otherwise it collides with the next backend's block. Higher IDs are rejected at runtime. Single- and double-digit broker IDs are the convention in most deployments, and Kafka's own generated IDs start at 1001, so this rarely applies — but check it if you are onboarding a cluster with hand-assigned high IDs.
+
+## Troubleshooting
+
+| Symptom                                                                | Likely cause                                                                                                                                                                       |
+| ---------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Bootstrap and topic listing work, but producing and consuming time out | The DNS entries for the advertised IDs do not exist. Clients resolve the bootstrap fine, then fail on the per-broker hostnames returned in metadata.                                |
+| `Client connected on a broker host carrying id N` warnings in the logs | Clients are still using the broker DNS entries of a single-backend deployment.                                                                                                     |
+| Connections fail only for one backend's brokers                        | That backend's block of entries is missing. Check the position of the backend in the Virtual Cluster configuration, since the block follows the listed order.                       |
+| TLS handshake failures on reconnect                                    | The per-broker hostnames are missing from the SAN of the Gateway certificate. See [Configure the Kafka Client & Gateway](configure-the-kafka-client-and-gateway.md).                |

--- a/docs/apim/4.12/kafka-gateway/virtual-cluster-broker-addressing.md
+++ b/docs/apim/4.12/kafka-gateway/virtual-cluster-broker-addressing.md
@@ -108,7 +108,15 @@ Client connected on a broker host carrying id 0, which this virtual cluster neve
 can re-target itself; check the broker DNS records point at the ids the mesh advertises.
 ```
 
-Treat that warning as a DNS mismatch to fix rather than a supported mode: the extra round trip is paid on every connection.
+If your broker pattern spells the backend out with `{clusterIndex}`, the hostname names a backend rather than an advertised ID, and the warning reports that instead:
+
+```
+Client connected on a broker host naming backend 3, which this virtual cluster does not have
+(it federates 2 backends, numbered 0..1). Serving the connection as bootstrap so the client
+can re-target itself; check the broker DNS records match the backends the mesh federates.
+```
+
+Treat either warning as a DNS mismatch to fix rather than a supported mode: the extra round trip is paid on every connection.
 
 ## Backend broker ID limit
 
@@ -120,5 +128,6 @@ Every backend broker ID must be **below 10000**, otherwise it collides with the 
 | ---------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Bootstrap and topic listing work, but producing and consuming time out | The DNS entries for the advertised IDs do not exist. Clients resolve the bootstrap fine, then fail on the per-broker hostnames returned in metadata.                                |
 | `Client connected on a broker host carrying id N` warnings in the logs | Clients are still using the broker DNS entries of a single-backend deployment.                                                                                                     |
+| `Client connected on a broker host naming backend N` warnings in the logs | With a `{clusterIndex}` pattern, DNS entries exist for more backends than the Virtual Cluster federates — left over from a backend that was removed, most often.                |
 | Connections fail only for one backend's brokers                        | That backend's block of entries is missing. Check the position of the backend in the Virtual Cluster configuration, since the block follows the listed order.                       |
 | TLS handshake failures on reconnect                                    | The per-broker hostnames are missing from the SAN of the Gateway certificate. See [Configure the Kafka Client & Gateway](configure-the-kafka-client-and-gateway.md).                |

--- a/docs/apim/4.12/kafka-gateway/virtual-cluster-broker-addressing.md
+++ b/docs/apim/4.12/kafka-gateway/virtual-cluster-broker-addressing.md
@@ -50,73 +50,13 @@ A wildcard DNS entry and a wildcard certificate covering `*.mycompany.org` cover
 
 If you are moving an existing single-backend Kafka API to a Virtual Cluster, the broker entries you already have (`broker-0-…` through `broker-74-…`) no longer match anything the Virtual Cluster advertises. You must **add** the rewritten ones.
 
-## Keeping your own broker numbering
-
-{% hint style="warning" %}
-`virtualClusterBrokerDomainPattern` and the `{realBrokerId}` and `{clusterIndex}` placeholders require **4.12.18 or later** (Kafka reactor 7.1.0).
-
-Everything above applies to every 4.12 release: broker IDs have been rewritten since 4.12.0 (Kafka reactor 7.0.0). On earlier 4.12 patches, Virtual Clusters follow `brokerDomainPattern` and the advertised IDs are the only ones you can build a hostname from.
-{% endhint %}
-
-If the rewritten IDs do not fit a DNS convention you already run, you can give Virtual Clusters their own broker hostname scheme with `virtualClusterBrokerDomainPattern`. It applies **only** to APIs backed by a Virtual Cluster, so the Kafka APIs already running on that Gateway keep their hostnames — and their DNS entries and certificate SANs — untouched.
-
-Three placeholders are available, in either pattern:
-
-| Placeholder      | Value                                                            |
-| ---------------- | ---------------------------------------------------------------- |
-| `{brokerId}`     | the advertised ID — rewritten on a Virtual Cluster (the default) |
-| `{realBrokerId}` | the ID as configured on the backend broker                       |
-| `{clusterIndex}` | the backend's zero-based position in the Virtual Cluster         |
-
-```yaml
-kafka:
-  enabled: true
-
-  routingMode: host
-  routingHostMode:
-    defaultDomain: "mycompany.org"
-
-    # Plain Kafka APIs: unchanged. broker 3 stays broker3-myapi.mycompany.org
-    brokerDomainPattern: "broker{brokerId}-{apiHost}.{defaultDomain}"
-
-    # Virtual Cluster APIs only: broker 3 of the second backend becomes
-    # broker3-c1-mymesh.mycompany.org
-    virtualClusterBrokerDomainPattern: "broker{realBrokerId}-c{clusterIndex}-{apiHost}.{defaultDomain}"
-```
-
-Brokers then keep the numbers your operators know, and the backend gets its own label. The placeholders can appear in any order in the pattern.
-
-`virtualClusterBrokerDomainPattern` is optional. Left unset, Virtual Clusters follow `brokerDomainPattern` like every other API, and their hostnames carry the rewritten IDs described above.
-
-{% hint style="info" %}
-A Virtual Cluster hostname **must** distinguish the backends, either through `{brokerId}` (which encodes the backend) or through `{clusterIndex}`. A pattern built only from `{realBrokerId}` would send broker 3 of the first backend and broker 3 of the second to the same hostname, and the Gateway could no longer tell them apart.
-{% endhint %}
-
-{% hint style="warning" %}
-Both settings are Gateway-wide, so `virtualClusterBrokerDomainPattern` applies to **every** Virtual Cluster API on that Gateway. Changing it after Virtual Clusters are in production moves their DNS entries and certificate SANs.
-{% endhint %}
-
-This override does not apply to Gateways using access points, where the broker domain comes from the access point rather than from configuration.
-
 ## Clients reaching an unadvertised broker hostname
 
-A client connecting on a broker hostname whose ID falls outside every advertised block — an entry left over from a single-backend deployment, most often — is served as a bootstrap connection: it receives the merged metadata and re-targets itself at the correct broker. The Gateway logs a warning naming the ID it received and the range it advertises:
+A client connecting on a broker hostname whose ID falls outside every advertised block — an entry left over from a single-backend deployment, most often — cannot be placed on any backend. The connection is closed without a response, and the client waits out its own timeout rather than failing fast.
 
-```
-Client connected on a broker host carrying id 0, which this virtual cluster never advertised
-(it advertises 10000..29999 across 2 backends). Serving the connection as bootstrap so the client
-can re-target itself; check the broker DNS records point at the ids the mesh advertises.
-```
+This is the usual shape of "bootstrap works, producing does not": producing is the first operation that needs a per-broker connection, so a stale set of broker entries surfaces there and nowhere earlier.
 
-If your broker pattern spells the backend out with `{clusterIndex}`, the hostname names a backend rather than an advertised ID, and the warning reports that instead:
-
-```
-Client connected on a broker host naming backend 3, which this virtual cluster does not have
-(it federates 2 backends, numbered 0..1). Serving the connection as bootstrap so the client
-can re-target itself; check the broker DNS records match the backends the mesh federates.
-```
-
-Treat either warning as a DNS mismatch to fix rather than a supported mode: the extra round trip is paid on every connection.
+Fix the DNS entries rather than the clients: they must carry the rewritten IDs the Virtual Cluster advertises, as described above.
 
 ## Backend broker ID limit
 
@@ -126,8 +66,6 @@ Every backend broker ID must be **below 10000**, otherwise it collides with the 
 
 | Symptom                                                                | Likely cause                                                                                                                                                                       |
 | ---------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Bootstrap and topic listing work, but producing and consuming time out | The DNS entries for the advertised IDs do not exist. Clients resolve the bootstrap fine, then fail on the per-broker hostnames returned in metadata.                                |
-| `Client connected on a broker host carrying id N` warnings in the logs | Clients are still using the broker DNS entries of a single-backend deployment.                                                                                                     |
-| `Client connected on a broker host naming backend N` warnings in the logs | With a `{clusterIndex}` pattern, DNS entries exist for more backends than the Virtual Cluster federates — left over from a backend that was removed, most often.                |
+| Bootstrap and topic listing work, but producing and consuming time out | The DNS entries for the advertised IDs do not exist, or still carry the numbering of a single-backend deployment. Clients resolve the bootstrap fine, then fail on the per-broker hostnames returned in metadata. |
 | Connections fail only for one backend's brokers                        | That backend's block of entries is missing. Check the position of the backend in the Virtual Cluster configuration, since the block follows the listed order.                       |
 | TLS handshake failures on reconnect                                    | The per-broker hostnames are missing from the SAN of the Gateway certificate. See [Configure the Kafka Client & Gateway](configure-the-kafka-client-and-gateway.md).                |

--- a/docs/apim/4.13/SUMMARY.md
+++ b/docs/apim/4.13/SUMMARY.md
@@ -510,6 +510,7 @@
       * [Documentation](kafka-gateway/create-and-configure-kafka-apis/configure-kafka-apis/documentation.md)
       * [Deployment](kafka-gateway/create-and-configure-kafka-apis/configure-kafka-apis/deployment.md)
   * [Create and Configure Kafka Clusters](kafka-gateway/create-and-configure-kafka-clusters.md)
+  * [Virtual Cluster Broker Addressing](kafka-gateway/virtual-cluster-broker-addressing.md)
   * [Configure and Deploy Kafka Console](kafka-gateway/configure-and-deploy-kafka-console.md)
   * [Plans](kafka-gateway/plans.md)
   * [Applications](kafka-gateway/applications.md)

--- a/docs/apim/4.13/kafka-gateway/virtual-cluster-broker-addressing.md
+++ b/docs/apim/4.13/kafka-gateway/virtual-cluster-broker-addressing.md
@@ -52,13 +52,15 @@ If you are moving an existing single-backend Kafka API to a Virtual Cluster, the
 
 ## Keeping your own broker numbering
 
-If the rewritten IDs do not fit a DNS convention you already run, the broker domain pattern can address the backend on its own label instead of folding it into the ID. Three placeholders are available in `kafka.routingHostMode.brokerDomainPattern`:
+If the rewritten IDs do not fit a DNS convention you already run, you can give Virtual Clusters their own broker hostname scheme with `virtualClusterBrokerDomainPattern`. It applies **only** to APIs backed by a Virtual Cluster, so the Kafka APIs already running on that Gateway keep their hostnames — and their DNS entries and certificate SANs — untouched.
 
-| Placeholder      | Value                                                             |
-| ---------------- | ----------------------------------------------------------------- |
-| `{brokerId}`     | the advertised ID — rewritten on a Virtual Cluster (the default)   |
-| `{realBrokerId}` | the ID as configured on the backend broker                        |
-| `{clusterIndex}` | the backend's zero-based position in the Virtual Cluster           |
+Three placeholders are available, in either pattern:
+
+| Placeholder      | Value                                                            |
+| ---------------- | ---------------------------------------------------------------- |
+| `{brokerId}`     | the advertised ID — rewritten on a Virtual Cluster (the default) |
+| `{realBrokerId}` | the ID as configured on the backend broker                       |
+| `{clusterIndex}` | the backend's zero-based position in the Virtual Cluster         |
 
 ```yaml
 kafka:
@@ -68,15 +70,27 @@ kafka:
   routingHostMode:
     defaultDomain: "mycompany.org"
 
-    # broker 3 of the second backend is advertised as broker3-c1-myapi.mycompany.org
-    brokerDomainPattern: "broker{realBrokerId}-c{clusterIndex}-{apiHost}.{defaultDomain}"
+    # Plain Kafka APIs: unchanged. broker 3 stays broker3-myapi.mycompany.org
+    brokerDomainPattern: "broker{brokerId}-{apiHost}.{defaultDomain}"
+
+    # Virtual Cluster APIs only: broker 3 of the second backend becomes
+    # broker3-c1-mymesh.mycompany.org
+    virtualClusterBrokerDomainPattern: "broker{realBrokerId}-c{clusterIndex}-{apiHost}.{defaultDomain}"
 ```
 
 Brokers then keep the numbers your operators know, and the backend gets its own label. The placeholders can appear in any order in the pattern.
 
-{% hint style="warning" %}
-`brokerDomainPattern` is a **Gateway-wide** setting: it applies to every Kafka API on that Gateway, whether or not it is backed by a Virtual Cluster. On a single-backend API, `{clusterIndex}` is always `0` and `{realBrokerId}` is the broker ID, so a split pattern stays correct there — but the DNS entries and certificate SANs of every API on the Gateway change together. Roll it out across the whole Gateway or not at all.
+`virtualClusterBrokerDomainPattern` is optional. Left unset, Virtual Clusters follow `brokerDomainPattern` like every other API, and their hostnames carry the rewritten IDs described above.
+
+{% hint style="info" %}
+A Virtual Cluster hostname **must** distinguish the backends, either through `{brokerId}` (which encodes the backend) or through `{clusterIndex}`. A pattern built only from `{realBrokerId}` would send broker 3 of the first backend and broker 3 of the second to the same hostname, and the Gateway could no longer tell them apart.
 {% endhint %}
+
+{% hint style="warning" %}
+Both settings are Gateway-wide, so `virtualClusterBrokerDomainPattern` applies to **every** Virtual Cluster API on that Gateway. Changing it after Virtual Clusters are in production moves their DNS entries and certificate SANs.
+{% endhint %}
+
+This override does not apply to Gateways using access points, where the broker domain comes from the access point rather than from configuration.
 
 ## Clients reaching an unadvertised broker hostname
 

--- a/docs/apim/4.13/kafka-gateway/virtual-cluster-broker-addressing.md
+++ b/docs/apim/4.13/kafka-gateway/virtual-cluster-broker-addressing.md
@@ -1,0 +1,104 @@
+---
+description: >-
+  How the Kafka Gateway rewrites broker IDs when a Kafka API is backed by a Virtual Cluster, and
+  which DNS entries and certificate SANs that requires.
+---
+
+# Virtual Cluster Broker Addressing
+
+## Overview
+
+A Virtual Cluster presents several backend Kafka clusters to clients as one. Kafka requires every broker in a cluster to have a unique ID, but two backends will happily both have a `broker.id=0`. The Gateway therefore rewrites broker IDs before advertising them, which means **the IDs clients see are not the IDs configured on your brokers**.
+
+This changes which DNS entries you need. It is the one part of the [Kafka Gateway host routing setup](configure-the-kafka-client-and-gateway.md) that a Virtual Cluster does not inherit unchanged, so read this page before exposing a Kafka API backed by a Virtual Cluster.
+
+## How broker IDs are rewritten
+
+Each backend cluster is assigned a block of 10,000 IDs, in the order the backends are listed in the Virtual Cluster configuration:
+
+```
+advertised broker ID = (backend position + 1) × 10000 + real broker ID
+```
+
+`backend position` is zero-based, so:
+
+| Backend position | Real broker IDs | Advertised IDs         |
+| ---------------- | --------------- | ---------------------- |
+| 0 (first listed) | 0, 1, 2, …      | 10000, 10001, 10002, … |
+| 1                | 0, 1, 2, …      | 20000, 20001, 20002, … |
+| 2                | 0, 1, 2, …      | 30000, 30001, 30002, … |
+
+The same rewriting applies everywhere a broker ID is visible to a client: `Metadata` responses, `DescribeCluster`, partition leaders and replicas, `FindCoordinator`, and the `resourceName` of a `BROKER` config resource.
+
+## DNS entries
+
+The broker hostname pattern is unchanged — by default `{brokerPrefix}{brokerId}{domainSeparator}{apiHost}.{defaultDomain}` — but `{brokerId}` carries the **advertised** ID, not the real one.
+
+For example, with two backends of 75 brokers each (real IDs 0–74), a Kafka API whose host prefix is `myapi`, and a default domain of `mycompany.org`:
+
+| Entry                                                                     | Resolves to             |
+| ------------------------------------------------------------------------- | ----------------------- |
+| `myapi.mycompany.org`                                                     | the Gateway (bootstrap) |
+| `broker-10000-myapi.mycompany.org` … `broker-10074-myapi.mycompany.org`   | the Gateway (backend 0) |
+| `broker-20000-myapi.mycompany.org` … `broker-20074-myapi.mycompany.org`   | the Gateway (backend 1) |
+
+All of them resolve to the same Gateway address — the Gateway tells the backends apart from the SNI, not from the IP. The same hostnames must also appear in the SAN of the certificate the Gateway presents.
+
+{% hint style="info" %}
+A wildcard DNS entry and a wildcard certificate covering `*.mycompany.org` cover every broker at once and keep working when you add a backend or scale one out. With per-broker entries, you must create new ones each time the topology changes. Use wildcards wherever your DNS and certificate policy allow it.
+{% endhint %}
+
+If you are moving an existing single-backend Kafka API to a Virtual Cluster, the broker entries you already have (`broker-0-…` through `broker-74-…`) no longer match anything the Virtual Cluster advertises. You must **add** the rewritten ones.
+
+## Keeping your own broker numbering
+
+If the rewritten IDs do not fit a DNS convention you already run, the broker domain pattern can address the backend on its own label instead of folding it into the ID. Three placeholders are available in `kafka.routingHostMode.brokerDomainPattern`:
+
+| Placeholder      | Value                                                             |
+| ---------------- | ----------------------------------------------------------------- |
+| `{brokerId}`     | the advertised ID — rewritten on a Virtual Cluster (the default)   |
+| `{realBrokerId}` | the ID as configured on the backend broker                        |
+| `{clusterIndex}` | the backend's zero-based position in the Virtual Cluster           |
+
+```yaml
+kafka:
+  enabled: true
+
+  routingMode: host
+  routingHostMode:
+    defaultDomain: "mycompany.org"
+
+    # broker 3 of the second backend is advertised as broker3-c1-myapi.mycompany.org
+    brokerDomainPattern: "broker{realBrokerId}-c{clusterIndex}-{apiHost}.{defaultDomain}"
+```
+
+Brokers then keep the numbers your operators know, and the backend gets its own label. The placeholders can appear in any order in the pattern.
+
+{% hint style="warning" %}
+`brokerDomainPattern` is a **Gateway-wide** setting: it applies to every Kafka API on that Gateway, whether or not it is backed by a Virtual Cluster. On a single-backend API, `{clusterIndex}` is always `0` and `{realBrokerId}` is the broker ID, so a split pattern stays correct there — but the DNS entries and certificate SANs of every API on the Gateway change together. Roll it out across the whole Gateway or not at all.
+{% endhint %}
+
+## Clients reaching an unadvertised broker hostname
+
+A client connecting on a broker hostname whose ID falls outside every advertised block — an entry left over from a single-backend deployment, most often — is served as a bootstrap connection: it receives the merged metadata and re-targets itself at the correct broker. The Gateway logs a warning naming the ID it received and the range it advertises:
+
+```
+Client connected on a broker host carrying id 0, which this virtual cluster never advertised
+(it advertises 10000..29999 across 2 backends). Serving the connection as bootstrap so the client
+can re-target itself; check the broker DNS records point at the ids the mesh advertises.
+```
+
+Treat that warning as a DNS mismatch to fix rather than a supported mode: the extra round trip is paid on every connection.
+
+## Backend broker ID limit
+
+Every backend broker ID must be **below 10000**, otherwise it collides with the next backend's block. Higher IDs are rejected at runtime. Single- and double-digit broker IDs are the convention in most deployments, and Kafka's own generated IDs start at 1001, so this rarely applies — but check it if you are onboarding a cluster with hand-assigned high IDs.
+
+## Troubleshooting
+
+| Symptom                                                                | Likely cause                                                                                                                                                                       |
+| ---------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Bootstrap and topic listing work, but producing and consuming time out | The DNS entries for the advertised IDs do not exist. Clients resolve the bootstrap fine, then fail on the per-broker hostnames returned in metadata.                                |
+| `Client connected on a broker host carrying id N` warnings in the logs | Clients are still using the broker DNS entries of a single-backend deployment.                                                                                                     |
+| Connections fail only for one backend's brokers                        | That backend's block of entries is missing. Check the position of the backend in the Virtual Cluster configuration, since the block follows the listed order.                       |
+| TLS handshake failures on reconnect                                    | The per-broker hostnames are missing from the SAN of the Gateway certificate. See [Configure the Kafka Client & Gateway](configure-the-kafka-client-and-gateway.md).                |

--- a/docs/apim/4.13/kafka-gateway/virtual-cluster-broker-addressing.md
+++ b/docs/apim/4.13/kafka-gateway/virtual-cluster-broker-addressing.md
@@ -102,7 +102,15 @@ Client connected on a broker host carrying id 0, which this virtual cluster neve
 can re-target itself; check the broker DNS records point at the ids the mesh advertises.
 ```
 
-Treat that warning as a DNS mismatch to fix rather than a supported mode: the extra round trip is paid on every connection.
+If your broker pattern spells the backend out with `{clusterIndex}`, the hostname names a backend rather than an advertised ID, and the warning reports that instead:
+
+```
+Client connected on a broker host naming backend 3, which this virtual cluster does not have
+(it federates 2 backends, numbered 0..1). Serving the connection as bootstrap so the client
+can re-target itself; check the broker DNS records match the backends the mesh federates.
+```
+
+Treat either warning as a DNS mismatch to fix rather than a supported mode: the extra round trip is paid on every connection.
 
 ## Backend broker ID limit
 
@@ -114,5 +122,6 @@ Every backend broker ID must be **below 10000**, otherwise it collides with the 
 | ---------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Bootstrap and topic listing work, but producing and consuming time out | The DNS entries for the advertised IDs do not exist. Clients resolve the bootstrap fine, then fail on the per-broker hostnames returned in metadata.                                |
 | `Client connected on a broker host carrying id N` warnings in the logs | Clients are still using the broker DNS entries of a single-backend deployment.                                                                                                     |
+| `Client connected on a broker host naming backend N` warnings in the logs | With a `{clusterIndex}` pattern, DNS entries exist for more backends than the Virtual Cluster federates — left over from a backend that was removed, most often.                |
 | Connections fail only for one backend's brokers                        | That backend's block of entries is missing. Check the position of the backend in the Virtual Cluster configuration, since the block follows the listed order.                       |
 | TLS handshake failures on reconnect                                    | The per-broker hostnames are missing from the SAN of the Gateway certificate. See [Configure the Kafka Client & Gateway](configure-the-kafka-client-and-gateway.md).                |

--- a/docs/apim/4.13/release-information/release-notes/apim-4.13.md
+++ b/docs/apim/4.13/release-information/release-notes/apim-4.13.md
@@ -86,6 +86,13 @@ The plan endpoints of the legacy Management API v1 no longer accept V4, Federate
 * Every addition carries a default implementation (`UNKNOWN` type, empty results), so an existing provider compiled against contract version `1.0.1` compiles and runs unchanged, and a registry that doesn't support these lookups returns the defaults.
 * The Confluent Schema Registry resource implements the new surface from plugin version `5.1.0`, bundled with APIM 4.13. For more information, see [Implement a schema registry provider](../../plugins/customization/schema-registry-provider.md).
 
+#### **Kafka Gateway: broker addressing for Virtual Clusters**
+
+* A Virtual Cluster rewrites broker IDs so they stay unique across its backends, which means the hostnames clients resolve are not the ones a single-backend deployment used. `gateway.kafka.routingHostMode.virtualClusterBrokerDomainPattern` sets the broker domain pattern for Kafka APIs backed by a Virtual Cluster only, so adopting one no longer moves the DNS records and certificate SANs of every other Kafka API on the same Gateway. It is optional: left unset, Virtual Clusters keep following `brokerDomainPattern`, and both defaults are unchanged.
+* Two placeholders come with it, usable in either pattern: `{realBrokerId}`, the broker ID as configured on the backend, and `{clusterIndex}`, the backend's zero-based position in the Virtual Cluster. Together they let a hostname keep your own broker numbering instead of the rewritten IDs. A Virtual Cluster pattern must still tell the backends apart — through `{brokerId}`, which encodes the backend, or through `{clusterIndex}` alongside `{realBrokerId}` — and the Gateway now refuses to deploy a pattern that cannot, rather than routing to the wrong backend silently.
+* A client connecting on a broker hostname the Virtual Cluster never advertised — a DNS record left over from a single-backend deployment, most often — is now served as a bootstrap connection, so it receives the merged metadata and re-targets itself at the correct broker. Previously the connection was closed without a response and the client waited out its own timeout, which typically surfaced as producing failing while bootstrap and topic listing worked. The Gateway logs a warning naming what it could not place, so the stale DNS record stays visible rather than being papered over.
+* For more information, see [Virtual Cluster Broker Addressing](../../kafka-gateway/virtual-cluster-broker-addressing.md).
+
 ## Improvements
 
 #### **Datadog Reporter: Consumer and error tags on the request count metric**


### PR DESCRIPTION
## What

Adds `Virtual Cluster Broker Addressing` under **APIM 4.13 → Kafka Gateway**, plus its `SUMMARY.md` entry.

https://gravitee.atlassian.net/browse/APIM-14954

## Why

Virtual Clusters are **undocumented today** — the only mention of "virtual cluster" anywhere in `docs/apim/4.13/` is an incidental one on the high-availability page.

That gap has a concrete cost. A Virtual Cluster rewrites broker IDs to `(backend position + 1) * 10000 + real ID` so they stay unique across backends, and that rewritten ID is what lands in the broker hostname. The broker DNS entries of a single-backend deployment therefore stop matching anything the Gateway advertises.

The resulting failure is genuinely confusing: bootstrap and topic listing keep working, because the Gateway serves those from its own merged cache without touching a broker, while producing and consuming time out on hostnames that do not resolve. A customer running a Virtual Cluster in front of several Confluent clusters lost a lab cycle to exactly this and reported it as "produce is broken".

## Scope

Deliberately limited to broker addressing — the piece that unblocks operators today.

Still missing, and wanting its own change: overview, prerequisites, setup, operations, and limitations for Virtual Clusters. Draft material for those exists on the unmerged `docs/kafka-mesh-feature` branch of `gravitee-reactor-native-kafka`, but it needs rework before publication (it states that transactions are unsupported, which stopped being true in reactor 7.0.0). Related: [DOC-1892](https://gravitee.atlassian.net/browse/DOC-1892).

## Notes for review

- The `{clusterIndex}` / `{realBrokerId}` placeholders and `virtualClusterBrokerDomainPattern` documented here are new and land in gravitee-io/gravitee-reactor-native-kafka#397, with the `gravitee.yml` and Helm references updated in gravitee-io/gravitee-api-management#19201. **This page should not be published before those ship.** Everything else on the page describes current behaviour.
- The "clients reaching an unadvertised broker hostname" section also describes behaviour from that PR: such a connection used to be dropped, and is now served as bootstrap with a warning.
- Targeted at 4.13 as the version currently receiving Kafka Gateway documentation updates. Tell me if it should be backported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[DOC-1892]: https://gravitee.atlassian.net/browse/DOC-1892?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ