### PR TITLE
docs(apim): document the certificate authorities the Gateway advertises

### DIFF
--- a/docs/apim/4.11/prepare-a-production-environment/configure-your-http-server.md
+++ b/docs/apim/4.11/prepare-a-production-environment/configure-your-http-server.md
@@ -353,6 +353,11 @@ The following fields configure HTTPS on the Gateway HTTP server. Set them under 
             <td><code>none</code></td>
         </tr>
         <tr>
+            <td><code>http.ssl.sendClientCertificateAuthorities</code></td>
+            <td>When <code>true</code>, the Gateway sends the configured truststore as the list of acceptable certificate authorities in the TLS <code>CertificateRequest</code>. Certificates registered at runtime by mTLS plan subscriptions are never sent. See <a href="configure-your-http-server.md#control-which-certificate-authorities-the-gateway-advertises">Control which certificate authorities the Gateway advertises</a>.</td>
+            <td><code>false</code></td>
+        </tr>
+        <tr>
             <td><code>http.ssl.clientAuthHeader.name</code></td>
             <td>Header name to extract the client certificate from. Use this when NGINX or another load balancer terminates TLS in front of the Gateway.</td>
             <td>-</td>
@@ -554,6 +559,85 @@ Available modes for `clientAuth`:
 * `required`: Client authentication is required (replacement of the `true` value)
 
 
+
+## Control which certificate authorities the Gateway advertises
+
+When `clientAuth` is `request` or `required`, the Gateway asks the client for a certificate with a TLS `CertificateRequest`. That message carries a list of acceptable certificate authorities, which a client can use to decide which of its certificates to present.
+
+Starting with Gravitee APIM 4.11.27, the Gateway sends an **empty** list. Earlier versions sent every certificate in the truststore, which disclosed the accepted client identities to every client of the listener, including callers that present no certificate at all. This matters most with [mTLS plans](../secure-and-expose-apis/plans/mtls.md), where the truststore holds each subscribed application's client certificate.
+
+An empty list means "no constraint": clients continue to present their certificate, and validation is unchanged. Enable the option only if your clients rely on the advertised list to pick a certificate.
+
+{% tabs %}
+{% tab title="gravitee.yaml" %}
+```yaml
+http:
+  ssl:
+    clientAuth: required
+    sendClientCertificateAuthorities: true
+    truststore:
+      path: /path/to/truststore.jks
+      password: adminadmin
+```
+{% endtab %}
+
+{% tab title=".env" %}
+```bash
+gravitee_http_ssl_clientAuth=required
+gravitee_http_ssl_sendClientCertificateAuthorities=true
+gravitee_http_ssl_truststore_path=/path/to/truststore.jks
+gravitee_http_ssl_truststore_password=adminadmin
+```
+{% endtab %}
+
+{% tab title="Helm values.yaml" %}
+```yaml
+gateway:
+  ssl:
+    enabled: true
+    clientAuth: required
+    sendClientCertificateAuthorities: true
+    truststore:
+      type: jks
+      path: /path/to/truststore.jks
+      password: adminadmin
+```
+{% endtab %}
+{% endtabs %}
+
+{% hint style="warning" %}
+Don't enable this on a listener that serves mTLS plans. A non-empty list is a constraint, not a hint: a client whose certificate issuer is absent from the list withholds its certificate entirely. Subscription certificates are self-signed leaves that are never issued by an authority of the configured truststore, so enabling this cuts off every mTLS subscription on that listener.
+{% endhint %}
+
+### Advertised authorities behavior
+
+* **Unset or `false`**: the Gateway sends an empty list. Clients aren't told which authorities are accepted, and every client certificate is still validated against the full truststore.
+* **`true`**: the Gateway sends the certificates of the **configured** truststore only, the one declared under `ssl.truststore`.
+* **Runtime certificates are never sent**: client certificates registered at runtime, such as those loaded from mTLS plan subscriptions, stay out of the advertised list whatever the setting. They remain fully trusted for validation.
+* **Reloads follow the truststore**: when the configured truststore is reloaded, the advertised list is rebuilt from its new contents.
+* **Requires a client certificate request**: the list is only ever sent when `clientAuth` is `request` or `required`. With `none`, the Gateway sends no `CertificateRequest` at all.
+
+### Apply advertised authorities to other Gateway servers
+
+The `ssl.sendClientCertificateAuthorities` field is available under every server prefix. Set it on the top-level TCP server, on the Kafka Gateway server, and on each entry of the `servers[]` array by adding it under the corresponding prefix.
+
+{% code title="gravitee.yaml" %}
+```yaml
+tcp:
+  ssl:
+    sendClientCertificateAuthorities: true
+
+kafka:
+  ssl:
+    sendClientCertificateAuthorities: true
+
+servers:
+  - id: "http_secured"
+    type: http
+    ssl:
+      sendClientCertificateAuthorities: true
+```
+{% endcode %}
 
 ## Reject revoked client certificates with a CRL
 

