### PR TITLE
AGENT-DRAFT: PORTAL-3 — Import content from external sources

### DIFF
--- a/docs/apim/4.13/developer-portal/new-developer-portal/customize-the-navigation/import-content-from-external-sources.md
+++ b/docs/apim/4.13/developer-portal/new-developer-portal/customize-the-navigation/import-content-from-external-sources.md
@@ -33,6 +33,8 @@ Complete the following steps before you link portal content to external sources:
 
 You link a page to a source when you create the page, or later by editing it. In both cases, the source configuration is the same.
 
+The Bitbucket, GitHub, GitLab, and HTTP fetchers include an `httpClientTimeout` field, in milliseconds. This value is applied as both the connection timeout and the idle timeout, so a stalled connection fails instead of hanging.
+
 ### Link a new page to an external source
 
 1. Click **Add**, and then click **Add Page**.
@@ -93,6 +95,8 @@ A manual fetch re-reads the source and updates the content immediately. Trigger 
     <figure><img src="../../../.gitbook/assets/devportal-fetch-all-menu.png" alt="Context menu of a folder in the Navigation items tree with the Fetch All entry"><figcaption><p>Fetch All in the context menu</p></figcaption></figure>
 
 A page that fails to fetch doesn't block the others. The result message reports how many pages were fetched and which ones failed, and each failing page records its error in its own **Last fetch failed** banner.
+
+When the fetcher reaches a repository or an HTTP URL, the recorded error names the URL that couldn't be fetched and, when the server responded, the status code and message it returned.
 
 ## Keep content in sync with auto-fetch
 
@@ -210,6 +214,5 @@ To verify that your external source works as expected, follow these steps:
 3. Publish the page, and then click **Open Website**.
 
 The fetched content appears on the page in the New Developer Portal.
-
 
 <figure><img src="../../../.gitbook/assets/devportal-sourced-page-in-portal.png" alt="The New Developer Portal rendering the page content fetched from the external source"><figcaption><p>Fetched content in the New Developer Portal</p></figcaption></figure>

--- a/docs/apim/4.13/release-information/release-notes/apim-4.13.md
+++ b/docs/apim/4.13/release-information/release-notes/apim-4.13.md
@@ -38,6 +38,7 @@ documentation.gravitee.io links for other versions.
 * The plan endpoints of the legacy Management API v1 now reject V4, Federated, and Federated Agent APIs with an HTTP `400` error that points to Management API v2.
 * The New Developer Portal catalog gains categories, so you group APIs in the APIM Console and consumers filter the catalog to one category and share that view by URL.
 * New Developer Portal navigation pages fetch their content from external sources such as GitHub, GitLab, or an HTTP URL, on demand or on an auto-fetch schedule, and a repository import mirrors a whole documentation tree into a read-only folder.
+* The Bitbucket, GitHub, GitLab, and HTTP fetchers used by New Developer Portal pages take an `httpClientTimeout` value so a stalled fetch fails instead of hanging, and the recorded error names the URL and the status the server returned.
 
 ## Breaking Changes and deprecations
 
@@ -124,3 +125,9 @@ The plan endpoints of the legacy Management API v1 no longer accept V4, Federate
 * The `x509CertificateChain` option now works with the `INLINE` and `PEM` key resolvers. The policy builds the `x5c` header from the certificates included in the key material, ordered from the signing certificate outward, and drops certificates that don't link into the chain.
 * The policy now parses key material that bundles certificates together with the private key.
 * For the `INLINE` and `PEM` key resolvers, if no certificate in the key material matches the signing key, the policy omits the `x5c` header and signs the token anyway, logging a warning when the key material is loaded.
+
+#### **Fetch Timeouts and Clearer Fetch Errors for New Developer Portal Sources**
+
+* The Bitbucket, GitHub, GitLab, and HTTP fetchers include an `httpClientTimeout` field, in milliseconds, which bounds how long a fetch waits on an unresponsive repository or URL.
+* The value is applied as both the connection timeout and the idle timeout, so a stalled connection fails rather than hanging.
+* When a fetch fails, the recorded error names the URL that couldn't be fetched and, when the server responded, the status code and message it returned, so you can tell a wrong URL from a rejected request without leaving the page.


### PR DESCRIPTION
Automated update: portal-3

Product: apim
Version: 4.13

---

## Release deliverables (Step 0)

- ✅ Release notes entry added to `docs/apim/4.13/release-information/release-notes/apim-4.13.md` under **Improvements**: Fetch Timeouts and Clearer Fetch Errors for New Developer Portal Sources
- No breaking change declared on this run (`breakingChange` not set).
- Version overrides: every changed file is already listed.

## Publishability gate

**Verdict: PASS**
- Nothing flagged



> Only lines this PR **adds** are judged. Pre-existing page content is never touched
> and never counted, so an already-dirty page is not penalised for debt it inherited.
> Removed items are gone from the committed file. Review items are left in place for
> you to decide on, because a blocked run produces no PR at all.

## Claims table (Phase 2 verification pass)

