### PR TITLE
docs(gamma): remove em dashes from the Observe overview intro

### DIFF
--- a/docs/gamma/4.12/agent-management/observe/README.md
+++ b/docs/gamma/4.12/agent-management/observe/README.md
@@ -6,7 +6,7 @@ description: Monitor AI traffic across your MCP, LLM, and A2A proxies, and from 
 
 # Observe
 
-Monitor AI traffic across all three proxy types — MCP, LLM, and A2A — and from employee devices through Edge Management.
+Monitor AI traffic across the MCP, LLM, and A2A proxy types, and from employee devices through Edge Management.
 
 * [**Monitor proxy activity on the Overview page**](monitor-proxy-activity.md). Read the rolling 24-hour snapshot on the Overview page of a single LLM Proxy or MCP Proxy.
 * [**Monitor your MCP servers**](monitor-your-mcp-servers.md): view tool invocation metrics, error rates, and latency for MCP Proxies.


### PR DESCRIPTION
## What

One-line style fix on `docs/gamma/4.12/agent-management/observe/README.md`: the section intro used two em dashes to set off the proxy types. The docs style guide doesn't allow em dashes, so the sentence now reads as a plain list. No other content change.

## Why now

Merging any change under `docs/gamma/4.12/` makes the GitBook GitHub App re-import the Gamma space, which also clears a stale cached 404 on the two new Tracing pages from #2323 (`agent-management/observe/tracing` and `.../tracing/trace-an-agent-request`). Both pages are in the published revision (their `.md` variants already return 200), only the HTML routes are stuck.

## Checks

- Vale at `--minAlertLevel=suggestion`: 0 errors, 0 warnings, 0 suggestions on the touched file.
- Backlog-style fix: no release notes or breaking-changes entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PWv6p8Gv3RaczQa7oinuAQ