--- a/docs/apim/4.11/release-information/breaking-changes-and-deprecations.md
+++ b/docs/apim/4.11/release-information/breaking-changes-and-deprecations.md
@@ -15,6 +15,28 @@ Here are the breaking changes for versions 4.X of Gravitee and versions 3.X of G
 
 Here are the breaking changes from versions 4.X of Gravitee.
 
+#### 4.11.27
+
+**The Gateway no longer advertises its truststore during the TLS handshake**
+
+From 4.11.27, the Gateway sends an empty list of acceptable certificate authorities in the TLS `CertificateRequest` it issues when `ssl.clientAuth` is `request` or `required`. Previously, it sent every certificate in its truststore.
+
+This closes an information disclosure. With an mTLS plan, the Gateway loads each subscribed application's client certificate into an in-memory truststore. Those certificates are end-entity leaves, not certificate authorities, and the Gateway advertised them to every client of the listener, including callers of the listener's other APIs who present no certificate at all. Anyone opening a TLS connection could read the distinguished names of the client identities the Gateway accepts.
+
+Client certificate validation is unchanged. The full truststore still validates incoming certificates, so mTLS plan matching and subscription behavior are unaffected. An empty list means "no constraint", so clients continue to present their certificate.
+
+The change affects only clients that relied on the advertised list to choose which certificate to present. A client holding several client certificates, typically a Java client with more than one key entry in its keystore, may now present the wrong one and be rejected. If that applies to you, set `ssl.sendClientCertificateAuthorities` to `true` on the affected listener to send the configured truststore again:
+
+```yaml
+http:
+  ssl:
+    sendClientCertificateAuthorities: true
+```
+
+Don't enable it on a listener that serves mTLS plans. A non-empty list is a constraint, not a hint: a client whose certificate issuer is absent from it withholds its certificate entirely. Subscription certificates are self-signed leaves that are never issued by an authority of the configured truststore, so enabling this cuts off every mTLS subscription on that listener. Certificates registered by subscriptions are never advertised, whatever the setting.
+
+For the full option reference, see [Control which certificate authorities the Gateway advertises](../prepare-a-production-environment/configure-your-http-server.md#control-which-certificate-authorities-the-gateway-advertises).
+
 #### 4.11.14
 
 **API Key policy: the header name set on a plan takes precedence over the Gateway setting**

--- a/docs/apim/4.11/secure-and-expose-apis/plans/mtls.md
+++ b/docs/apim/4.11/secure-and-expose-apis/plans/mtls.md
@@ -61,6 +61,12 @@ gateway:
 ```
 {% endcode %}
 
+{% hint style="warning" %}
+Don't set `ssl.sendClientCertificateAuthorities` to `true` on a listener that serves mTLS plans. Application certificates are self-signed leaves, so they are never issued by an authority of the configured truststore. A non-empty list of acceptable certificate authorities is a constraint, not a hint: clients whose issuer is absent from it withhold their certificate entirely, and every mTLS subscription on that listener stops working. See [Control which certificate authorities the Gateway advertises.](../../prepare-a-production-environment/configure-your-http-server.md#control-which-certificate-authorities-the-gateway-advertises)
+
+Starting with APIM 4.11.27, the Gateway sends an empty list by default, and never advertises the certificates it loads from subscriptions.
+{% endhint %}
+
 To reject clients whose certificates have been revoked, enable CRL checking on the Gateway. CRL evaluation runs during the TLS handshake, before plan selection, so revoked certificates never reach mTLS plan matching. See [Reject revoked client certificates with a CRL.](../../prepare-a-production-environment/configure-your-http-server.md#reject-revoked-client-certificates-with-a-crl)
 
 ## Creating an mTLS plan

--- a/docs/apim/4.12/prepare-a-production-environment/configure-your-http-server.md
+++ b/docs/apim/4.12/prepare-a-production-environment/configure-your-http-server.md
@@ -367,6 +367,11 @@ The following fields configure HTTPS on the Gateway HTTP server. Set them under 
             <td><code>none</code></td>
         </tr>
         <tr>
+            <td><code>http.ssl.sendClientCertificateAuthorities</code></td>
+            <td>When <code>true</code>, the Gateway sends the configured truststore as the list of acceptable certificate authorities in the TLS <code>CertificateRequest</code>. Certificates registered at runtime by mTLS plan subscriptions are never sent. See <a href="configure-your-http-server.md#control-which-certificate-authorities-the-gateway-advertises">Control which certificate authorities the Gateway advertises</a>.</td>
+            <td><code>false</code></td>
+        </tr>
+        <tr>
             <td><code>http.ssl.clientAuthHeader.name</code></td>
             <td>Header name to extract the client certificate from. Use this when NGINX or another load balancer terminates TLS in front of the Gateway.</td>
             <td>-</td>
@@ -568,6 +573,85 @@ Available modes for `clientAuth`:
 * `required`: Client authentication is required (replacement of the `true` value)
 
 
+
+## Control which certificate authorities the Gateway advertises
+
+When `clientAuth` is `request` or `required`, the Gateway asks the client for a certificate with a TLS `CertificateRequest`. That message carries a list of acceptable certificate authorities, which a client can use to decide which of its certificates to present.
+
+Starting with Gravitee APIM 4.12.19, the Gateway sends an **empty** list. Earlier versions sent every certificate in the truststore, which disclosed the accepted client identities to every client of the listener, including callers that present no certificate at all. This matters most with [mTLS plans](../secure-and-expose-apis/plans/mtls.md), where the truststore holds each subscribed application's client certificate.
+
+An empty list means "no constraint": clients continue to present their certificate, and validation is unchanged. Enable the option only if your clients rely on the advertised list to pick a certificate.
+
+{% tabs %}
+{% tab title="gravitee.yaml" %}
+```yaml
+http:
+  ssl:
+    clientAuth: required
+    sendClientCertificateAuthorities: true
+    truststore:
+      path: /path/to/truststore.jks
+      password: adminadmin
+```
+{% endtab %}
+
+{% tab title=".env" %}
+```bash
+gravitee_http_ssl_clientAuth=required
+gravitee_http_ssl_sendClientCertificateAuthorities=true
+gravitee_http_ssl_truststore_path=/path/to/truststore.jks
+gravitee_http_ssl_truststore_password=adminadmin
+```
+{% endtab %}
+
+{% tab title="Helm values.yaml" %}
+```yaml
+gateway:
+  ssl:
+    enabled: true
+    clientAuth: required
+    sendClientCertificateAuthorities: true
+    truststore:
+      type: jks
+      path: /path/to/truststore.jks
+      password: adminadmin
+```
+{% endtab %}
+{% endtabs %}
+
+{% hint style="warning" %}
+Don't enable this on a listener that serves mTLS plans. A non-empty list is a constraint, not a hint: a client whose certificate issuer is absent from the list withholds its certificate entirely. Subscription certificates are self-signed leaves that are never issued by an authority of the configured truststore, so enabling this cuts off every mTLS subscription on that listener.
+{% endhint %}
+
+### Advertised authorities behavior
+
+* **Unset or `false`**: the Gateway sends an empty list. Clients aren't told which authorities are accepted, and every client certificate is still validated against the full truststore.
+* **`true`**: the Gateway sends the certificates of the **configured** truststore only, the one declared under `ssl.truststore`.
+* **Runtime certificates are never sent**: client certificates registered at runtime, such as those loaded from mTLS plan subscriptions, stay out of the advertised list whatever the setting. They remain fully trusted for validation.
+* **Reloads follow the truststore**: when the configured truststore is reloaded, the advertised list is rebuilt from its new contents.
+* **Requires a client certificate request**: the list is only ever sent when `clientAuth` is `request` or `required`. With `none`, the Gateway sends no `CertificateRequest` at all.
+
+### Apply advertised authorities to other Gateway servers
+
+The `ssl.sendClientCertificateAuthorities` field is available under every server prefix. Set it on the top-level TCP server, on the Kafka Gateway server, and on each entry of the `servers[]` array by adding it under the corresponding prefix.
+
+{% code title="gravitee.yaml" %}
+```yaml
+tcp:
+  ssl:
+    sendClientCertificateAuthorities: true
+
+kafka:
+  ssl:
+    sendClientCertificateAuthorities: true
+
+servers:
+  - id: "http_secured"
+    type: http
+    ssl:
+      sendClientCertificateAuthorities: true
+```
+{% endcode %}
 
 ## Reject revoked client certificates with a CRL
 

--- a/docs/apim/4.12/release-information/breaking-changes-and-deprecations.md
+++ b/docs/apim/4.12/release-information/breaking-changes-and-deprecations.md
@@ -15,6 +15,28 @@ Here are the breaking changes for versions 4.X of Gravitee and versions 3.X of G
 
 Here are the breaking changes from versions 4.X of Gravitee.
 
+#### 4.12.19
+
+**The Gateway no longer advertises its truststore during the TLS handshake**
+
+From 4.12.19, the Gateway sends an empty list of acceptable certificate authorities in the TLS `CertificateRequest` it issues when `ssl.clientAuth` is `request` or `required`. Previously, it sent every certificate in its truststore.
+
+This closes an information disclosure. With an mTLS plan, the Gateway loads each subscribed application's client certificate into an in-memory truststore. Those certificates are end-entity leaves, not certificate authorities, and the Gateway advertised them to every client of the listener, including callers of the listener's other APIs who present no certificate at all. Anyone opening a TLS connection could read the distinguished names of the client identities the Gateway accepts.
+
+Client certificate validation is unchanged. The full truststore still validates incoming certificates, so mTLS plan matching and subscription behavior are unaffected. An empty list means "no constraint", so clients continue to present their certificate.
+
+The change affects only clients that relied on the advertised list to choose which certificate to present. A client holding several client certificates, typically a Java client with more than one key entry in its keystore, may now present the wrong one and be rejected. If that applies to you, set `ssl.sendClientCertificateAuthorities` to `true` on the affected listener to send the configured truststore again:
+
+```yaml
+http:
+  ssl:
+    sendClientCertificateAuthorities: true
+```
+
+Don't enable it on a listener that serves mTLS plans. A non-empty list is a constraint, not a hint: a client whose certificate issuer is absent from it withholds its certificate entirely. Subscription certificates are self-signed leaves that are never issued by an authority of the configured truststore, so enabling this cuts off every mTLS subscription on that listener. Certificates registered by subscriptions are never advertised, whatever the setting.
+
+For the full option reference, see [Control which certificate authorities the Gateway advertises](../prepare-a-production-environment/configure-your-http-server.md#control-which-certificate-authorities-the-gateway-advertises).
+
 #### 4.12.0
 
 **JSON Validation policy: response error keys corrected**

--- a/docs/apim/4.12/secure-and-expose-apis/plans/mtls.md
+++ b/docs/apim/4.12/secure-and-expose-apis/plans/mtls.md
@@ -61,6 +61,12 @@ gateway:
 ```
 {% endcode %}
 
+{% hint style="warning" %}
+Don't set `ssl.sendClientCertificateAuthorities` to `true` on a listener that serves mTLS plans. Application certificates are self-signed leaves, so they are never issued by an authority of the configured truststore. A non-empty list of acceptable certificate authorities is a constraint, not a hint: clients whose issuer is absent from it withhold their certificate entirely, and every mTLS subscription on that listener stops working. See [Control which certificate authorities the Gateway advertises.](../../prepare-a-production-environment/configure-your-http-server.md#control-which-certificate-authorities-the-gateway-advertises)
+
+Starting with APIM 4.12.19, the Gateway sends an empty list by default, and never advertises the certificates it loads from subscriptions.
+{% endhint %}
+
 To reject clients whose certificates have been revoked, enable CRL checking on the Gateway. CRL evaluation runs during the TLS handshake, before plan selection, so revoked certificates never reach mTLS plan matching. See [Reject revoked client certificates with a CRL.](../../prepare-a-production-environment/configure-your-http-server.md#reject-revoked-client-certificates-with-a-crl)
 
 ## Creating an mTLS plan

--- a/docs/apim/4.13/.version-overrides
+++ b/docs/apim/4.13/.version-overrides
@@ -51,3 +51,9 @@ analyze-and-monitor-apis/logging/configure-environment-level-logs.md
 # kafka_active_connections gauge (APIM 4.13.0 feature, ESM-72) — the metric ships in the 7.1.x
 # native Kafka reactor; 4.12 pins 7.0.8, which does not carry it, so the section must not sync back
 analyze-and-monitor-apis/logging/expose-metrics-to-prometheus.md
+# Gateway stops advertising its truststore as the TLS acceptable certificate authorities,
+# and the new ssl.sendClientCertificateAuthorities opt-in (APIM 4.13.0, APIM-14863).
+# 4.12 runs gravitee-node 9.7.0, where the option does not exist and the old behaviour stands,
+# so this content must not be written back to 4.12 nor re-synced from it.
+prepare-a-production-environment/configure-your-http-server.md
+secure-and-expose-apis/plans/mtls.md

--- a/docs/apim/4.13/.version-overrides
+++ b/docs/apim/4.13/.version-overrides
@@ -52,8 +52,9 @@ analyze-and-monitor-apis/logging/configure-environment-level-logs.md
 # native Kafka reactor; 4.12 pins 7.0.8, which does not carry it, so the section must not sync back
 analyze-and-monitor-apis/logging/expose-metrics-to-prometheus.md
 # Gateway stops advertising its truststore as the TLS acceptable certificate authorities,
-# and the new ssl.sendClientCertificateAuthorities opt-in (APIM 4.13.0, APIM-14863).
-# 4.12 runs gravitee-node 9.7.0, where the option does not exist and the old behaviour stands,
-# so this content must not be written back to 4.12 nor re-synced from it.
+# and the new ssl.sendClientCertificateAuthorities opt-in (APIM-14863).
+# The change is backported, so 4.12 documents it too — but each version names the release it
+# ships in (4.13.0 here, 4.12.19 there) and only 4.13 documents the Edge listener, which has
+# no ssl block before 4.13. Syncing this content down from 4.12 would overwrite both.
 prepare-a-production-environment/configure-your-http-server.md
 secure-and-expose-apis/plans/mtls.md

--- a/docs/apim/4.13/prepare-a-production-environment/configure-your-http-server.md
+++ b/docs/apim/4.13/prepare-a-production-environment/configure-your-http-server.md
@@ -367,6 +367,11 @@ The following fields configure HTTPS on the Gateway HTTP server. Set them under 
             <td><code>none</code></td>
         </tr>
         <tr>
+            <td><code>http.ssl.sendClientCertificateAuthorities</code></td>
+            <td>When <code>true</code>, the Gateway sends the configured truststore as the list of acceptable certificate authorities in the TLS <code>CertificateRequest</code>. Certificates registered at runtime by mTLS plan subscriptions are never sent. See <a href="configure-your-http-server.md#control-which-certificate-authorities-the-gateway-advertises">Control which certificate authorities the Gateway advertises</a>.</td>
+            <td><code>false</code></td>
+        </tr>
+        <tr>
             <td><code>http.ssl.clientAuthHeader.name</code></td>
             <td>Header name to extract the client certificate from. Use this when NGINX or another load balancer terminates TLS in front of the Gateway.</td>
             <td>-</td>
@@ -568,6 +573,93 @@ Available modes for `clientAuth`:
 * `required`: Client authentication is required (replacement of the `true` value)
 
 
+
+## Control which certificate authorities the Gateway advertises
+
+When `clientAuth` is `request` or `required`, the Gateway asks the client for a certificate with a TLS `CertificateRequest`. That message carries a list of acceptable certificate authorities, which a client can use to decide which of its certificates to present.
+
+Starting with Gravitee APIM 4.13, the Gateway sends an **empty** list. Earlier versions sent every certificate in the truststore, which disclosed the accepted client identities to every client of the listener, including callers that present no certificate at all. This matters most with [mTLS plans](../secure-and-expose-apis/plans/mtls.md), where the truststore holds each subscribed application's client certificate.
+
+An empty list means "no constraint": clients continue to present their certificate, and validation is unchanged. Enable the option only if your clients rely on the advertised list to pick a certificate.
+
+{% tabs %}
+{% tab title="gravitee.yaml" %}
+```yaml
+http:
+  ssl:
+    clientAuth: required
+    sendClientCertificateAuthorities: true
+    truststore:
+      path: /path/to/truststore.jks
+      password: adminadmin
+```
+{% endtab %}
+
+{% tab title=".env" %}
+```bash
+gravitee_http_ssl_clientAuth=required
+gravitee_http_ssl_sendClientCertificateAuthorities=true
+gravitee_http_ssl_truststore_path=/path/to/truststore.jks
+gravitee_http_ssl_truststore_password=adminadmin
+```
+{% endtab %}
+
+{% tab title="Helm values.yaml" %}
+```yaml
+gateway:
+  ssl:
+    enabled: true
+    clientAuth: required
+    sendClientCertificateAuthorities: true
+    truststore:
+      type: jks
+      path: /path/to/truststore.jks
+      password: adminadmin
+```
+{% endtab %}
+{% endtabs %}
+
+{% hint style="warning" %}
+Don't enable this on a listener that serves mTLS plans. A non-empty list is a constraint, not a hint: a client whose certificate issuer is absent from the list withholds its certificate entirely. Subscription certificates are self-signed leaves that are never issued by an authority of the configured truststore, so enabling this cuts off every mTLS subscription on that listener.
+{% endhint %}
+
+### Advertised authorities behavior
+
+* **Unset or `false`**: the Gateway sends an empty list. Clients aren't told which authorities are accepted, and every client certificate is still validated against the full truststore.
+* **`true`**: the Gateway sends the certificates of the **configured** truststore only, the one declared under `ssl.truststore`.
+* **Runtime certificates are never sent**: client certificates registered at runtime, such as those loaded from mTLS plan subscriptions, stay out of the advertised list whatever the setting. They remain fully trusted for validation.
+* **Reloads follow the truststore**: when the configured truststore is reloaded, the advertised list is rebuilt from its new contents.
+* **Requires a client certificate request**: the list is only ever sent when `clientAuth` is `request` or `required`. With `none`, the Gateway sends no `CertificateRequest` at all.
+
+### Apply advertised authorities to other Gateway servers
+
+The `ssl.sendClientCertificateAuthorities` field is available under every server prefix. Set it on the top-level TCP server, on the Kafka Gateway server, on the Edge Reactor server, and on each entry of the `servers[]` array by adding it under the corresponding prefix.
+
+{% code title="gravitee.yaml" %}
+```yaml
+tcp:
+  ssl:
+    sendClientCertificateAuthorities: true
+
+kafka:
+  ssl:
+    sendClientCertificateAuthorities: true
+
+edge:
+  ssl:
+    sendClientCertificateAuthorities: true
+
+servers:
+  - id: "http_secured"
+    type: http
+    ssl:
+      sendClientCertificateAuthorities: true
+```
+{% endcode %}
+
+{% hint style="info" %}
+The Edge Reactor server is the usual place to enable this. Its truststore holds the certificate authority of the Edge fleet rather than enrolled leaf certificates, and no subscription certificate is ever registered on it, so an enrolled agent holding several certificates can use the advertised list to pick the right one.
+{% endhint %}
 
 ## Reject revoked client certificates with a CRL
 

--- a/docs/apim/4.13/release-information/breaking-changes-and-deprecations.md
+++ b/docs/apim/4.13/release-information/breaking-changes-and-deprecations.md
@@ -25,6 +25,26 @@ A request carrying dot segments is now routed on the resolved path, so it can re
 
 Set `http.pathHandling: RAW` to restore the previous behavior, which also restores a known authorization bypass. Set `http.pathHandling: REJECT` to close the exposure without changing any routing decision: a non-canonical path is answered with `400` and nothing is rewritten. For the upgrade checklist and the limits of each mode, see [Request Path Handling](../configure-and-manage-the-platform/gravitee-gateway/request-path-handling/README.md).
 
+**The Gateway no longer advertises its truststore during the TLS handshake**
+
+From 4.13.0, the Gateway sends an empty list of acceptable certificate authorities in the TLS `CertificateRequest` it issues when `ssl.clientAuth` is `request` or `required`. Previously, it sent every certificate in its truststore.
+
+This closes an information disclosure. With an mTLS plan, the Gateway loads each subscribed application's client certificate into an in-memory truststore. Those certificates are end-entity leaves, not certificate authorities, and the Gateway advertised them to every client of the listener, including callers of the listener's other APIs who present no certificate at all. Anyone opening a TLS connection could read the distinguished names of the client identities the Gateway accepts.
+
+Client certificate validation is unchanged. The full truststore still validates incoming certificates, so mTLS plan matching and subscription behavior are unaffected. An empty list means "no constraint", so clients continue to present their certificate.
+
+The change affects only clients that relied on the advertised list to choose which certificate to present. A client holding several client certificates, typically a Java client with more than one key entry in its keystore, may now present the wrong one and be rejected. If that applies to you, set `ssl.sendClientCertificateAuthorities` to `true` on the affected listener to send the configured truststore again:
+
+```yaml
+http:
+  ssl:
+    sendClientCertificateAuthorities: true
+```
+
+Don't enable it on a listener that serves mTLS plans. A non-empty list is a constraint, not a hint: a client whose certificate issuer is absent from it withholds its certificate entirely. Subscription certificates are self-signed leaves that are never issued by an authority of the configured truststore, so enabling this cuts off every mTLS subscription on that listener. Certificates registered by subscriptions are never advertised, whatever the setting.
+
+For the full option reference, see [Control which certificate authorities the Gateway advertises](../prepare-a-production-environment/configure-your-http-server.md#control-which-certificate-authorities-the-gateway-advertises).
+
 **Management API v1 plan endpoints reject V4, Federated, and Federated Agent APIs**
 
 From 4.13.0, the plan endpoints of the legacy Management API v1 (`/management/organizations/{orgId}/environments/{envId}/apis/{apiId}/plans`) reject V4, Federated, and Federated Agent APIs. Every plan operation for one of these APIs returns HTTP `400`. The error message names the API's definition version, for example: `API definition version 4.0.0 is not supported by Management API v1. Use Management API v2 instead (/management/v2/environments/{envId}/apis/{apiId}/...).`

--- a/docs/apim/4.13/secure-and-expose-apis/plans/mtls.md
+++ b/docs/apim/4.13/secure-and-expose-apis/plans/mtls.md
@@ -61,6 +61,12 @@ gateway:
 ```
 {% endcode %}
 
+{% hint style="warning" %}
+Don't set `ssl.sendClientCertificateAuthorities` to `true` on a listener that serves mTLS plans. Application certificates are self-signed leaves, so they are never issued by an authority of the configured truststore. A non-empty list of acceptable certificate authorities is a constraint, not a hint: clients whose issuer is absent from it withhold their certificate entirely, and every mTLS subscription on that listener stops working. See [Control which certificate authorities the Gateway advertises.](../../prepare-a-production-environment/configure-your-http-server.md#control-which-certificate-authorities-the-gateway-advertises)
+
+Starting with APIM 4.13, the Gateway sends an empty list by default, and never advertises the certificates it loads from subscriptions.
+{% endhint %}
+
 To reject clients whose certificates have been revoked, enable CRL checking on the Gateway. CRL evaluation runs during the TLS handshake, before plan selection, so revoked certificates never reach mTLS plan matching. See [Reject revoked client certificates with a CRL.](../../prepare-a-production-environment/configure-your-http-server.md#reject-revoked-client-certificates-with-a-crl)
 
 ## Creating an mTLS plan


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14863

Companion to [gravitee-api-management#19349](https://github.com/gravitee-io/gravitee-api-management/pull/19349) (approved, targets `master` → 4.13) and [gravitee-node#603](https://github.com/gravitee-io/gravitee-node/pull/603) (merged, released in node 9.8.0).

## What changed in the product

When `ssl.clientAuth` is `request` or `required`, the Gateway asks clients for a certificate with a TLS `CertificateRequest`. That message carries a list of acceptable certificate authorities. The Gateway used to fill it with **every** certificate in its truststore.

With an mTLS plan the truststore holds each subscribed application's client certificate — end-entity leaves, not authorities. So the Gateway was telling every client of the listener which client identities it accepts, including callers of that listener's other APIs who present no certificate at all.

From 4.13 the list is **empty by default**, and certificates registered at runtime by subscriptions are never advertised, whatever the setting. Validation is untouched: the full truststore still validates client certificates, so mTLS plan matching is unaffected.

## Why this needs docs

`sendClientCertificateAuthorities` currently appears nowhere in this repository, and the behaviour change is absent from the 4.13.0 breaking changes. As it stands, an operator upgrading to 4.13 has no way to learn either that the behaviour changed or that the option exists.

## Versions covered

The fix is backported, so three doc versions carry it. 4.10 and 4.9 are deliberately out of scope — they run `gravitee-node` 7.27.0 and keep the old behaviour, so their pages are correct as they stand.

| Doc version | Ships in | Depends on |
|---|---|---|
| `4.13` | 4.13.0 | node 9.8.0, [apim#19349](https://github.com/gravitee-io/gravitee-api-management/pull/19349) (approved) |
| `4.12` | 4.12.19 | node 9.8.0, [apim#19514](https://github.com/gravitee-io/gravitee-api-management/pull/19514) |
| `4.11` | 4.11.27 | node 8.x, [gravitee-node#605](https://github.com/gravitee-io/gravitee-node/pull/605) → then an APIM 4.11.x bump |

⚠️ **The patch numbers are the current development revisions of each branch.** They hold only if the backports merge before the next patch release of 4.12.x and 4.11.x. Worth re-checking before this merges.

Two differences between versions, both deliberate:

- Each version names its own release rather than repeating 4.13.
- Only 4.13 documents the **Edge** listener. Neither 4.12 nor 4.11 has an `edge.ssl` block — Edge SSL support is a 4.13 feature — so the Edge paragraph and the Edge line of the multi-prefix example are dropped there, matching the same trimming applied to the 4.12 code backport.

## Three pages, three audiences

| Page | Audience | What it carries |
|---|---|---|
| `release-information/breaking-changes-and-deprecations.md` | operator preparing an upgrade | what changed, what did not, and the one case that breaks |
| `prepare-a-production-environment/configure-your-http-server.md` | operator configuring TLS | the reference: table row, three deployment forms, per-value behaviour, every server prefix |
| `secure-and-expose-apis/plans/mtls.md` | anyone setting up an mTLS plan | the trap, next to the client-auth config it applies to |

The new section in the HTTP server page mirrors the structure of the CRL section directly below it — same shape of option, also available under every server prefix.

## The trap, stated in all three

Enabling the option on a listener that serves mTLS plans **cuts off every subscription on it**. A non-empty list is a constraint, not a hint: a client whose certificate issuer is absent from it withholds its certificate entirely, and subscription certificates are self-signed leaves that no configured authority ever issued.

This is not inferred from the code — it is asserted by an integration test added in the companion PR, `should_cut_off_a_subscription_whose_certificate_is_not_issued_by_an_advertised_authority`, which pins a 401 and the mTLS failure message.

Edge is the counter-case and gets a note of its own: its truststore holds the certificate authority of the fleet rather than enrolled leaves, and no subscription certificate is ever registered on that private server, so it is the one listener where enabling this is usually both safe and wanted.

## Checked

- The three relative cross-links resolve to existing files, and the `#control-which-certificate-authorities-the-gateway-advertises` anchor matches the heading it points at.
- Property names and the `false` default match `VertxServerOptions` in gravitee-node 9.8.0, and the `.env` form (`gravitee_http_ssl_sendClientCertificateAuthorities`) follows the mapping already used on the same page.
- The `4.13` `.version-overrides` entry is still required and its justification was rewritten. It originally said the content must not reach 4.12 because 4.12 runs node 9.7.0 where the option does not exist — true when written, false once the backport was decided. The override still stands for a different reason: the versions name different releases and only 4.13 covers Edge, so syncing 4.12 down over 4.13 would overwrite both.
- `python .github/scripts/lint_overrides.py . apim 4.12 4.13` passes locally, run with the same arguments as CI.
- `4.10` and `4.9` are untouched on purpose.

## Additional context

Reproduced end to end on a running Gateway with `openssl s_client` and no client certificate, before and after, on TLS 1.2 and 1.3: the subscribed application's DN was visible before, `No client certificate CA names sent` after, with the subscribed leaf still returning 200 and no certificate still returning 401.