Each row was checked against the file status, full source, and diffs of
the changed files in the discovered code PRs. A row marked "not found in
provided sources" needs writer verification against the wider repo
before merge.

| Claim | Evidence | Verdict |
|:---|:---|:---|
| Source can be configured on portal navigation pages and folders | `openapi-environments.yaml`: `source: $ref: "#/components/schemas/PortalNavigationItemSource"` added under `PortalNavigationPage`, `PortalNavigationFolder`, `CreatePortalNavigationPage`, `CreatePortalNavigationFolder`, `UpdatePortalNavigationPage`, `UpdatePortalNavigationFolder` | verified |
| Source cannot be configured on `LINK`, `API`, `API_PRODUCT` items | `openapi-environments.yaml`: `source` added only to the PAGE and FOLDER schemas; `portalNavigationItem.ts` adds `source?` only to `PortalNavigationPage`, `PortalNavigationFolder` and their New/Update variants | verified |
| A source declares fetcher plugin, configuration, and auto-fetch schedule | `openapi-environments.yaml`: `PortalNavigationItemSource` properties `type`, `configuration`, `useAutoFetch`, `fetchCron` | verified |
| Fetch outcome is recorded on the item | `openapi-environments.yaml`: `lastFetchedAt` and `lastFetchError` with `readOnly: true`; `portalNavigationItem.ts` comments `/** Read-only, server-managed. */` | verified |
| Feature exposed through the Management v2 API | `gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml` schema additions | verified |
| `source` accepted on create payload | `openapi-environments.yaml`: `CreatePortalNavigationPage` / `CreatePortalNavigationFolder` gain `source`; `PortalNavigationItemsMapperTest.should_map_source_from_create_portal_navigation_page` | verified |
| `source` accepted on update payload | `openapi-environments.yaml`: `UpdatePortalNavigationPage` / `UpdatePortalNavigationFolder` gain `source`; `PortalNavigationItemsMapperTest.should_map_source_from_update_portal_navigation_page` | verified |
| `source` returned when reading an item | `PortalNavigationItemsMapper.map(core PortalNavigationItemSource)` building the REST model; `PortalNavigationItemsMapperTest.should_map_portal_navigation_page_source` | verified |
| `type` is required and is the fetcher plugin id, e.g. `github-fetcher` | `openapi-environments.yaml`: `required: [ type, configuration ]`, `description: Fetcher plugin id.`, `example: github-fetcher` | verified |
| `configuration` is required and is the fetcher configuration | `openapi-environments.yaml`: `required: [ type, configuration ]`, `configuration: type: object, description: Fetcher configuration.` | verified |
| Non-object configuration fails with `Configuration must be a JSON object` | `ConfigurationSerializationMapper.serializeConfiguration` throws `new InvalidDataException("Configuration must be a JSON object")` | verified |
| `configuration` example `{"repository":"docs"}` is serialized for storage | `PortalNavigationItemsMapperTest.should_map_source_from_create_portal_navigation_page` asserts `getSourceConfiguration()` equals `{
  "repository" : "docs"
}` | verified |
| `useAutoFetch` defaults to `false` | `openapi-environments.yaml`: `useAutoFetch: type: boolean ... default: false` | verified |
| `fetchCron` drives the auto-fetch schedule and is only used when `useAutoFetch` is true | `openapi-environments.yaml`: `description: Cron expression driving the auto-fetch schedule. Only used when useAutoFetch is true.` | verified |
| `lastFetchedAt` is read-only and holds the date of the last successful fetch | `openapi-environments.yaml`: `lastFetchedAt: readOnly: true, description: Date of the last successful fetch.` | verified |
| `lastFetchError` is read-only, holds the last failure message, absent on success | `openapi-environments.yaml`: `lastFetchError: readOnly: true, description: Error message of the last failed fetch. Absent when the last fetch succeeded.` | verified |
| Client-supplied `lastFetchedAt` / `lastFetchError` are discarded | `PortalNavigationItemsMapper`: `@Mapping(target = "lastFetchedAt", ignore = true)`, `@Mapping(target = "lastFetchError", ignore = true)`; `PortalNavigationItemsMapperTest.should_drop_client_provided_server_managed_fetch_state` | verified |
| Bitbucket fetcher non-`200` fails with `Unable to fetch '<url>'. Status code: <code>. Message: <statusMessage>` | `BitbucketFetcher.handleResponse` returns `Future.failedFuture(new FetcherException("Unable to fetch '" + url + "'. Status code: " + response.statusCode() + ". Message: " + response.statusMessage(), null))` | verified |
| GitLab fetcher non-`200` fails with the same message | `GitlabFetcher.handleResponse` same `FetcherException` message | verified |
| HTTP fetcher non-`200` fails with the same message | `HttpFetcher.fetchContent` compose branch returns `Future.failedFuture(new FetcherException("Unable to fetch '" + url + "'. Status code: ... Message: ...", null))` | verified |
| GitHub fetcher `404` returns `Unable to fetch '<url>` | `GitHubFetcher.handleResponse`: `Future.failedFuture(new ResourceNotFoundException("Unable to fetch '" + url, null))` | verified |
| GitHub fetcher other non-`200` returns status/message text | `GitHubFetcher.handleResponse` else branch `FetcherException("Unable to fetch '" + url + "'. Status code: ... Message: ...")` | verified |
| Failures reported as `Unable to fetch Bitbucket content (<cause message>)` | `BitbucketFetcher.fetch` catch: `throw new FetcherException("Unable to fetch Bitbucket content (" + cause.getMessage() + ")", cause)` | verified |
| Failures reported as `Unable to fetch GitHub content (<cause message>)` | `GitHubFetcher.request` catch: `throw new FetcherException("Unable to fetch GitHub content (" + cause.getMessage() + ")", cause)` | verified |
| Failures reported as `Unable to fetch Gitlab content (<cause message>)` | `GitlabFetcher.request` catch: `throw new FetcherException("Unable to fetch Gitlab content (" + cause.getMessage() + ")", cause)` | verified |
| Failures reported as `Unable to fetch Http content (<cause message>)` | `HttpFetcher.fetch` catch: `throw new FetcherException("Unable to fetch Http content (" + cause.getMessage() + ")", cause)` | verified |
| Reported cause is the original failure, not the async wrapper | `BitbucketFetcher`/`GitHubFetcher`: `ex instanceof CompletionException && ex.getCause() != null ? ex.getCause() : ex`; `GitlabFetcher`/`HttpFetcher`: `ex instanceof ExecutionException ...`; tests `should_expose_original_cause_instead_of_async_wrapper_when_fetch_fails` | verified |
| Interrupted GitLab fetch logged as `Fetch of Gitlab content '{}' has been interrupted` | `GitlabFetcher.request` `catch (InterruptedException ie) { Thread.currentThread().interrupt(); log.error("Fetch of Gitlab content '{}' has been interrupted", url, ie); ... }` | verified |
| Interrupted HTTP fetch logged as `Fetch of Http content '{}' has been interrupted` | `HttpFetcher.fetch` `catch (InterruptedException ie) { ... log.error("Fetch of Http content '{}' has been interrupted", httpFetcherConfiguration.getUrl(), ie); ... }` | verified |
| Interrupted fetch reported as a fetch failure | `GitlabFetcher`/`HttpFetcher` interrupted branches throw `FetcherException("Unable to fetch ... content (" + ie.getMessage() + ")", ie)` | verified |
| Bitbucket fetcher uses `httpClientTimeout` as connect and idle timeout, in milliseconds | `BitbucketFetcher.fetchContent`: `.setConnectTimeout(httpClientTimeout).setIdleTimeout(httpClientTimeout).setIdleTimeoutUnit(TimeUnit.MILLISECONDS)` | verified |
| GitHub fetcher uses `httpClientTimeout` as connect and idle timeout | `GitHubFetcher.fetchContent`: same option chain | verified |
| GitLab fetcher uses `httpClientTimeout` as connect and idle timeout | `GitlabFetcher.fetchContent`: same option chain | verified |
| HTTP fetcher uses `httpClientTimeout` as connect and idle timeout | `HttpFetcher.fetchContent`: `.setConnectTimeout(httpClientTimeout).setIdleTimeout(httpClientTimeout).setIdleTimeoutUnit(TimeUnit.MILLISECONDS)` | verified |
| Connect and idle timeouts cannot be set independently | Same single `httpClientTimeout` field passed to both setters in all four fetchers | verified |
| A stalled connection fails instead of hanging | `should_fail_when_connection_stalls_while_reading_body` in `BitbucketFetcherTest`, `GitHubFetcherTest`, `GitlabFetcherTest`, `HttpFetcherTest` assert `FetcherException` with `@Timeout(10, SECONDS)` | verified |
| Bitbucket: cron validated whenever `autoFetch` is enabled | `BitbucketFetcher.checkRequiredFields`: `if (bitbucketFetcherConfiguration.isAutoFetch()) { CronExpression.parse(...) }` | verified |
| GitHub: cron validated whenever `autoFetch` is enabled | `GitHubFetcher.checkRequiredFields`: `if (gitHubFetcherConfiguration.isAutoFetch()) { CronExpression.parse(...) }` | verified |
| GitLab: cron validated whenever `autoFetch` is enabled | `GitlabFetcher.checkRequiredFields`: `if (gitlabFetcherConfiguration.isAutoFetch()) { CronExpression.parse(...) }` | verified |
| Missing or blank `fetchCron` with auto-fetch rejected with `Some required configuration attributes are missing.` | `checkRequiredFields` in all three fetchers: `isAutoFetch() && (getFetchCron() == null \|\| getFetchCron().isEmpty())` → `throw new FetcherException("Some required configuration attributes are missing.", null)` | verified |
| Invalid cron expression is rejected by cron parsing | `checkRequiredFields`: `try { CronExpression.parse(...) } catch (IllegalArgumentException e)` → throws | verified (thrown message not visible in diffs) |
| Error text changed from `Step.configuration must be a JSON object` to `Configuration must be a JSON object` | `ConfigurationSerializationMapper.serializeConfiguration`: three `InvalidDataException` messages changed | verified |