### PR TITLE
docs(cloud): clarify migration IP ranges, ports and hybrid connectivity TT-11285

### DIFF
--- a/docs/apim/4.12/hybrid-installation-and-configuration-guides/classic-cloud/classic-cloud-ip-ranges.md
+++ b/docs/apim/4.12/hybrid-installation-and-configuration-guides/classic-cloud/classic-cloud-ip-ranges.md
@@ -10,6 +10,12 @@ Gravitee is migrating Classic Cloud hosted environments to a new platform. This 
 
 If your organization restricts network traffic with firewall rules, add the following IP ranges to your firewall rules before Gravitee migrates your environment, and keep them in place after the migration. If your firewall rules don't allow the new IP ranges, traffic to and from your environment's endpoints is blocked after the migration.
 
+{% hint style="warning" %}
+**Add the new ranges alongside your existing rules. Do not replace your current entries.**
+
+Keep the IP addresses that your firewall rules already allow for your Gravitee environment. Both your current addresses and the new ranges are needed until your environment has migrated. After Gravitee confirms that your migration is complete, you can remove the entries you no longer need.
+{% endhint %}
+
 {% hint style="info" %}
 Gravitee contacts hosted customers before their environments are migrated.
 {% endhint %}
@@ -43,6 +49,8 @@ Your environment receives incoming traffic on the following IP ranges. If your n
 2c0f:f248::/32
 ```
 
+These are Cloudflare's published IP ranges. Cloudflare maintains the authoritative list at [cloudflare.com/ips](https://www.cloudflare.com/ips/). If you generate your firewall rules automatically, source the ranges from there so that you pick up any future changes to the list.
+
 ## Outgoing IP ranges
 
 Traffic that leaves your environment, for example calls from your Gateways to your backend services, originates from the following IP ranges. Allow these ranges as sources in the firewall rules that protect your backend services.
@@ -51,3 +59,22 @@ Traffic that leaves your environment, for example calls from your Gateways to yo
 48.222.129.24/29
 2603:1020:203:2d::8/125
 ```
+
+## Ports
+
+Allow the following ports alongside the IP ranges above.
+
+| Traffic | Protocol and port |
+| ------- | ----------------- |
+| Client applications to your Gravitee environment endpoints | TCP 443 (HTTPS) |
+| Self-hosted hybrid Gateway to Gravitee | TCP 443 (HTTPS), outbound |
+
+{% hint style="info" %}
+If you use the Kafka Gateway, its endpoint is not covered by the incoming IP ranges above and uses a different port. Contact Gravitee for the address and port that apply to your environment.
+{% endhint %}
+
+## Hybrid Gateway connectivity
+
+If you run self-hosted hybrid Gateways, they connect outbound to the Bridge over HTTPS on port 443.
+
+Your Gateway always initiates this connection. Gravitee does not open connections into your network, so you do not need to open any inbound ports for your hybrid Gateway.

--- a/docs/apim/4.12/hybrid-installation-and-configuration-guides/classic-cloud/classic-cloud-ip-ranges.md
+++ b/docs/apim/4.12/hybrid-installation-and-configuration-guides/classic-cloud/classic-cloud-ip-ranges.md
@@ -11,7 +11,7 @@ Gravitee is migrating Classic Cloud hosted environments to a new platform. This 
 If your organization restricts network traffic with firewall rules, add the following IP ranges to your firewall rules before Gravitee migrates your environment, and keep them in place after the migration. If your firewall rules don't allow the new IP ranges, traffic to and from your environment's endpoints is blocked after the migration.
 
 {% hint style="warning" %}
-**Add the new ranges alongside your existing rules. Do not replace your current entries.**
+**Add the new ranges alongside your existing rules, and keep your current entries in place.**
 
 Keep the IP addresses that your firewall rules already allow for your Gravitee environment. Both your current addresses and the new ranges are needed until your environment has migrated. After Gravitee confirms that your migration is complete, you can remove the entries you no longer need.
 {% endhint %}
@@ -49,7 +49,7 @@ Your environment receives incoming traffic on the following IP ranges. If your n
 2c0f:f248::/32
 ```
 
-These are Cloudflare's published IP ranges. Cloudflare maintains the authoritative list at [cloudflare.com/ips](https://www.cloudflare.com/ips/). If you generate your firewall rules automatically, source the ranges from there so that you pick up any future changes to the list.
+The preceding IP ranges are published by Cloudflare. Cloudflare maintains the authoritative list at [cloudflare.com/ips](https://www.cloudflare.com/ips/). If you generate your firewall rules automatically, source the ranges from that list so that you capture any future changes.
 
 ## Outgoing IP ranges
 
@@ -62,19 +62,19 @@ Traffic that leaves your environment, for example calls from your Gateways to yo
 
 ## Ports
 
-Allow the following ports alongside the IP ranges above.
+The following table lists the ports to allow alongside the preceding IP ranges:
 
 | Traffic | Protocol and port |
 | ------- | ----------------- |
-| Client applications to your Gravitee environment endpoints | TCP 443 (HTTPS) |
-| Self-hosted hybrid Gateway to Gravitee | TCP 443 (HTTPS), outbound |
+| Client applications to your Gravitee environment endpoints | HTTPS over TCP 443 |
+| Self-hosted hybrid Gateway to Gravitee | Outbound HTTPS over TCP 443 |
 
 {% hint style="info" %}
-If you use the Kafka Gateway, its endpoint is not covered by the incoming IP ranges above and uses a different port. Contact Gravitee for the address and port that apply to your environment.
+If you use the Kafka Gateway, its endpoint isn't covered by the preceding incoming IP ranges and uses a different port. Contact Gravitee for the address and port that apply to your environment.
 {% endhint %}
 
 ## Hybrid Gateway connectivity
 
-If you run self-hosted hybrid Gateways, they connect outbound to the Bridge over HTTPS on port 443.
+If you run self-hosted hybrid Gateways, they connect outbound to the Bridge Gateway over HTTPS on port 443.
 
-Your Gateway always initiates this connection. Gravitee does not open connections into your network, so you do not need to open any inbound ports for your hybrid Gateway.
+Your Gateway always initiates this connection. Gravitee doesn't open connections into your network, so you only need to allow outbound traffic for your hybrid Gateway.

--- a/docs/apim/4.12/hybrid-installation-and-configuration-guides/next-gen-cloud/next-gen-cloud-ip-ranges.md
+++ b/docs/apim/4.12/hybrid-installation-and-configuration-guides/next-gen-cloud/next-gen-cloud-ip-ranges.md
@@ -8,12 +8,12 @@ description: Add the new Next-Gen Cloud IP ranges to your firewall rules before 
 
 Gravitee is moving Next-Gen Cloud hosted environments behind Cloudflare to strengthen security and protect public access to Gravitee services.
 
-After the change, client traffic to your Gravitee environment will reach Cloudflare first, which securely proxies requests to Gravitee. As a result, the public IP addresses resolved and contacted by your client applications may change.
+After the change, client traffic to your Gravitee environment reaches Cloudflare first, which securely proxies requests to Gravitee. As a result, the public IP addresses resolved and contacted by your client applications can change.
 
-If your organization restricts network traffic with firewall rules, add the following IP ranges to your firewall rules before Gravitee migrates your environment, and keep them in place after the migration. If your firewall rules don't allow the new IP ranges, this might block access to Gravitee endpoints from your side.
+If your organization restricts network traffic with firewall rules, add the following IP ranges to your firewall rules before Gravitee migrates your environment, and keep them in place after the migration. If your firewall rules don't allow the new IP ranges, your client applications might not reach your Gravitee endpoints.
 
 {% hint style="warning" %}
-**Add the new ranges alongside your existing rules. Do not replace your current entries.**
+**Add the new ranges alongside your existing rules, and keep your current entries in place.**
 
 Keep the IP addresses that your firewall rules already allow for your Gravitee environment. Both your current addresses and the new ranges are needed until your environment has migrated. After Gravitee confirms that your migration is complete, you can remove the entries you no longer need.
 {% endhint %}
@@ -51,23 +51,23 @@ Your environment receives incoming traffic on the following IP ranges. If your n
 2c0f:f248::/32
 ```
 
-These are Cloudflare's published IP ranges. Cloudflare maintains the authoritative list at [cloudflare.com/ips](https://www.cloudflare.com/ips/). If you generate your firewall rules automatically, source the ranges from there so that you pick up any future changes to the list.
+The preceding IP ranges are published by Cloudflare. Cloudflare maintains the authoritative list at [cloudflare.com/ips](https://www.cloudflare.com/ips/). If you generate your firewall rules automatically, source the ranges from that list so that you capture any future changes.
 
 ## Ports
 
-Allow the following ports alongside the IP ranges above.
+The following table lists the ports to allow alongside the preceding IP ranges:
 
 | Traffic | Protocol and port |
 | ------- | ----------------- |
-| Client applications to your Gravitee environment endpoints | TCP 443 (HTTPS) |
-| Self-hosted hybrid Gateway to Gravitee | TCP 443 (HTTPS), outbound |
+| Client applications to your Gravitee environment endpoints | HTTPS over TCP 443 |
+| Self-hosted hybrid Gateway to Gravitee | Outbound HTTPS over TCP 443 |
 
 {% hint style="info" %}
-If you use the Kafka Gateway, its endpoint is not covered by the incoming IP ranges above and uses a different port. Contact Gravitee for the address and port that apply to your environment.
+If you use the Kafka Gateway, its endpoint isn't covered by the preceding incoming IP ranges and uses a different port. Contact Gravitee for the address and port that apply to your environment.
 {% endhint %}
 
 ## Hybrid Gateway connectivity
 
-If you run self-hosted hybrid Gateways, they connect outbound to the Cloud Gate for your Control Plane region over HTTPS on port 443. For the Cloud Gate URL for each region, see the Next-Gen Cloud hybrid installation guide.
+If you run self-hosted hybrid Gateways, they connect outbound to the Cloud Gate for your Control Plane region over HTTPS on port 443. For the Cloud Gate URL of your region, see the [Next-Gen Cloud architecture](./#architecture).
 
-Your Gateway always initiates this connection. Gravitee does not open connections into your network, so you do not need to open any inbound ports for your hybrid Gateway.
+Your Gateway always initiates this connection. Gravitee doesn't open connections into your network, so you only need to allow outbound traffic for your hybrid Gateway.

--- a/docs/apim/4.12/hybrid-installation-and-configuration-guides/next-gen-cloud/next-gen-cloud-ip-ranges.md
+++ b/docs/apim/4.12/hybrid-installation-and-configuration-guides/next-gen-cloud/next-gen-cloud-ip-ranges.md
@@ -53,6 +53,10 @@ Your environment receives incoming traffic on the following IP ranges. If your n
 
 The preceding IP ranges are published by Cloudflare. Cloudflare maintains the authoritative list at [cloudflare.com/ips](https://www.cloudflare.com/ips/). If you generate your firewall rules automatically, source the ranges from that list so that you capture any future changes.
 
+## Outgoing IP ranges
+
+Outgoing traffic from your environment isn't affected by this change. The IP addresses that your Gateways call your backend services from remain the same, so you don't need to change the firewall rules that protect your backend services.
+
 ## Ports
 
 The following table lists the ports to allow alongside the preceding IP ranges:

--- a/docs/apim/4.12/hybrid-installation-and-configuration-guides/next-gen-cloud/next-gen-cloud-ip-ranges.md
+++ b/docs/apim/4.12/hybrid-installation-and-configuration-guides/next-gen-cloud/next-gen-cloud-ip-ranges.md
@@ -8,9 +8,15 @@ description: Add the new Next-Gen Cloud IP ranges to your firewall rules before 
 
 Gravitee is moving Next-Gen Cloud hosted environments behind Cloudflare to strengthen security and protect public access to Gravitee services.
 
-After the change, client traffic to your Gravitee environment will reach Cloudflare first, which securely proxies requests to Gravitee. As a result, the public IP addresses resolved and contacted by your client applications may change
+After the change, client traffic to your Gravitee environment will reach Cloudflare first, which securely proxies requests to Gravitee. As a result, the public IP addresses resolved and contacted by your client applications may change.
 
-If your organization restricts network traffic with firewall rules, add the following IP ranges to your firewall rules before Gravitee migrates your environment, and keep them in place after the migration. If your firewall rules don't allow the new IP ranges, this might block access to gravitee endpoints from your side.
+If your organization restricts network traffic with firewall rules, add the following IP ranges to your firewall rules before Gravitee migrates your environment, and keep them in place after the migration. If your firewall rules don't allow the new IP ranges, this might block access to Gravitee endpoints from your side.
+
+{% hint style="warning" %}
+**Add the new ranges alongside your existing rules. Do not replace your current entries.**
+
+Keep the IP addresses that your firewall rules already allow for your Gravitee environment. Both your current addresses and the new ranges are needed until your environment has migrated. After Gravitee confirms that your migration is complete, you can remove the entries you no longer need.
+{% endhint %}
 
 {% hint style="info" %}
 Gravitee contacts hosted customers before their environments are migrated.
@@ -44,3 +50,24 @@ Your environment receives incoming traffic on the following IP ranges. If your n
 2a06:98c0::/29
 2c0f:f248::/32
 ```
+
+These are Cloudflare's published IP ranges. Cloudflare maintains the authoritative list at [cloudflare.com/ips](https://www.cloudflare.com/ips/). If you generate your firewall rules automatically, source the ranges from there so that you pick up any future changes to the list.
+
+## Ports
+
+Allow the following ports alongside the IP ranges above.
+
+| Traffic | Protocol and port |
+| ------- | ----------------- |
+| Client applications to your Gravitee environment endpoints | TCP 443 (HTTPS) |
+| Self-hosted hybrid Gateway to Gravitee | TCP 443 (HTTPS), outbound |
+
+{% hint style="info" %}
+If you use the Kafka Gateway, its endpoint is not covered by the incoming IP ranges above and uses a different port. Contact Gravitee for the address and port that apply to your environment.
+{% endhint %}
+
+## Hybrid Gateway connectivity
+
+If you run self-hosted hybrid Gateways, they connect outbound to the Cloud Gate for your Control Plane region over HTTPS on port 443. For the Cloud Gate URL for each region, see the Next-Gen Cloud hybrid installation guide.
+
+Your Gateway always initiates this connection. Gravitee does not open connections into your network, so you do not need to open any inbound ports for your hybrid Gateway.

--- a/docs/apim/4.13/hybrid-installation-and-configuration-guides/classic-cloud/classic-cloud-ip-ranges.md
+++ b/docs/apim/4.13/hybrid-installation-and-configuration-guides/classic-cloud/classic-cloud-ip-ranges.md
@@ -10,6 +10,12 @@ Gravitee is migrating Classic Cloud hosted environments to a new platform. This 
 
 If your organization restricts network traffic with firewall rules, add the following IP ranges to your firewall rules before Gravitee migrates your environment, and keep them in place after the migration. If your firewall rules don't allow the new IP ranges, traffic to and from your environment's endpoints is blocked after the migration.
 
+{% hint style="warning" %}
+**Add the new ranges alongside your existing rules. Do not replace your current entries.**
+
+Keep the IP addresses that your firewall rules already allow for your Gravitee environment. Both your current addresses and the new ranges are needed until your environment has migrated. After Gravitee confirms that your migration is complete, you can remove the entries you no longer need.
+{% endhint %}
+
 {% hint style="info" %}
 Gravitee contacts hosted customers before their environments are migrated.
 {% endhint %}
@@ -43,6 +49,8 @@ Your environment receives incoming traffic on the following IP ranges. If your n
 2c0f:f248::/32
 ```
 
+These are Cloudflare's published IP ranges. Cloudflare maintains the authoritative list at [cloudflare.com/ips](https://www.cloudflare.com/ips/). If you generate your firewall rules automatically, source the ranges from there so that you pick up any future changes to the list.
+
 ## Outgoing IP ranges
 
 Traffic that leaves your environment, for example calls from your Gateways to your backend services, originates from the following IP ranges. Allow these ranges as sources in the firewall rules that protect your backend services.
@@ -51,3 +59,22 @@ Traffic that leaves your environment, for example calls from your Gateways to yo
 48.222.129.24/29
 2603:1020:203:2d::8/125
 ```
+
+## Ports
+
+Allow the following ports alongside the IP ranges above.
+
+| Traffic | Protocol and port |
+| ------- | ----------------- |
+| Client applications to your Gravitee environment endpoints | TCP 443 (HTTPS) |
+| Self-hosted hybrid Gateway to Gravitee | TCP 443 (HTTPS), outbound |
+
+{% hint style="info" %}
+If you use the Kafka Gateway, its endpoint is not covered by the incoming IP ranges above and uses a different port. Contact Gravitee for the address and port that apply to your environment.
+{% endhint %}
+
+## Hybrid Gateway connectivity
+
+If you run self-hosted hybrid Gateways, they connect outbound to the Bridge over HTTPS on port 443.
+
+Your Gateway always initiates this connection. Gravitee does not open connections into your network, so you do not need to open any inbound ports for your hybrid Gateway.

--- a/docs/apim/4.13/hybrid-installation-and-configuration-guides/classic-cloud/classic-cloud-ip-ranges.md
+++ b/docs/apim/4.13/hybrid-installation-and-configuration-guides/classic-cloud/classic-cloud-ip-ranges.md
@@ -11,7 +11,7 @@ Gravitee is migrating Classic Cloud hosted environments to a new platform. This 
 If your organization restricts network traffic with firewall rules, add the following IP ranges to your firewall rules before Gravitee migrates your environment, and keep them in place after the migration. If your firewall rules don't allow the new IP ranges, traffic to and from your environment's endpoints is blocked after the migration.
 
 {% hint style="warning" %}
-**Add the new ranges alongside your existing rules. Do not replace your current entries.**
+**Add the new ranges alongside your existing rules, and keep your current entries in place.**
 
 Keep the IP addresses that your firewall rules already allow for your Gravitee environment. Both your current addresses and the new ranges are needed until your environment has migrated. After Gravitee confirms that your migration is complete, you can remove the entries you no longer need.
 {% endhint %}
@@ -49,7 +49,7 @@ Your environment receives incoming traffic on the following IP ranges. If your n
 2c0f:f248::/32
 ```
 
-These are Cloudflare's published IP ranges. Cloudflare maintains the authoritative list at [cloudflare.com/ips](https://www.cloudflare.com/ips/). If you generate your firewall rules automatically, source the ranges from there so that you pick up any future changes to the list.
+The preceding IP ranges are published by Cloudflare. Cloudflare maintains the authoritative list at [cloudflare.com/ips](https://www.cloudflare.com/ips/). If you generate your firewall rules automatically, source the ranges from that list so that you capture any future changes.
 
 ## Outgoing IP ranges
 
@@ -62,19 +62,19 @@ Traffic that leaves your environment, for example calls from your Gateways to yo
 
 ## Ports
 
-Allow the following ports alongside the IP ranges above.
+The following table lists the ports to allow alongside the preceding IP ranges:
 
 | Traffic | Protocol and port |
 | ------- | ----------------- |
-| Client applications to your Gravitee environment endpoints | TCP 443 (HTTPS) |
-| Self-hosted hybrid Gateway to Gravitee | TCP 443 (HTTPS), outbound |
+| Client applications to your Gravitee environment endpoints | HTTPS over TCP 443 |
+| Self-hosted hybrid Gateway to Gravitee | Outbound HTTPS over TCP 443 |
 
 {% hint style="info" %}
-If you use the Kafka Gateway, its endpoint is not covered by the incoming IP ranges above and uses a different port. Contact Gravitee for the address and port that apply to your environment.
+If you use the Kafka Gateway, its endpoint isn't covered by the preceding incoming IP ranges and uses a different port. Contact Gravitee for the address and port that apply to your environment.
 {% endhint %}
 
 ## Hybrid Gateway connectivity
 
-If you run self-hosted hybrid Gateways, they connect outbound to the Bridge over HTTPS on port 443.
+If you run self-hosted hybrid Gateways, they connect outbound to the Bridge Gateway over HTTPS on port 443.
 
-Your Gateway always initiates this connection. Gravitee does not open connections into your network, so you do not need to open any inbound ports for your hybrid Gateway.
+Your Gateway always initiates this connection. Gravitee doesn't open connections into your network, so you only need to allow outbound traffic for your hybrid Gateway.

--- a/docs/apim/4.13/hybrid-installation-and-configuration-guides/next-gen-cloud/next-gen-cloud-ip-ranges.md
+++ b/docs/apim/4.13/hybrid-installation-and-configuration-guides/next-gen-cloud/next-gen-cloud-ip-ranges.md
@@ -8,12 +8,12 @@ description: Add the new Next-Gen Cloud IP ranges to your firewall rules before 
 
 Gravitee is moving Next-Gen Cloud hosted environments behind Cloudflare to strengthen security and protect public access to Gravitee services.
 
-After the change, client traffic to your Gravitee environment will reach Cloudflare first, which securely proxies requests to Gravitee. As a result, the public IP addresses resolved and contacted by your client applications may change.
+After the change, client traffic to your Gravitee environment reaches Cloudflare first, which securely proxies requests to Gravitee. As a result, the public IP addresses resolved and contacted by your client applications can change.
 
-If your organization restricts network traffic with firewall rules, add the following IP ranges to your firewall rules before Gravitee migrates your environment, and keep them in place after the migration. If your firewall rules don't allow the new IP ranges, this might block access to Gravitee endpoints from your side.
+If your organization restricts network traffic with firewall rules, add the following IP ranges to your firewall rules before Gravitee migrates your environment, and keep them in place after the migration. If your firewall rules don't allow the new IP ranges, your client applications might not reach your Gravitee endpoints.
 
 {% hint style="warning" %}
-**Add the new ranges alongside your existing rules. Do not replace your current entries.**
+**Add the new ranges alongside your existing rules, and keep your current entries in place.**
 
 Keep the IP addresses that your firewall rules already allow for your Gravitee environment. Both your current addresses and the new ranges are needed until your environment has migrated. After Gravitee confirms that your migration is complete, you can remove the entries you no longer need.
 {% endhint %}
@@ -51,23 +51,23 @@ Your environment receives incoming traffic on the following IP ranges. If your n
 2c0f:f248::/32
 ```
 
-These are Cloudflare's published IP ranges. Cloudflare maintains the authoritative list at [cloudflare.com/ips](https://www.cloudflare.com/ips/). If you generate your firewall rules automatically, source the ranges from there so that you pick up any future changes to the list.
+The preceding IP ranges are published by Cloudflare. Cloudflare maintains the authoritative list at [cloudflare.com/ips](https://www.cloudflare.com/ips/). If you generate your firewall rules automatically, source the ranges from that list so that you capture any future changes.
 
 ## Ports
 
-Allow the following ports alongside the IP ranges above.
+The following table lists the ports to allow alongside the preceding IP ranges:
 
 | Traffic | Protocol and port |
 | ------- | ----------------- |
-| Client applications to your Gravitee environment endpoints | TCP 443 (HTTPS) |
-| Self-hosted hybrid Gateway to Gravitee | TCP 443 (HTTPS), outbound |
+| Client applications to your Gravitee environment endpoints | HTTPS over TCP 443 |
+| Self-hosted hybrid Gateway to Gravitee | Outbound HTTPS over TCP 443 |
 
 {% hint style="info" %}
-If you use the Kafka Gateway, its endpoint is not covered by the incoming IP ranges above and uses a different port. Contact Gravitee for the address and port that apply to your environment.
+If you use the Kafka Gateway, its endpoint isn't covered by the preceding incoming IP ranges and uses a different port. Contact Gravitee for the address and port that apply to your environment.
 {% endhint %}
 
 ## Hybrid Gateway connectivity
 
-If you run self-hosted hybrid Gateways, they connect outbound to the Cloud Gate for your Control Plane region over HTTPS on port 443. For the Cloud Gate URL for each region, see the Next-Gen Cloud hybrid installation guide.
+If you run self-hosted hybrid Gateways, they connect outbound to the Cloud Gate for your Control Plane region over HTTPS on port 443. For the Cloud Gate URL of your region, see the [Next-Gen Cloud architecture](./#architecture).
 
-Your Gateway always initiates this connection. Gravitee does not open connections into your network, so you do not need to open any inbound ports for your hybrid Gateway.
+Your Gateway always initiates this connection. Gravitee doesn't open connections into your network, so you only need to allow outbound traffic for your hybrid Gateway.

--- a/docs/apim/4.13/hybrid-installation-and-configuration-guides/next-gen-cloud/next-gen-cloud-ip-ranges.md
+++ b/docs/apim/4.13/hybrid-installation-and-configuration-guides/next-gen-cloud/next-gen-cloud-ip-ranges.md
@@ -53,6 +53,10 @@ Your environment receives incoming traffic on the following IP ranges. If your n
 
 The preceding IP ranges are published by Cloudflare. Cloudflare maintains the authoritative list at [cloudflare.com/ips](https://www.cloudflare.com/ips/). If you generate your firewall rules automatically, source the ranges from that list so that you capture any future changes.
 
+## Outgoing IP ranges
+
+Outgoing traffic from your environment isn't affected by this change. The IP addresses that your Gateways call your backend services from remain the same, so you don't need to change the firewall rules that protect your backend services.
+
 ## Ports
 
 The following table lists the ports to allow alongside the preceding IP ranges:

--- a/docs/apim/4.13/hybrid-installation-and-configuration-guides/next-gen-cloud/next-gen-cloud-ip-ranges.md
+++ b/docs/apim/4.13/hybrid-installation-and-configuration-guides/next-gen-cloud/next-gen-cloud-ip-ranges.md
@@ -8,9 +8,15 @@ description: Add the new Next-Gen Cloud IP ranges to your firewall rules before 
 
 Gravitee is moving Next-Gen Cloud hosted environments behind Cloudflare to strengthen security and protect public access to Gravitee services.
 
-After the change, client traffic to your Gravitee environment will reach Cloudflare first, which securely proxies requests to Gravitee. As a result, the public IP addresses resolved and contacted by your client applications may change
+After the change, client traffic to your Gravitee environment will reach Cloudflare first, which securely proxies requests to Gravitee. As a result, the public IP addresses resolved and contacted by your client applications may change.
 
-If your organization restricts network traffic with firewall rules, add the following IP ranges to your firewall rules before Gravitee migrates your environment, and keep them in place after the migration. If your firewall rules don't allow the new IP ranges, this might block access to gravitee endpoints from your side.
+If your organization restricts network traffic with firewall rules, add the following IP ranges to your firewall rules before Gravitee migrates your environment, and keep them in place after the migration. If your firewall rules don't allow the new IP ranges, this might block access to Gravitee endpoints from your side.
+
+{% hint style="warning" %}
+**Add the new ranges alongside your existing rules. Do not replace your current entries.**
+
+Keep the IP addresses that your firewall rules already allow for your Gravitee environment. Both your current addresses and the new ranges are needed until your environment has migrated. After Gravitee confirms that your migration is complete, you can remove the entries you no longer need.
+{% endhint %}
 
 {% hint style="info" %}
 Gravitee contacts hosted customers before their environments are migrated.
@@ -44,3 +50,24 @@ Your environment receives incoming traffic on the following IP ranges. If your n
 2a06:98c0::/29
 2c0f:f248::/32
 ```
+
+These are Cloudflare's published IP ranges. Cloudflare maintains the authoritative list at [cloudflare.com/ips](https://www.cloudflare.com/ips/). If you generate your firewall rules automatically, source the ranges from there so that you pick up any future changes to the list.
+
+## Ports
+
+Allow the following ports alongside the IP ranges above.
+
+| Traffic | Protocol and port |
+| ------- | ----------------- |
+| Client applications to your Gravitee environment endpoints | TCP 443 (HTTPS) |
+| Self-hosted hybrid Gateway to Gravitee | TCP 443 (HTTPS), outbound |
+
+{% hint style="info" %}
+If you use the Kafka Gateway, its endpoint is not covered by the incoming IP ranges above and uses a different port. Contact Gravitee for the address and port that apply to your environment.
+{% endhint %}
+
+## Hybrid Gateway connectivity
+
+If you run self-hosted hybrid Gateways, they connect outbound to the Cloud Gate for your Control Plane region over HTTPS on port 443. For the Cloud Gate URL for each region, see the Next-Gen Cloud hybrid installation guide.
+
+Your Gateway always initiates this connection. Gravitee does not open connections into your network, so you do not need to open any inbound ports for your hybrid Gateway.


### PR DESCRIPTION
## Why

Customer replies to the 27 Aug Cloud migration campaign clustered around gaps on the Classic Cloud and Next-Gen Cloud IP range pages. Each change below traces to at least one live customer question.

## What changes

Applied to both pages, in **4.12 and 4.13**.

### 1. Say that the customer keeps their existing entry

Both pages already say to *add* the new ranges "and keep them in place after the migration" — but that refers to the **new** ranges. Neither page mentions the address the customer already allows.

A reader can follow the page correctly and still remove the entry carrying their live traffic, breaking access **before** their migration has started. Added a warning hint making the additive instruction explicit, and saying when the old entry can safely be removed.

This is the only change here that prevents a customer-side outage.

### 2. State that Next-Gen outgoing traffic is unaffected

The Next-Gen page documents incoming ranges only. That is correct — Next-Gen environments are not moving platform, so their egress addresses do not change — but the page never says so.

Because the Classic page *does* have an outgoing section, a customer with estate on both platforms cannot tell whether the omission means "unchanged" or "not documented yet". Added an `Outgoing IP ranges` section mirroring the Classic page's heading and position, stating plainly that outgoing is unaffected. **No IP ranges are published by this change.**

### 3. Add ports

The pages list ranges but no ports, so the ranges are not actionable in a firewall rule. Added a ports table (HTTPS over TCP 443 for client traffic, and outbound for hybrid Gateway traffic).

The Kafka Gateway is handled with a pointer rather than a number: its endpoint is not behind the Cloudflare ranges, so a customer who allowlists only those has the wrong list. The specific port is left to Gravitee to confirm per environment rather than published here.

### 4. State that hybrid is outbound-only

Customers with self-hosted hybrid Gateways have been asking which **inbound** ports to open. The connection is outbound-only and Gateway-initiated. Added a short section saying so, using each platform's existing terminology — the **Bridge** on Classic, the **Cloud Gate** on Next-Gen.

### 5. Link Cloudflare's canonical list

The incoming ranges are a static copy of Cloudflare's published list and will silently lag it. Linked `cloudflare.com/ips` for customers who generate firewall rules automatically.

### Drive-by

A missing full stop and a lowercase "gravitee" on the Next-Gen page.

## Notes for reviewers

- The IP ranges themselves are **unchanged**. The incoming list was verified on 2026-08-28 as an exact match for Cloudflare's current published list.
- 4.12 and 4.13 are kept identical, as they were before this change.
- Thanks @garethbrinn for the style pass — the later commit is rebased on top of it and follows the same conventions.
- Still deliberately out of scope: stating that the published Classic outgoing range covers the shared worker platform only. Customers on dedicated clusters have their own addresses and cannot reconcile what they observe against that range — but fixing it properly needs a decision on what to publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)